### PR TITLE
Tx receipts

### DIFF
--- a/ui/client/src/components/EnrichedTransaction.tsx
+++ b/ui/client/src/components/EnrichedTransaction.tsx
@@ -118,12 +118,12 @@ export const EnrichedTransaction: React.FC<Props> = ({
           }}>
             <img src={iconLight} width="12" />
             <Typography variant="body2">{t('paladin')}</Typography>
-            <Chip label={enrichedTransaction.paladinTransactions.length} sx={{ borderRadius: '4px', height: '25px' }} />
+            <Chip label={enrichedTransaction.receipts.length} sx={{ borderRadius: '4px', height: '25px' }} />
             <Box sx={{ width: '20px' }} />
-            {enrichedTransaction.paladinTransactions.map(paladinTransaction =>
+            {enrichedTransaction.receipts.map(receipt =>
               <PaladinTransactionChip 
-              key={paladinTransaction.id} 
-              paladinTransaction={paladinTransaction}
+              key={receipt.id} 
+              paladinTransaction={receipt}
                />
             )}
           </Box>

--- a/ui/client/src/components/PaladinTransactionChip.tsx
+++ b/ui/client/src/components/PaladinTransactionChip.tsx
@@ -15,14 +15,14 @@
 // limitations under the License.
 
 import { Button } from "@mui/material";
-import { IPaladinTransaction } from "../interfaces";
+import { IPaladinTransaction, ITransactionReceipt } from "../interfaces";
 import { getShortId } from "../utils";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 type Props = {
-  paladinTransaction: IPaladinTransaction
+  paladinTransaction: IPaladinTransaction | ITransactionReceipt
 }
 
 export const PaladinTransactionChip: React.FC<Props> = ({

--- a/ui/client/src/queries/rpcMethods.ts
+++ b/ui/client/src/queries/rpcMethods.ts
@@ -29,6 +29,7 @@ export const RpcMethods = {
   ptx_QueryPendingTransactions: 'ptx_queryPendingTransactions',
   ptx_QueryTransactionReceipts: 'ptx_queryTransactionReceipts',
   ptx_getTransactionReceipt: 'ptx_getTransactionReceipt',
+  ptx_getTransactionReceiptFull: 'ptx_getTransactionReceiptFull',
   ptx_QueryTransactions: 'ptx_queryTransactions',
   ptx_QueryTransactionsFull: 'ptx_queryTransactionsFull',
   ptx_getStateReceipt: 'ptx_getStateReceipt',

--- a/ui/client/src/queries/transactions.ts
+++ b/ui/client/src/queries/transactions.ts
@@ -203,6 +203,24 @@ export const fetchTransactionReceipt = async (
   );
 };
 
+export const fetchTransactionReceiptFull = async (
+  transactionId: string
+): Promise<ITransactionReceipt> => {
+  const payload = {
+    jsonrpc: '2.0',
+    id: Date.now(),
+    method: RpcMethods.ptx_getTransactionReceiptFull,
+    params: [transactionId],
+  };
+
+  return <Promise<ITransactionReceipt>>(
+    returnResponse(
+      () => fetch(RpcEndpoint, generatePostReq(JSON.stringify(payload))),
+      i18next.t('errorFetchingTransactionReceipt')
+    )
+  );
+};
+
 export const fetchTransactionReceipts = async (
   transactions: ITransaction[]
 ): Promise<ITransactionReceipt[]> => {

--- a/ui/client/src/views/TransactionDetails.tsx
+++ b/ui/client/src/views/TransactionDetails.tsx
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Box, Button, Fade, Grid2, Typography } from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Alert, Box, Button, Fade, Grid2, Typography } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
-import { fetchPaladinTransaction, fetchTransaction } from "../queries/transactions";
+import { fetchPaladinTransaction, fetchTransaction, fetchTransactionReceiptFull } from "../queries/transactions";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { isValidTransactionHash, isValidUUID } from "../utils";
@@ -25,6 +25,8 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { TransactionOverview } from "../components/TransactionOverview";
 import { EventsOverview } from "../components/EventsOverview";
 import { PaladinTransactionSection } from "../components/PaladinTransactionSection";
+import { JSONBox } from "../components/JSONBox";
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 export const TransactionDetails: React.FC = () => {
 
@@ -59,6 +61,12 @@ export const TransactionDetails: React.FC = () => {
     enabled: id !== undefined
   });
 
+  const { data: receipt, error: receiptError } = useQuery({
+    queryKey: [`paladin-receipt-full-${id}`],
+    queryFn: () => fetchTransactionReceiptFull(id!),
+    enabled: id !== undefined
+  });
+  
   useEffect(() => {
     if (hash === undefined && paladinTransaction !== undefined) {
       setHash(paladinTransaction?.receipt?.transactionHash);
@@ -69,7 +77,7 @@ export const TransactionDetails: React.FC = () => {
     return <></>;
   }
 
-  if (blockchainTransactionError || paladinTransactionError) {
+  if (blockchainTransactionError || paladinTransactionError || receiptError) {
     return <Alert sx={{ margin: '30px' }} severity="error" variant="filled">{blockchainTransactionError?.message ?? paladinTransactionError?.message}</Alert>
   }
 
@@ -113,11 +121,21 @@ export const TransactionDetails: React.FC = () => {
               }
             </Grid2>
           </Grid2>}
-        {enrichedTransaction === undefined && paladinTransaction !== undefined &&
+        {enrichedTransaction === undefined && paladinTransaction !== undefined && paladinTransaction !== null &&
           <Box>
             <Typography align="center" variant="h6" sx={{ marginBottom: '5px' }}>{t('paladinTransaction')}</Typography>
             <PaladinTransactionSection paladinTransactions={[paladinTransaction]} />
           </Box>
+        }
+        {enrichedTransaction === undefined && receipt !== undefined &&
+          <Accordion elevation={0} disableGutters>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            {t('receipt')}
+          </AccordionSummary>
+          <AccordionDetails >
+            <JSONBox data={receipt} />
+          </AccordionDetails>
+        </Accordion>
         }
       </Box>
     </Fade>


### PR DESCRIPTION
Ensure that the transactions panel shows paladin entries when there is a receipt for it, independently of whether the actual Paladin transaction is present or not. In addition, modify the transaction details panel so that it shows the receipt details in full for cases where the Paladin transaction is not present.