### PR TITLE
Reduce buffer allocation in transport writer

### DIFF
--- a/core/go/internal/sequencer/transport/transport_writer.go
+++ b/core/go/internal/sequencer/transport/transport_writer.go
@@ -16,8 +16,10 @@
 package transport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -32,6 +34,31 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+var jsonBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// marshalJSON is a drop-in replacement for json.Marshal that reuses buffers via sync.Pool
+// to reduce allocation pressure on the Go GC in high-throughput paths (heartbeats, delegation, assembly).
+func marshalJSON(v any) ([]byte, error) {
+	buf := jsonBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		jsonBufPool.Put(buf)
+		return nil, err
+	}
+	b := buf.Bytes()
+	if len(b) > 0 && b[len(b)-1] == '\n' {
+		b = b[:len(b)-1]
+	}
+	result := make([]byte, len(b))
+	copy(result, b)
+	jsonBufPool.Put(buf)
+	return result, nil
+}
 
 type TransportWriter interface {
 	StartLoopbackWriter()
@@ -94,7 +121,7 @@ func (tw *transportWriter) SendDelegationRequest(
 	blockHeight uint64,
 ) error {
 	for _, transaction := range transactions {
-		transactionBytes, err := json.Marshal(transaction)
+		transactionBytes, err := marshalJSON(transaction)
 
 		if err != nil {
 			log.L(ctx).Errorf("error marshalling transaction message: %s", err)
@@ -308,7 +335,7 @@ func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNo
 
 	log.L(ctx).Tracef("transport writer attempting to send assemble request to assembling node %s", assemblingNode)
 
-	preAssemblyBytes, err := json.Marshal(preAssembly)
+	preAssemblyBytes, err := marshalJSON(preAssembly)
 	if err != nil {
 		log.L(ctx).Error("error marshalling preassembly", err)
 		return err
@@ -373,12 +400,12 @@ func (tw *transportWriter) SendAssembleResponse(ctx context.Context, txID uuid.U
 
 	log.L(ctx).Tracef("transport writer attempting to send assemble response to node %s", recipient)
 
-	postAssemblyBytes, err := json.Marshal(postAssembly)
+	postAssemblyBytes, err := marshalJSON(postAssembly)
 	if err != nil {
 		return err
 	}
 
-	preAssemblyBytes, err := json.Marshal(preAssembly)
+	preAssemblyBytes, err := marshalJSON(preAssembly)
 	if err != nil {
 		return err
 	}
@@ -420,7 +447,7 @@ func (tw *transportWriter) SendHandoverRequest(ctx context.Context, activeCoordi
 	handoverRequest := &HandoverRequest{
 		ContractAddress: contractAddress,
 	}
-	handoverRequestBytes, err := json.Marshal(handoverRequest)
+	handoverRequestBytes, err := marshalJSON(handoverRequest)
 	if err != nil {
 		log.L(ctx).Errorf("error marshalling handover request message: %s", err)
 	}
@@ -541,7 +568,7 @@ func (tw *transportWriter) SendHeartbeat(ctx context.Context, targetNode string,
 
 	log.L(ctx).Tracef("transport writer attempting to send haertbeat to node %s", targetNode)
 
-	coordinatorSnapshotBytes, err := json.Marshal(coordinatorSnapshot)
+	coordinatorSnapshotBytes, err := marshalJSON(coordinatorSnapshot)
 	if err != nil {
 		log.L(ctx).Error("error marshalling heartbeat", err)
 	}

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -2294,3 +2294,50 @@ func TestSendTransactionUnknown_Loopback(t *testing.T) {
 	mockTransportManager.AssertExpectations(t)
 	mockLoopbackTransport.AssertExpectations(t)
 }
+
+func TestMarshalJSON_MatchesStdlib(t *testing.T) {
+	type sample struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+	input := sample{Name: "test", Value: 42}
+
+	stdResult, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	poolResult, err := marshalJSON(input)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(stdResult), string(poolResult))
+}
+
+func TestMarshalJSON_NoTrailingNewline(t *testing.T) {
+	result, err := marshalJSON(map[string]string{"k": "v"})
+	require.NoError(t, err)
+	assert.NotEqual(t, byte('\n'), result[len(result)-1])
+}
+
+func TestMarshalJSON_HTMLCharsNotEscaped(t *testing.T) {
+	result, err := marshalJSON(map[string]string{"url": "a<b>c&d"})
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "<b>")
+	assert.Contains(t, string(result), "&d")
+}
+
+func TestMarshalJSON_ResultDoesNotAliasPool(t *testing.T) {
+	result1, err := marshalJSON(map[string]int{"a": 1})
+	require.NoError(t, err)
+	snapshot := make([]byte, len(result1))
+	copy(snapshot, result1)
+
+	// Second call reuses the pooled buffer; result1 must be unaffected
+	_, err = marshalJSON(map[string]int{"b": 99999})
+	require.NoError(t, err)
+
+	assert.Equal(t, snapshot, result1)
+}
+
+func TestMarshalJSON_Error(t *testing.T) {
+	_, err := marshalJSON(make(chan int))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Use a sync pool of buffers so they can be reused for serializing JSON in transport requests