### PR TITLE
add PTX dispatch and chained-dispatch wrappers

### DIFF
--- a/sdk/typescript/src/interfaces/transaction.ts
+++ b/sdk/typescript/src/interfaces/transaction.ts
@@ -60,6 +60,18 @@ export interface IPreparedTransaction {
   metadata: any;
 }
 
+export interface IDispatch {
+  id: string;
+  transactionID: string;
+  publicTransactionID: number;
+}
+
+export interface IChainedDispatch {
+  id: string;
+  transactionID: string;
+  chainedTransactionID: string;
+}
+
 export interface ITransactionInput extends ITransactionBase {
   abiReference?: string;
   abi?: ethers.InterfaceAbi;

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -6,6 +6,8 @@ import {
   DomainInvokeRPC,
   IABIDecodedData,
   IBlockchainEventListener,
+  IChainedDispatch,
+  IDispatch,
   IDomain,
   IDomainSmartContract,
   IEthAddress,
@@ -540,6 +542,44 @@ export default class PaladinClient {
         [query]
       );
       return res.data.result;
+    },
+
+    queryDispatches: async (query: IQuery) => {
+      const res = await this.post<JsonRpcResult<IDispatch[]>>(
+        "ptx_queryDispatches",
+        [query]
+      );
+      return res.data.result;
+    },
+
+    getDispatch: async (id: string) => {
+      const res = await this.post<JsonRpcResult<IDispatch>>(
+        "ptx_getDispatch",
+        [id],
+        {
+          validateStatus: (status) => status < 300 || status === 404,
+        }
+      );
+      return res.status === 404 ? undefined : res.data.result;
+    },
+
+    queryChainedDispatches: async (query: IQuery) => {
+      const res = await this.post<JsonRpcResult<IChainedDispatch[]>>(
+        "ptx_queryChainedDispatches",
+        [query]
+      );
+      return res.data.result;
+    },
+
+    getChainedDispatch: async (id: string) => {
+      const res = await this.post<JsonRpcResult<IChainedDispatch>>(
+        "ptx_getChainedDispatch",
+        [id],
+        {
+          validateStatus: (status) => status < 300 || status === 404,
+        }
+      );
+      return res.status === 404 ? undefined : res.data.result;
     },
 
     queryPendingTransactions: async (query: IQuery, full?: boolean) => {


### PR DESCRIPTION
### Summary
Adds missing PTX dispatch visibility wrappers to the TypeScript SDK for parity with Paladin RPC and Go pldclient.

Solves https://github.com/LFDT-Paladin/paladin/issues/1167
### Added methods

1. ptx.queryDispatches(query)
2. ptx.getDispatch(id)
3. ptx.queryChainedDispatches(query)
4. ptx.getChainedDispatch(id)

### Why
TypeScript users currently need raw JSON-RPC calls for dispatch/chained-dispatch queries. This PR improves discoverability, type safety, and SDK parity.

### Scope
SDK wrapper + typings only