### PR TITLE
fix(mockery): use config file with --config .mockery.yml

### DIFF
--- a/core/go/build.gradle
+++ b/core/go/build.gradle
@@ -156,7 +156,10 @@ task protoc(type: ProtoCompile, dependsOn: [
 }
 
 task makeMocksComponents(type: Exec, dependsOn: [":installMockery", protoc]) {
+    workingDir '.'
+    inputs.file('.mockery.yml')
    executable "mockery"
+    args "--config", ".mockery.yml"
 }
 
 task makeMocksTransport(type: Exec, dependsOn: [makeMocksComponents]) {


### PR DESCRIPTION
1. Problem Classification  
- Type: infra  
- Subsystem: build (core/go mock generation pipeline)  
- Root cause: first mockery task invocation used bare CLI without explicit config argument, causing deprecated invocation mode warnings.
2. Code-Level Diagnosis  
- File: core/go/build.gradle  
- Failure point: task makeMocksComponents(type: Exec, dependsOn: [":installMockery", protoc])  
- Pre-fix behavior: only executable "mockery"; no explicit --config passed at the entrypoint task in the chain.
3. Minimal Fix (Primary Solution)  
- Localized change in core/go/build.gradle at makeMocksComponents only.  
- Added lines:
  - workingDir '.'
  - inputs.file('.mockery.yml')
  - args "--config", ".mockery.yml"
- No other task or dependency changes.
4. Alternative Fixes (if applicable)  
- Alternative considered: apply fix at downstream makeMocks.  
- Rejected in this branch topology because goGet depends on makeMocks; changing dependencies there risks cycle/graph disruption and is not minimal.
5. System Impact  
- Runtime behavior: none (build-time tooling only).  
- Backward compatibility: preserved.  
- Performance: negligible.  
- Security/privacy: unchanged.
6. Validation Plan  
- Diff check:
  - git diff core/go/build.gradle
  - Must include only the three added lines above.
- Execution check (in CI or compatible local environment):
  - ./gradlew :core:go:makeMocks
  - Verify mockery runs with explicit config mode and no CLI deprecation warning at entrypoint invocation.
7. Regression Risks  
- Low risk due to single-task, additive-only change.  
- Main risk is environmental/toolchain setup (Gradle bootstrap/tool install/proto prereqs), not logic in this fix.  
- Checkpoints: PR CI for :core:go:makeMocks, and no unrelated file diffs in branch.




fixes: #180 