### PR TITLE
feat(sequencer): add coordinator failover for endorser mode (#1143)

### DIFF
--- a/core/go/internal/sequencer/coordinator/coordinator.go
+++ b/core/go/internal/sequencer/coordinator/coordinator.go
@@ -91,6 +91,7 @@ type coordinator struct {
 	stateTimeout                      time.Duration
 	nodeName                          string
 	coordinatorSelectionBlockRange    uint64
+	coordinatorFailoverIndex          int
 	maxInflightTransactions           int
 	maxDispatchAhead                  int
 

--- a/core/go/internal/sequencer/coordinator/inactive.go
+++ b/core/go/internal/sequencer/coordinator/inactive.go
@@ -18,12 +18,20 @@ package coordinator
 import (
 	"context"
 
+	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 )
 
 func action_NewBlock(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*NewBlockEvent)
+	prevEffective := c.currentBlockHeight - (c.currentBlockHeight % c.coordinatorSelectionBlockRange)
 	c.currentBlockHeight = e.BlockHeight
+	newEffective := c.currentBlockHeight - (c.currentBlockHeight % c.coordinatorSelectionBlockRange)
+	if newEffective != prevEffective && c.coordinatorFailoverIndex != 0 {
+		log.L(ctx).Debugf("block range boundary crossed (effective %d → %d): resetting coordinator failover index from %d to 0",
+			prevEffective, newEffective, c.coordinatorFailoverIndex)
+		c.coordinatorFailoverIndex = 0
+	}
 	return nil
 }
 
@@ -45,6 +53,8 @@ func action_HeartbeatReceived(_ context.Context, c *coordinator, event common.Ev
 		c.updateOriginatorNodePool(e.From) // In case we ever take over as coordinator we need to send heartbeats to potential originators
 	}
 	c.activeCoordinatorBlockHeight = e.BlockHeight
+	// A valid heartbeat confirms the current coordinator is alive; reset any failover state.
+	c.coordinatorFailoverIndex = 0
 	for _, flushPoint := range e.FlushPoints {
 		c.activeCoordinatorsFlushPointsBySignerNonce[flushPoint.GetSignerNonce()] = flushPoint
 	}
@@ -58,6 +68,7 @@ func action_SendHandoverRequest(ctx context.Context, c *coordinator, _ common.Ev
 
 func action_Idle(_ context.Context, c *coordinator, _ common.Event) error {
 	c.coordinatorIdle(c.contractAddress)
+	c.coordinatorFailoverIndex = 0
 	return nil
 }
 

--- a/core/go/internal/sequencer/coordinator/inactive_test.go
+++ b/core/go/internal/sequencer/coordinator/inactive_test.go
@@ -18,9 +18,12 @@ package coordinator
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/LFDT-Paladin/paladin/config/pkg/confutil"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,3 +172,112 @@ func Test_guard_ObservingIdleThresholdExceeded_Exceeded(t *testing.T) {
 	assert.True(t, guard_ObservingIdleThresholdExceeded(ctx, c))
 }
 
+func Test_action_NewBlock_ResetsFailoverIndex_OnBlockRangeBoundary(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Standby)
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+
+	c.currentBlockHeight = 1000 // effective range: 1000
+	c.coordinatorFailoverIndex = 2
+
+	// A block still within the same range should NOT reset the failover index
+	err := action_NewBlock(ctx, c, &NewBlockEvent{BlockHeight: 1099})
+	require.NoError(t, err)
+	assert.Equal(t, 2, c.coordinatorFailoverIndex, "failover index should not reset within the same block range")
+
+	// A block crossing the boundary SHOULD reset the failover index
+	err = action_NewBlock(ctx, c, &NewBlockEvent{BlockHeight: 1100})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1100), c.currentBlockHeight)
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "failover index should reset when block range boundary is crossed")
+}
+
+func Test_action_NewBlock_DoesNotResetFailoverIndex_WhenAlreadyZero(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Standby)
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+
+	c.currentBlockHeight = 1000
+	c.coordinatorFailoverIndex = 0 // already zero
+
+	err := action_NewBlock(ctx, c, &NewBlockEvent{BlockHeight: 1100}) // range boundary
+	require.NoError(t, err)
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "failover index remains 0 when crossing boundary with index already at 0")
+}
+
+func Test_action_HeartbeatReceived_ResetsFailoverIndex(t *testing.T) {
+	ctx := context.Background()
+	addr := pldtypes.RandAddress()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing).ContractAddress(addr)
+	contractAddress := builder.GetContractAddress()
+	c, _, done := builder.Build(ctx)
+	defer done()
+
+	c.coordinatorFailoverIndex = 3 // some previous failover attempts
+
+	event := &HeartbeatReceivedEvent{}
+	event.From = "node1"
+	event.ContractAddress = &contractAddress
+	event.BlockHeight = 2000
+
+	err := action_HeartbeatReceived(ctx, c, event)
+	require.NoError(t, err)
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "receiving a valid heartbeat should reset the failover index")
+}
+
+func Test_action_Idle_ResetsFailoverIndex(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.coordinatorFailoverIndex = 2
+
+	err := action_Idle(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "entering idle state should reset the failover index")
+}
+
+func Test_Observing_FailoverThenEventuallyIdle_IntegrationFlow(t *testing.T) {
+	// Full state-machine integration test: 3 nodes, primary coordinator goes offline,
+	// failover cycles through the pool, all unresponsive, ends up in State_Idle.
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	config.InactiveToIdleGracePeriod = confutil.P(2) // short threshold for the test
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+	c.coordinatorFailoverIndex = 0
+
+	// Pick the primary coordinator and start observing it
+	primaryCoordinator, _ := c.selectActiveCoordinatorNode(ctx)
+	c.activeCoordinatorNode = primaryCoordinator
+
+	// Queue enough heartbeat intervals to exhaust all 3 candidates (3 candidates × 2 threshold = 6 intervals)
+	// After 2 intervals: primary candidate times out → failover to candidate 2
+	// After 2 more intervals: candidate 2 times out → failover to candidate 3
+	// After 2 more intervals: candidate 3 times out → all exhausted → State_Idle
+	for i := 0; i < 6; i++ {
+		c.QueueEvent(ctx, &common.HeartbeatIntervalEvent{})
+	}
+
+	require.Eventually(t, func() bool {
+		return c.GetCurrentState() == State_Idle
+	}, 2*time.Second, 10*time.Millisecond, "should eventually reach State_Idle after all coordinator candidates are exhausted")
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "failover index should be reset after going idle")
+}

