### PR TITLE
Return HTTP 200 for proper jsonrpc responses

### DIFF
--- a/toolkit/go/pkg/rpcserver/rpchandler.go
+++ b/toolkit/go/pkg/rpcserver/rpchandler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"sync"
 	"time"
 	"unicode"
 
@@ -31,10 +32,10 @@ import (
 )
 
 type handlerResult struct {
-	sendRes bool
-	isOK    bool
-	res     any
-	postSend func()
+	sendRes      bool
+	res          any
+	postSend     func()
+	unauthorized bool
 }
 
 func (s *rpcServer) rpcHandler(ctx context.Context, r io.Reader, wsc *webSocketConnection) handlerResult {
@@ -55,8 +56,8 @@ func (s *rpcServer) rpcHandler(ctx context.Context, r io.Reader, wsc *webSocketC
 			log.L(ctx).Errorf("Bad RPC array received %s", b)
 			return s.replyRPCParseError(ctx, b, err)
 		}
-		batchRes, isOK, postSend := s.handleRPCBatch(ctx, rpcArray, wsc)
-		return handlerResult{isOK: isOK, sendRes: true, res: batchRes, postSend: postSend}
+		batchRes, unauthorized, postSend := s.handleRPCBatch(ctx, rpcArray, wsc)
+		return handlerResult{sendRes: true, res: batchRes, postSend: postSend, unauthorized: unauthorized}
 	}
 
 	var rpcRequest rpcclient.RPCRequest
@@ -66,7 +67,7 @@ func (s *rpcServer) rpcHandler(ctx context.Context, r io.Reader, wsc *webSocketC
 	}
 	startTime := time.Now()
 	log.L(ctx).Debugf("RPC-server[%s] --> %s", rpcRequest.ID, rpcRequest.Method)
