### PR TITLE
feat(pente): Add updateEndorsementConfig for dynamic privacy group membership

### DIFF
--- a/solidity/contracts/domains/pente/PentePrivacyGroup.sol
+++ b/solidity/contracts/domains/pente/PentePrivacyGroup.sol
@@ -30,6 +30,9 @@ contract PentePrivacyGroup is IPente, UUPSUpgradeable, EIP712Upgradeable {
     bytes32 private constant UPGRADE_TYPEHASH =
         keccak256("Upgrade(address address)");
 
+    bytes32 private constant UPDATE_ENDORSEMENT_TYPEHASH =
+        keccak256("UpdateEndorsement(uint256 threshold,address[] endorsementSet)");
+
     mapping(bytes32 => bool) private _unspent;
     mapping(bytes32 => address) private _approvals;
     mapping(bytes32 => bool) private _txids;
@@ -48,6 +51,7 @@ contract PentePrivacyGroup is IPente, UUPSUpgradeable, EIP712Upgradeable {
     error PenteReadNotAvailable(bytes32 read);
     error PenteOutputAlreadyUnspent(bytes32 output);
     error PenteExternalCallsDisabled();
+    error PenteEmptyEndorsementSet();
     error PenteInvalidDelegate(
         bytes32 txhash,
         address delegate,
@@ -115,6 +119,22 @@ contract PentePrivacyGroup is IPente, UUPSUpgradeable, EIP712Upgradeable {
         bytes32 upgradeHash = _buildUpgradeHash(newImplementation);
         validateEndorsements(upgradeHash, signatures);
         _nextImplementation = newImplementation;
+    }
+
+    function updateEndorsementConfig(
+        uint threshold,
+        address[] calldata endorsementSet,
+        bytes[] calldata signatures
+    ) external {
+        if (endorsementSet.length == 0) {
+            revert PenteEmptyEndorsementSet();
+        }
+        bytes32 updateHash = _buildUpdateEndorsementHash(threshold, endorsementSet);
+        validateEndorsements(updateHash, signatures);
+        _endorsementConfig = EndorsementConfig({
+            threshold: threshold,
+            endorsementSet: endorsementSet
+        });
     }
 
     function transition(
@@ -241,6 +261,20 @@ contract PentePrivacyGroup is IPente, UUPSUpgradeable, EIP712Upgradeable {
     ) internal view returns (bytes32) {
         bytes32 structHash = keccak256(
             abi.encode(UPGRADE_TYPEHASH, newImplementation)
+        );
+        return _hashTypedDataV4(structHash);
+    }
+
+    function _buildUpdateEndorsementHash(
+        uint threshold,
+        address[] calldata endorsementSet
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                UPDATE_ENDORSEMENT_TYPEHASH,
+                threshold,
+                keccak256(abi.encodePacked(endorsementSet))
+            )
         );
         return _hashTypedDataV4(structHash);
     }


### PR DESCRIPTION
## Motivation

Privacy groups in production will face membership changes. New institutions join networks, existing participants exit markets or undergo restructuring. Currently the endorsement set is fixed at `initialize()` and the only way to change membership requires deploying a new privacy group and migrating all assets, which is operationally impractical for live financial networks.

The V1.0 roadmap includes M-of-N endorsement policies (threshold flexibility), but dynamic membership management -- adding or removing endorsers from an existing group -- is a separate need that is not currently addressed.

## How it works

`updateEndorsementConfig()` follows the same EIP-712 signature verification pattern already established by `preAuthorizeUpgrade()`:

1. Caller submits new threshold + endorsement set + signatures from current endorsers
2. `validateEndorsements()` verifies current endorsers signed the update
3. `_endorsementConfig` is replaced atomically

All current endorsers (meeting the existing threshold) must sign the update. No member can be added or removed without group consensus.

## Example

```
Current: endorsementSet = [A, B, C], threshold = 3

Add D:    updateEndorsementConfig(4, [A, B, C, D], [sigA, sigB, sigC])
Remove C: updateEndorsementConfig(2, [A, B],       [sigA, sigB, sigC])
```