--- a/core/go/internal/sequencer/coordinator/selection.go
+++ b/core/go/internal/sequencer/coordinator/selection.go
@@ -74,8 +74,11 @@ func (c *coordinator) selectActiveCoordinatorNode(ctx context.Context) (string, 
 		// Take a numeric hash of the identities using the current block range
 		h := fnv.New32a()
 		h.Write([]byte(strconv.FormatUint(effectiveBlockNumber, 10)))
-		coordinatorNode = c.originatorNodePool[int(h.Sum32())%len(c.originatorNodePool)]
-		log.L(ctx).Debugf("coordinator %s selected based on hash modulus of the originator pool %+v", coordinatorNode, c.originatorNodePool)
+		primaryIdx := int(h.Sum32()) % len(c.originatorNodePool)
+		selectedIdx := (primaryIdx + c.coordinatorFailoverIndex) % len(c.originatorNodePool)
+		coordinatorNode = c.originatorNodePool[selectedIdx]
+		log.L(ctx).Debugf("coordinator %s selected (primaryCandidate=%s, failoverIndex=%d) based on effective block %d, pool %+v",
+			coordinatorNode, c.originatorNodePool[primaryIdx], c.coordinatorFailoverIndex, effectiveBlockNumber, c.originatorNodePool)
 	} else if c.domainAPI.ContractConfig().GetCoordinatorSelection() == prototk.ContractConfig_COORDINATOR_SENDER {
 		// E.g. Zeto
 		log.L(ctx).Debugf("coordinator %s selected as next active coordinator in originator coordinator mode", c.nodeName)
@@ -104,4 +107,82 @@ func (c *coordinator) updateOriginatorNodePool(originatorNode string) {
 		c.originatorNodePool = append(c.originatorNodePool, c.nodeName)
 	}
 	slices.Sort(c.originatorNodePool)
+}
+
+// action_AttemptCoordinatorFailover is triggered when the currently observed coordinator has not
+// sent a heartbeat for long enough to exceed the inactiveToIdleGracePeriod. It advances
+// coordinatorFailoverIndex by one and selects the next deterministic candidate from the
+// originatorNodePool. All peers independently compute the same candidate because they share
+// the same sorted pool, block range, and failover counter progression.
+//
+// If the new candidate responds with a heartbeat, coordinatorFailoverIndex is reset to 0
+// (in action_HeartbeatReceived) and normal operation resumes.
+//
+// If every node in the pool has been tried without response, coordinatorFailoverIndex wraps
+// past the pool size: the index is reset to 0, activeCoordinatorNode is cleared, and the
+// coordinator transitions to State_Idle.
+//
+// Only COORDINATOR_ENDORSER mode supports multi-node failover. For COORDINATOR_STATIC and
+// COORDINATOR_SENDER modes, activeCoordinatorNode is cleared so the state machine can
+// transition directly to State_Idle.
+func action_AttemptCoordinatorFailover(ctx context.Context, c *coordinator, _ common.Event) error {
+	if c.domainAPI.ContractConfig().GetCoordinatorSelection() != prototk.ContractConfig_COORDINATOR_ENDORSER {
+		// Static and sender modes have no fallback; go idle.
+		c.activeCoordinatorNode = ""
+		return nil
+	}
+	if len(c.originatorNodePool) <= 1 {
+		log.L(ctx).Warnf("coordinator failover: pool has ≤1 node, going idle")
+		c.activeCoordinatorNode = ""
+		return nil
+	}
+
+	c.coordinatorFailoverIndex++
+	if c.coordinatorFailoverIndex >= len(c.originatorNodePool) {
+		// All candidates have been tried without a heartbeat response.
+		log.L(ctx).Warnf("coordinator failover: all %d candidates in pool tried without response, going idle", len(c.originatorNodePool))
+		c.coordinatorFailoverIndex = 0
+		c.activeCoordinatorNode = ""
+		return nil
+	}
+
+	newCoordinator, err := c.selectActiveCoordinatorNode(ctx)
+	if err != nil || newCoordinator == "" {
+		log.L(ctx).Warnf("coordinator failover: selection returned empty/error at failoverIndex=%d, going idle: %v", c.coordinatorFailoverIndex, err)
+		c.activeCoordinatorNode = ""
+		return nil
+	}
+
+	log.L(ctx).Infof("coordinator failover attempt %d: switching from %s to next candidate %s",
+		c.coordinatorFailoverIndex, c.activeCoordinatorNode, newCoordinator)
+	c.activeCoordinatorNode = newCoordinator
+	c.coordinatorActive(c.contractAddress, newCoordinator)
+	// Give the new candidate a fresh window to respond.
+	c.heartbeatIntervalsSinceLastReceive = 0
+	return nil
+}
+
+// action_ReevaluateCoordinatorOnNewBlock is called when a new block is received while in
+// State_Observing. If the effective block range has changed (causing action_NewBlock to
+// have reset coordinatorFailoverIndex to 0), this action re-runs coordinator selection so
+// that the primary candidate for the new block range is tried first.
+func action_ReevaluateCoordinatorOnNewBlock(ctx context.Context, c *coordinator, _ common.Event) error {
+	if c.domainAPI.ContractConfig().GetCoordinatorSelection() != prototk.ContractConfig_COORDINATOR_ENDORSER {
+		return nil
+	}
+	if len(c.originatorNodePool) == 0 {
+		return nil
+	}
+	newCoordinator, err := c.selectActiveCoordinatorNode(ctx)
+	if err != nil || newCoordinator == "" {
+		return nil
+	}
+	if newCoordinator != c.activeCoordinatorNode {
+		log.L(ctx).Infof("coordinator selection changed after new block: %s → %s (failoverIndex=%d)",
+			c.activeCoordinatorNode, newCoordinator, c.coordinatorFailoverIndex)
+		c.activeCoordinatorNode = newCoordinator
+		c.coordinatorActive(c.contractAddress, newCoordinator)
+		c.heartbeatIntervalsSinceLastReceive = 0
+	}
+	return nil
 }

