### PR TITLE
Fork a new JVM for each test class

### DIFF
--- a/domains/pente/build.gradle
+++ b/domains/pente/build.gradle
@@ -63,6 +63,9 @@ test {
         }
     }
     useJUnitPlatform()
+    // Each test class gets its own JVM to limit accumulation of Go C-shared
+    // library native threads which busy-spin and eventually starve the JVM.
+    forkEvery = 1
     systemProperty "jna.library.path", [
         new File(project(":core:go").buildDir, "libs").absolutePath,
         new File(project(":toolkit:go").buildDir, "libs").absolutePath,


### PR DESCRIPTION
The gradle domains:pente:test task was hanging because the Go C-shared libraries loaded via JNA (libcore, libnoto, etc.) create native OS threads that persist even after the Go runtime is "stopped" and the JNA library handle is closed. These threads busy-spin, consuming significant CPU. Each Testbed lifecycle (create → use → close) leaves behind a batch of these unkillable native threads.

In the previous configuration, all test classes ran in a single JVM process. The Pente test suite has multiple test classes, and within each class, multiple test methods each create and destroy Testbed instances. As the JVM progresses through the suite, native threads accumulate across all these cycles. Eventually the combined CPU consumption (observed at 390%+ on my laptop) starved the JVM's own threads. This meant Java code could no longer make forward progress, tests stopped completing, and the process appeared hung.

`forkEvery = 1` tells Gradle to spawn a fresh JVM for each test class. When that JVM exits after the class finishes, the OS reclaims all its threads — including the lingering Go native threads. The next test class starts in a clean JVM with zero accumulated threads. This caps the native thread buildup to whatever a single test class produces, which is manageable, and eliminates the cross-class accumulation that causes the hang.