-	res, isOK, postSend := s.processRPC(ctx, &rpcRequest, wsc)
+	res, unauthorized, postSend := s.processRPC(ctx, &rpcRequest, wsc)
 	durationMS := float64(time.Since(startTime)) / float64(time.Millisecond)
 	if res != nil && res.Error != nil {
 		log.L(ctx).Errorf("RPC-server[%s] <-- %s [%.2fms]: %s", rpcRequest.ID.StringValue(), rpcRequest.Method, durationMS, res.Error.Message)
@@ -76,14 +77,13 @@ func (s *rpcServer) rpcHandler(ctx context.Context, r io.Reader, wsc *webSocketC
 	if log.IsTraceEnabled() {
 		log.L(ctx).Tracef("RPC-server[%s] <-- %s", rpcRequest.ID.StringValue(), pldtypes.JSONString(res))
 	}
-	return handlerResult{isOK: isOK, sendRes: res != nil, res: res, postSend: postSend}
+	return handlerResult{sendRes: res != nil, res: res, postSend: postSend, unauthorized: unauthorized}
 
 }
 
 func (s *rpcServer) replyRPCParseError(ctx context.Context, b []byte, err error) handlerResult {
 	log.L(ctx).Errorf("Request could not be parsed (err=%v): %s", err, b)
 	return handlerResult{
-		isOK:    false,
 		sendRes: true,
 		res: rpcclient.NewRPCErrorResponse(
 			i18n.NewError(ctx, pldmsgs.MsgJSONRPCInvalidRequest),
@@ -95,9 +95,7 @@ func (s *rpcServer) replyRPCParseError(ctx context.Context, b []byte, err error)
 
 func (s *rpcServer) sniffFirstByte(data []byte) byte {
 	sniffLen := len(data)
-	if sniffLen > 100 {
-		sniffLen = 100
-	}
+	sniffLen = min(sniffLen, 100)
 	for _, b := range data[0:sniffLen] {
 		if !unicode.IsSpace(rune(b)) {
 			return b
@@ -107,19 +105,26 @@ func (s *rpcServer) sniffFirstByte(data []byte) byte {
 }
 
 func (s *rpcServer) handleRPCBatch(ctx context.Context, rpcArray []*rpcclient.RPCRequest, wsc *webSocketConnection) ([]*rpcclient.RPCResponse, bool, func()) {
-
 	// Kick off a routine to fill in each
 	rpcResponses := make([]*rpcclient.RPCResponse, len(rpcArray))
 	postSends := make([]func(), len(rpcArray))
-	results := make(chan bool)
+	var wg sync.WaitGroup
+	var unauthorizedMu sync.Mutex
+	anyUnauthorized := false
 	for i, r := range rpcArray {
 		responseNumber := i
 		rpcRequest := r
+		wg.Add(1)
 		go func() {
-			var ok bool
+			defer wg.Done()
 			startTime := time.Now()
 			log.L(ctx).Debugf("RPC-server[%v] (b=%d) --> %s", rpcRequest.ID.StringValue(), i, rpcRequest.Method)
-			res, ok, postSend := s.processRPC(ctx, rpcRequest, wsc)
+			res, unauthorized, postSend := s.processRPC(ctx, rpcRequest, wsc)
+			if unauthorized {
+				unauthorizedMu.Lock()
+				anyUnauthorized = true
+				unauthorizedMu.Unlock()
+			}
 			durationMS := float64(time.Since(startTime)) / float64(time.Millisecond)
 			if res != nil && res.Error != nil {
 				log.L(ctx).Errorf("RPC-server[%s] (b=%d) <-- %s [%.2fms]: %s", rpcRequest.ID.StringValue(), i, rpcRequest.Method, durationMS, res.Error.Message)
@@ -131,18 +136,10 @@ func (s *rpcServer) handleRPCBatch(ctx context.Context, rpcArray []*rpcclient.RP
 			}
 			rpcResponses[responseNumber] = res
 			postSends[responseNumber] = postSend
-			results <- ok
 		}()
 	}
-	failCount := 0
-	for range rpcResponses {
-		ok := <-results
-		if !ok {
-			failCount++
-		}
-	}
-	// Only return a failure response code if all the requests in the batch failed
-	return rpcResponses, failCount != len(rpcArray), func() {
+	wg.Wait()
+	return rpcResponses, anyUnauthorized, func() {
 		for _, postSend := range postSends {
 			if postSend != nil {
 				postSend()

--- a/toolkit/go/pkg/rpcserver/rpchandler_test.go
+++ b/toolkit/go/pkg/rpcserver/rpchandler_test.go
@@ -114,6 +114,74 @@ func TestRPCMessageBatch(t *testing.T) {
 
 }
 
+func TestRPCMessageBatchUnauthorized(t *testing.T) {
+
+	url, s, done := newTestServerHTTP(t, &pldconf.RPCServerConfig{})
+	defer done()
+
+	auth := &mockAuthorizer{
+		authenticateFunc: func(ctx context.Context, headers map[string]string) (string, error) {
+			return `{"username":"test"}`, nil
+		},
+		authorizeFunc: func(ctx context.Context, result string, method string, payload []byte) bool {
+			return false
+		},
+	}
+	s.SetAuthorizers([]Authorizer{auth})
+
+	regTestRPC(s, "ut_methodA", RPCMethod2(func(ctx context.Context, param0, param1 string) (string, error) {
+		assert.Equal(t, "valueA0", param0)
+		assert.Equal(t, "valueA1", param1)
+		return "resultA", nil
+	}))
+	regTestRPC(s, "ut_methodB", RPCMethod2(func(ctx context.Context, param0, param1 string) (string, error) {
+		assert.Equal(t, "valueB0", param0)
+		assert.Equal(t, "valueB1", param1)
+		return "", fmt.Errorf("pop")
+	}))
+
+	var jsonResponse pldtypes.RawJSON
+	res, err := resty.New().R().
+		SetBody(`[
+			{
+				"jsonrpc": "2.0",
+				"id": "1",
+				"method": "ut_methodA",
+				"params": ["valueA0","valueA1"]
+			},
+			{
+				"jsonrpc": "2.0",
+				"id": "2",
+				"method": "ut_methodB",
+				"params": ["valueB0","valueB1"]
+			}
+		]`).
+		SetResult(&jsonResponse).
+		SetError(&jsonResponse).
+		Post(url)
+	require.NoError(t, err)
+	assert.False(t, res.IsSuccess())
+	assert.JSONEq(t, `[
+		{
+			"jsonrpc": "2.0",
+			"id": "1",
+			"error": {
+			  "code": -32000,
+			  "message": "PD020707: Unauthorized"
+			}
+		},
+		{
+			"jsonrpc": "2.0",
+			"id": "2",
+			"error": {
+			  "code": -32000,
+			  "message": "PD020707: Unauthorized"
+			}
+		}
+	]`, (string)(jsonResponse))
+
+}
+
 func TestRPCMessageBatchOneFails200WithError(t *testing.T) {
 
 	url, s, done := newTestServerHTTP(t, &pldconf.RPCServerConfig{})
@@ -215,7 +283,7 @@ func TestRPCMessageBatchAllFail(t *testing.T) {
 		SetError(&jsonResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.JSONEq(t, `[
 		{
 			"jsonrpc": "2.0",
@@ -257,7 +325,7 @@ func TestRPCHandleBadDataEmptySpace(t *testing.T) {
 		SetError(&jsonResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), jsonResponse.Error.Code)
 	assert.Regexp(t, "PD020700", jsonResponse.Error.Message)
 
@@ -269,7 +337,6 @@ func TestRPCHandleIOError(t *testing.T) {
 	defer done()
 
 	r := s.rpcHandler(context.Background(), iotest.ErrReader(fmt.Errorf("pop")), nil)
-	assert.False(t, r.isOK)
 	jsonResponse := r.res.(*rpcclient.RPCResponse)
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), jsonResponse.Error.Code)
 	assert.Regexp(t, "PD020700", jsonResponse.Error.Message)
@@ -282,7 +349,6 @@ func TestRPCBadArrayError(t *testing.T) {
 	defer done()
 
 	r := s.rpcHandler(context.Background(), strings.NewReader("[... this is not an array"), nil)
-	assert.False(t, r.isOK)
 	jsonResponse := r.res.(*rpcclient.RPCResponse)
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), jsonResponse.Error.Code)
 	assert.Regexp(t, "PD020700", jsonResponse.Error.Message)

--- a/toolkit/go/pkg/rpcserver/rpcmethod_test.go
+++ b/toolkit/go/pkg/rpcserver/rpcmethod_test.go
@@ -332,10 +332,10 @@ func TestRCPMethodInvalidValue(t *testing.T) {
 		  "method": "stringy_method",
 		  "params": [ "not an array" ]
 		}`).
-		SetError(&errResponse).
+		SetResult(&errResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess()) // we return a 200 here b/c we are getting back a valid error body
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), errResponse.Error.Code)
 	assert.Regexp(t, "PD020704", errResponse.Error.Message)
 
@@ -359,10 +359,10 @@ func TestRCPMethodWrongParamCount(t *testing.T) {
 		  "method": "stringy_method",
 		  "params": [ "more", "than", "one" ]
 		}`).
-		SetError(&errResponse).
+		SetResult(&errResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), errResponse.Error.Code)
 	assert.Regexp(t, "PD020703", errResponse.Error.Message)
 
@@ -385,10 +385,10 @@ func TestRCPMethodBadResult(t *testing.T) {
 		  "method": "stringy_method",
 		  "params": [ ]
 		}`).
-		SetError(&errResponse).
+		SetResult(&errResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.Equal(t, int64(rpcclient.RPCCodeInternalError), errResponse.Error.Code)
 	assert.Regexp(t, "PD020705", errResponse.Error.Message)
 

--- a/toolkit/go/pkg/rpcserver/rpcprocessor.go
+++ b/toolkit/go/pkg/rpcserver/rpcprocessor.go
@@ -61,7 +61,7 @@ func (s *rpcServer) processRPC(ctx context.Context, rpcReq *rpcclient.RPCRequest
 				i18n.NewError(ctx, pldmsgs.MsgJSONRPCUnauthorized),
 				rpcReq.ID,
 				rpcclient.RPCCodeUnauthorized,
-			), false, nil
+			), true, nil
 		}
 
 		// Authorize through chain - stop on first failure
@@ -73,7 +73,7 @@ func (s *rpcServer) processRPC(ctx context.Context, rpcReq *rpcclient.RPCRequest
 					i18n.NewError(ctx, pldmsgs.MsgJSONRPCUnauthorized),
 					rpcReq.ID,
 					rpcclient.RPCCodeUnauthorized,
-				), false, nil
+				), true, nil
 			}
 
 			authorized := auth.Authorize(ctx, authenticationResults[i], rpcReq.Method, payload)
@@ -83,7 +83,7 @@ func (s *rpcServer) processRPC(ctx context.Context, rpcReq *rpcclient.RPCRequest
 					i18n.NewError(ctx, pldmsgs.MsgJSONRPCUnauthorized),
 					rpcReq.ID,
 					rpcclient.RPCCodeUnauthorized,
-				), false, nil
+				), true, nil
 			}
 		}
 	}
@@ -113,9 +113,5 @@ func (s *rpcServer) processRPC(ctx context.Context, rpcReq *rpcclient.RPCRequest
 			rpcRes = wsc.handleLifecycle(ctx, rpcReq, mh.async)
 		}
 	}
-	isOK := true
-	if rpcRes != nil {
-		isOK = rpcRes.Error == nil
-	}
-	return rpcRes, isOK, afterSend
+	return rpcRes, false, afterSend
 }

--- a/toolkit/go/pkg/rpcserver/rpcprocessor_test.go
+++ b/toolkit/go/pkg/rpcserver/rpcprocessor_test.go
@@ -37,10 +37,10 @@ func TestRCPMissingID(t *testing.T) {
 	var errResponse rpcclient.RPCResponse
 	res, err := resty.New().R().
 		SetBody(`{}`).
-		SetError(&errResponse).
+		SetResult(&errResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), errResponse.Error.Code)
 	assert.Regexp(t, "PD020701", errResponse.Error.Message)
 
@@ -57,10 +57,10 @@ func TestRCPUnknownMethod(t *testing.T) {
 		  "id": 12345,
 		  "method": "wrong"
 		}`).
-		SetError(&errResponse).
+		SetResult(&errResponse).
 		Post(url)
 	require.NoError(t, err)
-	assert.False(t, res.IsSuccess())
+	assert.True(t, res.IsSuccess())
 	assert.Equal(t, int64(rpcclient.RPCCodeInvalidRequest), errResponse.Error.Code)
 	assert.Regexp(t, "PD020702", errResponse.Error.Message)
 
@@ -478,9 +478,9 @@ func TestRPCProcessor_HTTP_NoStoredAuthenticationResults(t *testing.T) {
 	}
 
 	// Call processRPC directly with HTTP context (wsc == nil) that has no authentication results
-	response, isOK, _ := server.processRPC(ctx, rpcReq, nil /* HTTP request, no WebSocket connection */)
+	response, unauthorized, _ := server.processRPC(ctx, rpcReq, nil /* HTTP request, no WebSocket connection */)
+	assert.True(t, unauthorized)
 
-	assert.False(t, isOK)
 	assert.NotNil(t, response)
 	assert.NotNil(t, response.Error)
 	assert.Equal(t, int64(rpcclient.RPCCodeUnauthorized), response.Error.Code)
@@ -518,9 +518,9 @@ func TestRPCProcessor_WebSocket_NoStoredIdentities(t *testing.T) {
 	}
 
 	// Call processRPC directly with WebSocket connection that has no identities
-	response, isOK, _ := server.processRPC(ctx, rpcReq, wsc)
+	response, unauthorized, _ := server.processRPC(ctx, rpcReq, wsc)
+	assert.True(t, unauthorized)
 
-	assert.False(t, isOK)
 	assert.NotNil(t, response)
 	assert.NotNil(t, response.Error)
 	assert.Equal(t, int64(rpcclient.RPCCodeUnauthorized), response.Error.Code)
@@ -566,9 +566,9 @@ func TestRPCProcessor_AuthenticationResultMismatch(t *testing.T) {
 	}
 
 	// Call processRPC directly with WebSocket connection that has authentication result mismatch
-	response, isOK, _ := server.processRPC(ctx, rpcReq, wsc)
+	response, unauthorized, _ := server.processRPC(ctx, rpcReq, wsc)
+	assert.True(t, unauthorized)
 
-	assert.False(t, isOK)
 	assert.NotNil(t, response)
 	assert.NotNil(t, response.Error)
 	assert.Equal(t, int64(rpcclient.RPCCodeUnauthorized), response.Error.Code)

--- a/toolkit/go/pkg/rpcserver/rpcserver.go
+++ b/toolkit/go/pkg/rpcserver/rpcserver.go
@@ -147,6 +147,7 @@ func (s *rpcServer) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 func (s *rpcServer) httpHandler(res http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		res.WriteHeader(http.StatusMethodNotAllowed)
+		return
 	}
 
 	ctx := req.Context()
@@ -166,8 +167,8 @@ func (s *rpcServer) httpHandler(res http.ResponseWriter, req *http.Request) {
 
 	res.Header().Set("Content-Type", "application/json; charset=utf-8")
 	status := http.StatusOK
-	if !r.isOK {
-		status = http.StatusInternalServerError
+	if r.unauthorized {
+		status = http.StatusForbidden
 	}
 	res.WriteHeader(status)
 	_ = json.NewEncoder(res).Encode(r.res)

--- a/toolkit/go/pkg/rpcserver/rpcserver_test.go
+++ b/toolkit/go/pkg/rpcserver/rpcserver_test.go
@@ -276,7 +276,7 @@ func TestHTTPHandler(t *testing.T) {
 	req := httptest.NewRequest("POST", "/", nil)
 	res := httptest.NewRecorder()
 	rpcServer.HTTPHandler(res, req)
-	assert.Equal(t, http.StatusInternalServerError, res.Code)
+	assert.Equal(t, http.StatusOK, res.Code)
 }
 
 func TestHTTPHandler_AuthenticationFailure(t *testing.T) {


### PR DESCRIPTION
Previously, most jsonrpc errors would result in a HTTP 500 status code, e.g. an idempotency conflict. This commit changes that behavior to better align the with the JSON/RPC spec. Now, anytime the rpc response contains a proper JSON/RPC response body, the HTTP error code will be 200. Only authentication/authorization issues will result a 401/403 HTTP code.

resolves https://github.com/LFDT-Paladin/paladin/issues/1001