--- a/core/go/internal/sequencer/coordinator/selection_test.go
+++ b/core/go/internal/sequencer/coordinator/selection_test.go
@@ -430,3 +430,284 @@ func Test_action_SelectActiveCoordinator_WhenSelectReturnsError_ReturnsNil(t *te
 	require.NoError(t, err)
 	assert.Empty(t, c.activeCoordinatorNode, "activeCoordinatorNode should remain empty when select returns error")
 }
+
+func Test_selectActiveCoordinatorNode_EndorserMode_FailoverIndex0_SameAsPrimarySelection(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+	c.coordinatorFailoverIndex = 0
+
+	coordinator0, err := c.selectActiveCoordinatorNode(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, []string{"node1", "node2", "node3"}, coordinator0)
+}
+
+func Test_selectActiveCoordinatorNode_EndorserMode_FailoverIndex1_SelectsDifferentNode(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+
+	c.coordinatorFailoverIndex = 0
+	primary, err0 := c.selectActiveCoordinatorNode(ctx)
+	require.NoError(t, err0)
+
+	c.coordinatorFailoverIndex = 1
+	failover1, err1 := c.selectActiveCoordinatorNode(ctx)
+	require.NoError(t, err1)
+
+	assert.NotEqual(t, primary, failover1, "failover index 1 should select a different node than primary")
+	assert.Contains(t, []string{"node1", "node2", "node3"}, failover1)
+}
+
+func Test_selectActiveCoordinatorNode_EndorserMode_FailoverIndex2_SelectsThirdOption(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+
+	c.coordinatorFailoverIndex = 0
+	p0, _ := c.selectActiveCoordinatorNode(ctx)
+	c.coordinatorFailoverIndex = 1
+	p1, _ := c.selectActiveCoordinatorNode(ctx)
+	c.coordinatorFailoverIndex = 2
+	p2, err := c.selectActiveCoordinatorNode(ctx)
+	require.NoError(t, err)
+
+	// All three failover slots should be distinct nodes covering the whole pool
+	selected := []string{p0, p1, p2}
+	assert.ElementsMatch(t, []string{"node1", "node2", "node3"}, selected,
+		"the three failover indices should select each node in the pool exactly once")
+}
+
+func Test_selectActiveCoordinatorNode_EndorserMode_FailoverWrapsAround(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+
+	c.coordinatorFailoverIndex = 0
+	p0, _ := c.selectActiveCoordinatorNode(ctx)
+	c.coordinatorFailoverIndex = 3 // wraps around to the same as index 0
+	p3, err := c.selectActiveCoordinatorNode(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, p0, p3, "failoverIndex=3 should wrap around to the same node as failoverIndex=0 for a 3-node pool")
+}
+
+func Test_action_AttemptCoordinatorFailover_EndorserMode_SingleNodePool_GoesIdle(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1"}
+	c.activeCoordinatorNode = "node1"
+
+	err := action_AttemptCoordinatorFailover(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Empty(t, c.activeCoordinatorNode, "single-node pool should result in idle (no other candidates)")
+}
+
+func Test_action_AttemptCoordinatorFailover_EndorserMode_MultiNodePool_SelectsNextCandidate(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+	c.coordinatorFailoverIndex = 0
+
+	// Record the primary coordinator
+	primaryCoordinator, _ := c.selectActiveCoordinatorNode(ctx)
+	c.activeCoordinatorNode = primaryCoordinator
+	c.heartbeatIntervalsSinceLastReceive = 5 // simulates having waited
+
+	err := action_AttemptCoordinatorFailover(ctx, c, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, c.coordinatorFailoverIndex, "failover index should be incremented to 1")
+	assert.NotEqual(t, primaryCoordinator, c.activeCoordinatorNode, "failover should select a different node from the primary")
+	assert.Contains(t, []string{"node1", "node2", "node3"}, c.activeCoordinatorNode)
+	assert.Equal(t, 0, c.heartbeatIntervalsSinceLastReceive, "heartbeat counter should be reset so new candidate gets a fair window")
+}
+
+func Test_action_AttemptCoordinatorFailover_EndorserMode_AllNodesExhausted_GoesIdle(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2"}
+	c.currentBlockHeight = 1000
+	// Simulate already having tried node2 (index 1 was the last failover), so next increment
+	// would bring us to 2 which equals len(pool)
+	c.coordinatorFailoverIndex = 1
+	c.activeCoordinatorNode = "node2"
+
+	err := action_AttemptCoordinatorFailover(ctx, c, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, c.activeCoordinatorNode, "all candidates tried — should go idle")
+	assert.Equal(t, 0, c.coordinatorFailoverIndex, "failover index should be reset after exhaustion")
+}
+
+func Test_action_AttemptCoordinatorFailover_StaticMode_GoesIdle(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_STATIC,
+		StaticCoordinator:    proto.String("identity@node1"),
+	})
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.activeCoordinatorNode = "node1"
+
+	err := action_AttemptCoordinatorFailover(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Empty(t, c.activeCoordinatorNode, "static mode has no fallback; should go idle")
+}
+
+func Test_action_AttemptCoordinatorFailover_SenderMode_GoesIdle(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
+	})
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.activeCoordinatorNode = "someNode"
+
+	err := action_AttemptCoordinatorFailover(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Empty(t, c.activeCoordinatorNode, "sender mode has no pool fallback; should go idle")
+}
+
+func Test_action_ReevaluateCoordinatorOnNewBlock_NonEndorserMode_IsNoop(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
+	})
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.activeCoordinatorNode = "node1"
+	original := c.activeCoordinatorNode
+
+	err := action_ReevaluateCoordinatorOnNewBlock(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Equal(t, original, c.activeCoordinatorNode, "non-endorser mode should be a no-op")
+}
+
+func Test_action_ReevaluateCoordinatorOnNewBlock_EmptyPool_IsNoop(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{}
+	c.activeCoordinatorNode = ""
+
+	err := action_ReevaluateCoordinatorOnNewBlock(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Empty(t, c.activeCoordinatorNode, "empty pool should be a no-op")
+}
+
+func Test_action_ReevaluateCoordinatorOnNewBlock_SameSelection_NoUpdate(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(100))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 1000
+	c.coordinatorFailoverIndex = 0
+
+	selected, _ := c.selectActiveCoordinatorNode(ctx)
+	c.activeCoordinatorNode = selected
+
+	// Re-evaluate without changing block or failover index — same selection expected.
+	err := action_ReevaluateCoordinatorOnNewBlock(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Equal(t, selected, c.activeCoordinatorNode, "same block range and failover index should produce the same selection")
+}
+
+func Test_action_ReevaluateCoordinatorOnNewBlock_RangeChanged_UpdatesCoordinator(t *testing.T) {
+	ctx := context.Background()
+	builder := NewCoordinatorBuilderForTesting(t, State_Observing)
+	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_ENDORSER,
+	})
+	config := builder.GetSequencerConfig()
+	config.BlockRange = confutil.P(uint64(50))
+	builder.OverrideSequencerConfig(config)
+	c, _, done := builder.Build(ctx)
+	defer done()
+	c.originatorNodePool = []string{"node1", "node2", "node3"}
+	c.currentBlockHeight = 100
+	c.coordinatorFailoverIndex = 0
+
+	firstSelected, _ := c.selectActiveCoordinatorNode(ctx)
+	c.activeCoordinatorNode = firstSelected
+
+	// Simulate crossing a block-range boundary (action_NewBlock would have updated currentBlockHeight
+	// and reset coordinatorFailoverIndex if it was non-zero).
+	c.currentBlockHeight = 150 // new range: 150 - (150 % 50) = 150
+
+	// Now re-evaluate — may or may not change depending on the hash, but must not error.
+	err := action_ReevaluateCoordinatorOnNewBlock(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Contains(t, []string{"node1", "node2", "node3"}, c.activeCoordinatorNode)
+}

--- a/core/go/internal/sequencer/coordinator/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/state_machine.go
@@ -112,6 +112,9 @@ var stateDefinitionsMap = StateDefinitions{
 					},
 				},
 			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
+			},
 		},
 	},
 	State_Idle: {
@@ -137,6 +140,9 @@ var stateDefinitionsMap = StateDefinitions{
 			},
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
+			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
 			},
 		},
 	},
@@ -164,11 +170,25 @@ var stateDefinitionsMap = StateDefinitions{
 			common.Event_HeartbeatInterval: {
 				Actions: []ActionRule{
 					{Action: action_IncrementHeartbeatIntervalsSinceLastReceive},
+					// When the threshold is exceeded, try the next deterministic coordinator candidate
+					// before committing to State_Idle. On a successful failover, action_AttemptCoordinatorFailover
+					// resets heartbeatIntervalsSinceLastReceive to 0, which causes guard_ObservingIdleThresholdExceeded
+					// to return false and prevents the transition below.
+					{
+						Action: action_AttemptCoordinatorFailover,
+						If:     guard_ObservingIdleThresholdExceeded,
+					},
 				},
 				Transitions: []Transition{{
 					To: State_Idle,
 					If: guard_ObservingIdleThresholdExceeded,
 				}},
+			},
+			Event_NewBlock: {
+				Actions: []ActionRule{
+					{Action: action_NewBlock},                        // updates currentBlockHeight, resets failoverIndex on range change
+					{Action: action_ReevaluateCoordinatorOnNewBlock}, // re-selects coordinator if index or range changed
+				},
 			},
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
@@ -206,6 +226,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
 			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
+			},
 		},
 	},
 	State_Prepared: {
@@ -222,6 +245,9 @@ var stateDefinitionsMap = StateDefinitions{
 			},
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
+			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
 			},
 		},
 	},
@@ -284,6 +310,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
 			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
+			},
 		},
 	},
 	State_Flush: {
@@ -319,6 +348,9 @@ var stateDefinitionsMap = StateDefinitions{
 			},
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
+			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
 			},
 		},
 	},
@@ -357,6 +389,9 @@ var stateDefinitionsMap = StateDefinitions{
 			},
 			Event_OriginatorNodePoolUpdateRequested: {
 				Actions: []ActionRule{{Action: action_UpdateOriginatorNodePoolFromEvent}},
+			},
+			Event_NewBlock: {
+				Actions: []ActionRule{{Action: action_NewBlock}},
 			},
 		},
 	},

--- a/core/go/internal/sequencer/sequencer.go
+++ b/core/go/internal/sequencer/sequencer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
+	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator"
 	coordinatorTx "github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/metrics"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/originator"
@@ -534,8 +535,24 @@ func (sMgr *sequencerManager) handleTx(ctx context.Context, dbTX persistence.DBT
 func (sMgr *sequencerManager) OnNewBlockHeight(ctx context.Context, blockHeight int64) {
 	log.L(ctx).Tracef("new block height %d", blockHeight)
 	sMgr.blockHeightMutex.Lock()
-	defer sMgr.blockHeightMutex.Unlock()
 	sMgr.blockHeight = blockHeight
+	sMgr.blockHeightMutex.Unlock()
+
+	// Notify all loaded sequencer coordinators of the new block height so they can
+	// update their local view and re-evaluate coordinator selection when the block
+	// range boundary is crossed. TryQueueEvent is non-blocking to avoid stalling
+	// the indexer post-commit callback.
+	sMgr.sequencersLock.RLock()
+	defer sMgr.sequencersLock.RUnlock()
+	if len(sMgr.sequencers) > 0 {
+		blockEvent := &coordinator.NewBlockEvent{
+			BaseEvent:   common.BaseEvent{EventTime: time.Now()},
+			BlockHeight: uint64(blockHeight),
+		}
+		for _, seq := range sMgr.sequencers {
+			seq.GetCoordinator().TryQueueEvent(ctx, blockEvent)
+		}
+	}
 }
 
 func (sMgr *sequencerManager) GetBlockHeight() int64 {

--- a/core/go/noderuntests/coordinationtest/coordinator_failover_test.go
+++ b/core/go/noderuntests/coordinationtest/coordinator_failover_test.go
@@ -1,0 +1,530 @@
+/*
+ * Copyright © 2025 Kaleido, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+Integration tests for the coordinator failover feature (issue-1143).
+
+These tests exercise the full multi-node stack and verify that when the
+currently-observed coordinator node stops heartbeating, the remaining nodes
+deterministically fail over to the next candidate from the originator pool
+and complete in-flight transactions — rather than going immediately idle.
+
+All tests use SelfEndorsement + ENDORSER_SUBMISSION so that each originating
+node can assemble and endorse its own transaction without requiring other nodes
+to be online. This isolates the coordinator-selection/failover logic from
+endorsement availability — we can verify that transactions submitted by alice
+complete even when bob (a coordinator candidate) is offline, because alice can
+self-endorse; the only thing that changes is which node acts as coordinator.
+
+Scenarios covered:
+
+ 1. TestCoordinatorFailover_PrimaryCoordinatorStops_TransactionCompletesViaFailover
+    Three nodes (alice, bob, carol) using SelfEndorsement. Alice submits a
+    transaction. Bob is then stopped. The test verifies that the remaining
+    nodes elect the next deterministic coordinator candidate and the transaction
+    eventually completes via the failover coordinator.
+
+ 2. TestCoordinatorFailover_PrimaryCoordinatorStopsAndRecovers_FailoverIndexReset
+    Same 3-node topology. Bob stops — failover kicks in and alice completes a
+    transaction. Bob then restarts, sending heartbeats that reset the failover
+    index on peers. A post-recovery transaction verifies the system re-converges
+    and completes normally.
+
+ 3. TestCoordinatorFailover_AllCandidatesUnresponsive_SystemGoesIdle
+    Three nodes using NotaryEndorsement with bob as the notary. After populating
+    the coordinator pool, both bob and carol are stopped. Because bob is both a
+    coordinator candidate AND the required notary endorser, alice cannot complete
+    any transaction: the coordinator pool is fully exhausted (idle) AND endorsement
+    is unavailable. The test verifies the transaction does NOT complete within the
+    normal window — safe idle behaviour rather than looping forever.
+
+ 4. TestCoordinatorFailover_FailoverThenNewBlockRange_ReselectsPrimary
+    Two-node setup (alice, bob) using SelfEndorsement with a small BlockRange.
+    Bob is stopped so failover fires. New blocks cross a block-range boundary,
+    resetting coordinatorFailoverIndex to 0 and triggering
+    action_ReevaluateCoordinatorOnNewBlock. Bob is restarted; the test verifies
+    the stalled transaction completes once the boundary reset re-selects a live
+    coordinator.
+*/
+package coordinationtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LFDT-Paladin/paladin/config/pkg/confutil"
+	"github.com/LFDT-Paladin/paladin/config/pkg/pldconf"
+	testutils "github.com/LFDT-Paladin/paladin/core/noderuntests/pkg"
+	"github.com/LFDT-Paladin/paladin/core/noderuntests/pkg/domains"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failoverSequencerConfig returns a SequencerConfig tuned for fast failover in tests:
+//   - 1 s heartbeat interval  → observers detect missed heartbeats quickly
+//   - InactiveToIdleGracePeriod=2  → after 2 missed intervals the failover action fires
+//   - RedelegateGracePeriod=1  → redelegate quickly once we become active coordinator
+//   - short RequestTimeout / StateTimeout so stalled assembly is re-pooled fast
+func failoverSequencerConfig() *pldconf.SequencerConfig {
+	cfg := pldconf.SequencerDefaults
+	cfg.HeartbeatInterval = confutil.P("1s")
+	cfg.InactiveToIdleGracePeriod = confutil.P(2)
+	cfg.RedelegateGracePeriod = confutil.P(1)
+	cfg.RequestTimeout = confutil.P("3s")
+	cfg.StateTimeout = confutil.P("10s")
+	return &cfg
+}
+
+// failoverTransactionLatencyThreshold gives a generous window for failover tests
+// because failover itself takes a few heartbeat cycles before transactions resume.
+func failoverTransactionLatencyThreshold(t *testing.T) time.Duration {
+	return transactionLatencyThresholdCustom(t, func() *time.Duration {
+		d := 30 * time.Second
+		return &d
+	}())
+}
+
+// ── Test 1 ───────────────────────────────────────────────────────────────────
+
+// TestCoordinatorFailover_PrimaryCoordinatorStops_TransactionCompletesViaFailover
+// verifies that when the primary coordinator node goes offline, the remaining
+// nodes fail over to the next candidate in the pool and the pending transaction
+// eventually completes.
+//
+// SelfEndorsement is used so that alice can assemble and endorse her own
+// transaction without needing bob or carol online — the only coordination role
+// bob provides is as coordinator, not as endorser.
+func TestCoordinatorFailover_PrimaryCoordinatorStops_TransactionCompletesViaFailover(t *testing.T) {
+	ctx := t.Context()
+
+	domainRegistryAddress := deployDomainRegistry(t, "alice")
+
+	alice := testutils.NewPartyForTesting(t, "alice", domainRegistryAddress)
+	bob := testutils.NewPartyForTesting(t, "bob", domainRegistryAddress)
+	carol := testutils.NewPartyForTesting(t, "carol", domainRegistryAddress)
+
+	// Wire all peers together so all three appear in the coordinator pool.
+	alice.AddPeer(bob.GetNodeConfig(), carol.GetNodeConfig())
+	bob.AddPeer(alice.GetNodeConfig(), carol.GetNodeConfig())
+	carol.AddPeer(alice.GetNodeConfig(), bob.GetNodeConfig())
+
+	seqCfg := failoverSequencerConfig()
+	alice.OverrideSequencerConfig(seqCfg)
+	bob.OverrideSequencerConfig(seqCfg)
+	carol.OverrideSequencerConfig(seqCfg)
+
+	// SelfEndorsement: each node endorses its own transactions, so alice's
+	// transactions can complete without bob or carol being online as endorsers.
+	// ENDORSER_SUBMISSION: the coordinator node submits to the base ledger.
+	domainConfig := &domains.SimpleDomainConfig{
+		SubmitMode: domains.ENDORSER_SUBMISSION,
+	}
+
+	startNode(t, alice, domainConfig)
+	startNode(t, bob, domainConfig)
+	startNode(t, carol, domainConfig)
+	t.Cleanup(func() {
+		stopNode(t, alice)
+		stopNode(t, carol)
+	})
+
+	constructorParameters := &domains.ConstructorParameters{
+		From:            alice.GetIdentity(),
+		Name:            "FailoverToken1",
+		Symbol:          "FO1",
+		EndorsementMode: domains.SelfEndorsement,
+	}
+
+	contractAddress := alice.DeploySimpleDomainInstanceContract(t, constructorParameters, failoverTransactionLatencyThreshold)
+
+	// Warm-up: submit a transaction while all nodes are healthy. This populates
+	// the originator node pool on all coordinators so failover has candidates to
+	// cycle through.
+	warmupTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("failover-warmup-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "100000000000000000000"
+		}`)).
+		Send().Wait(failoverTransactionLatencyThreshold(t))
+	require.NoError(t, warmupTx.Error(), "warm-up transaction should succeed with all nodes healthy")
+
+	// Stop bob. After InactiveToIdleGracePeriod heartbeat intervals the failover
+	// action fires on observing nodes and picks the next live candidate from the
+	// pool (alice or carol, whichever the hash selects next).
+	stopNode(t, bob)
+
+	// Submit a transaction while bob is offline — it should eventually complete
+	// via the failover coordinator (alice or carol).
+	failoverTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("failover-tx-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "50000000000000000000"
+		}`)).
+		Send()
+	require.NoError(t, failoverTx.Error(), "send should not return an immediate error")
+
+	// Failover takes a few heartbeat cycles; use the generous threshold.
+	assert.Eventually(t,
+		transactionReceiptCondition(t, ctx, *failoverTx.ID(), alice.GetClient(), false),
+		failoverTransactionLatencyThreshold(t),
+		200*time.Millisecond,
+		"transaction should complete after coordinator failover with bob offline",
+	)
+}
+
+// ── Test 2 ───────────────────────────────────────────────────────────────────
+
+// TestCoordinatorFailover_PrimaryCoordinatorStopsAndRecovers_FailoverIndexReset
+// verifies that when the primary coordinator stops, failover engages, a
+// transaction still completes via the failover coordinator, and then when the
+// primary restarts and sends a heartbeat the failover index is reset so
+// subsequent transactions complete normally.
+//
+// SelfEndorsement is used so alice can complete transactions regardless of
+// whether bob is online as an endorser — the test is purely about coordinator
+// role failover and recovery, not endorsement availability.
+func TestCoordinatorFailover_PrimaryCoordinatorStopsAndRecovers_FailoverIndexReset(t *testing.T) {
+	ctx := t.Context()
+
+	domainRegistryAddress := deployDomainRegistry(t, "alice")
+
+	alice := testutils.NewPartyForTesting(t, "alice", domainRegistryAddress)
+	bob := testutils.NewPartyForTesting(t, "bob", domainRegistryAddress)
+	carol := testutils.NewPartyForTesting(t, "carol", domainRegistryAddress)
+
+	alice.AddPeer(bob.GetNodeConfig(), carol.GetNodeConfig())
+	bob.AddPeer(alice.GetNodeConfig(), carol.GetNodeConfig())
+	carol.AddPeer(alice.GetNodeConfig(), bob.GetNodeConfig())
+
+	seqCfg := failoverSequencerConfig()
+	alice.OverrideSequencerConfig(seqCfg)
+	bob.OverrideSequencerConfig(seqCfg)
+	carol.OverrideSequencerConfig(seqCfg)
+
+	domainConfig := &domains.SimpleDomainConfig{
+		SubmitMode: domains.ENDORSER_SUBMISSION,
+	}
+
+	startNode(t, alice, domainConfig)
+	startNode(t, bob, domainConfig)
+	startNode(t, carol, domainConfig)
+	t.Cleanup(func() {
+		stopNode(t, carol)
+	})
+
+	constructorParameters := &domains.ConstructorParameters{
+		From:            alice.GetIdentity(),
+		Name:            "FailoverToken2",
+		Symbol:          "FO2",
+		EndorsementMode: domains.SelfEndorsement,
+	}
+
+	contractAddress := alice.DeploySimpleDomainInstanceContract(t, constructorParameters, failoverTransactionLatencyThreshold)
+
+	// Warm-up: confirm healthy operation and populate the coordinator pool.
+	warmupTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("recovery-warmup-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "100000000000000000000"
+		}`)).
+		Send().Wait(failoverTransactionLatencyThreshold(t))
+	require.NoError(t, warmupTx.Error(), "warm-up transaction should succeed with all nodes healthy")
+
+	// Stop bob to trigger failover on observing nodes.
+	stopNode(t, bob)
+
+	// Submit a transaction — should complete via the failover coordinator
+	// (alice or carol, whoever the hash selects at failoverIndex=1).
+	failoverTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("recovery-failover-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "50000000000000000000"
+		}`)).
+		Send()
+	require.NoError(t, failoverTx.Error())
+
+	assert.Eventually(t,
+		transactionReceiptCondition(t, ctx, *failoverTx.ID(), alice.GetClient(), false),
+		failoverTransactionLatencyThreshold(t),
+		200*time.Millisecond,
+		"failover transaction should complete while bob is offline",
+	)
+
+	// Restart bob — his heartbeats will reach alice and carol, and
+	// action_HeartbeatReceived will reset coordinatorFailoverIndex to 0.
+	startNode(t, bob, domainConfig)
+	t.Cleanup(func() {
+		stopNode(t, bob)
+		stopNode(t, alice)
+	})
+
+	// Allow enough time for at least 2 heartbeat cycles so the reset propagates.
+	time.Sleep(3 * time.Second)
+
+	// Post-recovery transaction — should complete normally now that bob is back
+	// and the failover index has been reset to 0.
+	recoveryTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("post-recovery-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "25000000000000000000"
+		}`)).
+		Send().Wait(failoverTransactionLatencyThreshold(t))
+	require.NoError(t, recoveryTx.Error(), "post-recovery transaction should complete after bob rejoins and failover index resets")
+}
+
+// ── Test 3 ───────────────────────────────────────────────────────────────────
+
+// TestCoordinatorFailover_AllCandidatesUnresponsive_SystemGoesIdle
+// verifies that when every candidate in the originator pool is unreachable, the
+// surviving node exhausts the failover list and the submitted transaction does
+// NOT complete within the normal latency window — safe idle behaviour rather
+// than looping forever.
+//
+// NotaryEndorsement with bob as notary is used so that alice's transaction
+// genuinely cannot complete when bob is offline: bob is both a required endorser
+// AND a coordinator candidate, so the system is stuck from both angles.
+func TestCoordinatorFailover_AllCandidatesUnresponsive_SystemGoesIdle(t *testing.T) {
+	ctx := t.Context()
+
+	domainRegistryAddress := deployDomainRegistry(t, "alice")
+
+	alice := testutils.NewPartyForTesting(t, "alice", domainRegistryAddress)
+	bob := testutils.NewPartyForTesting(t, "bob", domainRegistryAddress)
+	carol := testutils.NewPartyForTesting(t, "carol", domainRegistryAddress)
+
+	alice.AddPeer(bob.GetNodeConfig(), carol.GetNodeConfig())
+	bob.AddPeer(alice.GetNodeConfig(), carol.GetNodeConfig())
+	carol.AddPeer(alice.GetNodeConfig(), bob.GetNodeConfig())
+
+	// Very short grace period so all failover candidates are exhausted quickly.
+	seqCfg := failoverSequencerConfig()
+	seqCfg.InactiveToIdleGracePeriod = confutil.P(1)
+	alice.OverrideSequencerConfig(seqCfg)
+	bob.OverrideSequencerConfig(seqCfg)
+	carol.OverrideSequencerConfig(seqCfg)
+
+	domainConfig := &domains.SimpleDomainConfig{
+		SubmitMode: domains.ENDORSER_SUBMISSION,
+	}
+
+	startNode(t, alice, domainConfig)
+	startNode(t, bob, domainConfig)
+	startNode(t, carol, domainConfig)
+
+	// NotaryEndorsement: bob is the notary, so every transaction submitted by
+	// alice requires bob's endorsement. When bob goes offline, transactions are
+	// stuck from both the coordinator side (pool exhausted → idle) and the
+	// endorsement side (notary unreachable).
+	constructorParameters := &domains.ConstructorParameters{
+		From:            alice.GetIdentity(),
+		Name:            "FailoverToken3",
+		Symbol:          "FO3",
+		EndorsementMode: domains.NotaryEndorsement,
+		Notary:          bob.GetIdentityLocator(),
+	}
+
+	contractAddress := alice.DeploySimpleDomainInstanceContract(t, constructorParameters, failoverTransactionLatencyThreshold)
+
+	// Warm-up: populate the coordinator pool on all nodes. With NotaryEndorsement
+	// the notary (bob) must be online to endorse — which he is at this point.
+	warmupTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("idle-warmup-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "100000000000000000000"
+		}`)).
+		Send().Wait(failoverTransactionLatencyThreshold(t))
+	require.NoError(t, warmupTx.Error(), "warm-up transaction should succeed with all nodes healthy")
+
+	// Stop bob and carol — alice has no reachable coordinator candidates.
+	stopNode(t, bob)
+	stopNode(t, carol)
+	t.Cleanup(func() {
+		stopNode(t, alice)
+	})
+
+	// Submit a transaction that requires bob's notary endorsement — which is now
+	// impossible since bob is offline. Alice should exhaust all coordinator
+	// failover candidates and go idle rather than looping forever.
+	// The transaction must NOT receive a receipt within the normal window.
+	stalledTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("idle-stall-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "10000000000000000000"
+		}`)).
+		Send()
+	require.NoError(t, stalledTx.Error(), "send should not fail synchronously")
+
+	// Use the short (normal) threshold — a receipt here would be a test failure.
+	result := stalledTx.Wait(transactionLatencyThreshold(t))
+	require.Error(t, result.Error(), "stalled transaction should NOT complete when bob (notary + coordinator candidate) is offline")
+	assert.Contains(t, result.Error().Error(), "timed out",
+		"error should indicate a timeout, not a hard failure")
+}
+
+// ── Test 4 ───────────────────────────────────────────────────────────────────
+
+// TestCoordinatorFailover_FailoverThenNewBlockRange_ReselectsPrimary
+// verifies the OnNewBlockHeight → TryQueueEvent → action_ReevaluateCoordinatorOnNewBlock
+// wiring end-to-end. When a new block-range boundary is crossed the failover
+// index is reset to 0 and the coordinator is re-selected, so transactions
+// resume once a live node is re-elected as primary.
+//
+// SelfEndorsement is used so alice's transaction can complete without bob as
+// an endorser — bob's role here is purely as a coordinator candidate.
+func TestCoordinatorFailover_FailoverThenNewBlockRange_ReselectsPrimary(t *testing.T) {
+	ctx := t.Context()
+
+	domainRegistryAddress := deployDomainRegistry(t, "alice")
+
+	alice := testutils.NewPartyForTesting(t, "alice", domainRegistryAddress)
+	bob := testutils.NewPartyForTesting(t, "bob", domainRegistryAddress)
+
+	alice.AddPeer(bob.GetNodeConfig())
+	bob.AddPeer(alice.GetNodeConfig())
+
+	// Small BlockRange (minimum = 10) so a boundary is crossed quickly during
+	// the test without needing to wait for many blocks.
+	seqCfg := failoverSequencerConfig()
+	seqCfg.BlockRange = confutil.P(uint64(10))
+	alice.OverrideSequencerConfig(seqCfg)
+	bob.OverrideSequencerConfig(seqCfg)
+
+	domainConfig := &domains.SimpleDomainConfig{
+		SubmitMode: domains.ENDORSER_SUBMISSION,
+	}
+
+	startNode(t, alice, domainConfig)
+	startNode(t, bob, domainConfig)
+	t.Cleanup(func() {
+		stopNode(t, alice)
+	})
+
+	constructorParameters := &domains.ConstructorParameters{
+		From:            alice.GetIdentity(),
+		Name:            "FailoverToken4",
+		Symbol:          "FO4",
+		EndorsementMode: domains.SelfEndorsement,
+	}
+
+	contractAddress := alice.DeploySimpleDomainInstanceContract(t, constructorParameters, failoverTransactionLatencyThreshold)
+
+	// Warm-up: populate the coordinator pool on both nodes.
+	warmupTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("blockrange-warmup-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "100000000000000000000"
+		}`)).
+		Send().Wait(failoverTransactionLatencyThreshold(t))
+	require.NoError(t, warmupTx.Error(), "warm-up transaction should succeed with all nodes healthy")
+
+	// Stop bob to force failover on alice's coordinator state machine.
+	stopNode(t, bob)
+
+	// Submit a transaction while bob is offline — will stall until a live
+	// coordinator is selected (either via failover or block-range reset).
+	stalledTx := alice.GetClient().ForABI(ctx, *domains.SimpleTokenTransferABI()).
+		Private().
+		Domain("domain1").
+		IdempotencyKey("blockrange-stall-" + uuid.New().String()).
+		From(alice.GetIdentity()).
+		To(contractAddress).
+		Function("transfer").
+		Inputs(pldtypes.RawJSON(`{
+			"from": "",
+			"to": "` + alice.GetIdentityLocator() + `",
+			"amount": "10000000000000000000"
+		}`)).
+		Send()
+	require.NoError(t, stalledTx.Error())
+
+	// Allow the failover action to fire (≥2 heartbeat intervals = ≥2 s) and for
+	// Besu to mine enough blocks to cross a block-range boundary (every 10 blocks).
+	// action_NewBlock resets coordinatorFailoverIndex to 0 at the boundary, and
+	// action_ReevaluateCoordinatorOnNewBlock re-selects the primary candidate.
+	time.Sleep(5 * time.Second)
+
+	// Restart bob. With the failover index reset, the next coordinator selection
+	// may land on alice (who is always live), so the stalled transaction should
+	// be able to complete even before a second boundary.
+	startNode(t, bob, domainConfig)
+	t.Cleanup(func() {
+		stopNode(t, bob)
+	})
+
+	assert.Eventually(t,
+		transactionReceiptCondition(t, ctx, *stalledTx.ID(), alice.GetClient(), false),
+		failoverTransactionLatencyThreshold(t),
+		200*time.Millisecond,
+		"stalled transaction should complete after bob restarts and block-range boundary resets the failover index",
+	)
+}


### PR DESCRIPTION
feature# - https://github.com/LFDT-Paladin/paladin/issues/1143

Coordinator Failover for Endorser Mode (`issue-1143`)

### Problem

When the currently-observed coordinator node stopped heartbeating, the sequencer would immediately transition to `State_Idle` after `inactiveToIdleGracePeriod` intervals — even if other healthy nodes in the originator pool could take over. This caused in-flight transactions to stall unnecessarily until the original coordinator came back online.

### Solution

Introduce a `coordinatorFailoverIndex` field on the coordinator state machine. When the heartbeat threshold is exceeded in `State_Observing`, instead of going idle immediately, the system increments the failover index and deterministically selects the next candidate from the sorted originator pool using the same hash-modulus logic as primary selection. Since all nodes share the same sorted pool and block range, they independently arrive at the same failover candidate — no additional coordination is needed.

The failover index is reset to `0` in three cases:
- A valid heartbeat is received (`action_HeartbeatReceived`) — primary is back
- A block-range boundary is crossed (`action_NewBlock`) — new epoch, start fresh
- The coordinator enters idle (`action_Idle`) — pool fully exhausted

`OnNewBlockHeight` in the sequencer manager now broadcasts a `NewBlockEvent` to all loaded coordinators via `TryQueueEvent`, enabling `action_ReevaluateCoordinatorOnNewBlock` to re-select the primary when the range resets.

Only `COORDINATOR_ENDORSER` mode supports multi-node failover. `COORDINATOR_STATIC` and `COORDINATOR_SENDER` modes clear `activeCoordinatorNode` and go idle immediately as before.

Tests

**Unit tests** (`internal/sequencer/coordinator/`) — 13 packages, all passing:
- Failover index selection with index 0/1/2 and wrap-around
- `action_AttemptCoordinatorFailover` for single-node pool, multi-node pool, all-exhausted, static mode, sender mode
- `action_ReevaluateCoordinatorOnNewBlock` no-op cases and active re-selection
- Block-range boundary reset and heartbeat reset

**Integration tests** (`noderuntests/coordinationtest/coordinator_failover_test.go`) — 4 new tests, all passing:
- Primary coordinator stops → failover coordinator completes the transaction
- Primary stops and recovers → failover index resets → system re-converges
- All candidates unresponsive → system goes idle safely (no infinite loop)
- Block-range boundary reset → re-selects primary → stalled transaction completes