### PR TITLE
Implement public transaction manager Prometheus metrics

### DIFF
--- a/core/go/internal/publictxmgr/metrics/metrics.go
+++ b/core/go/internal/publictxmgr/metrics/metrics.go
@@ -27,7 +27,6 @@ type PublicTransactionManagerMetrics interface {
 	IncCompletedTransactions()
 	IncCompletedTransactionsByN(numberOfTransactions uint64)
 
-	// TODO - TX manager currently expects these, currently they need implementing
 	RecordOperationMetrics(ctx context.Context, operationName string, operationResult string, durationInSeconds float64)
 	RecordStageChangeMetrics(ctx context.Context, stage string, durationInSeconds float64)
 	RecordInFlightTxQueueMetrics(ctx context.Context, usedCountPerStage map[string]int, freeCount int)
@@ -37,9 +36,20 @@ type PublicTransactionManagerMetrics interface {
 
 var METRICS_SUBSYSTEM = "public_transaction_manager"
 
+// durationBuckets are second-based buckets covering sub-millisecond to multi-minute ranges
+// typical for signing, gas estimation, and submission operations.
+var durationBuckets = []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60}
+
 type publicTransactionManagerMetrics struct {
-	dbSubmittedTransactions prometheus.Counter
-	completedTransactions   prometheus.Counter
+	dbSubmittedTransactions   prometheus.Counter
+	completedTransactions     prometheus.Counter
+	operationDuration         *prometheus.HistogramVec
+	stageDuration             *prometheus.HistogramVec
+	inflightTxsByStage        *prometheus.GaugeVec
+	inflightTxsFree           prometheus.Gauge
+	completedTxsByStatus      *prometheus.CounterVec
+	inflightOrchestratorState *prometheus.GaugeVec
+	inflightOrchestratorFree  prometheus.Gauge
 }
 
 func InitMetrics(ctx context.Context, registry *prometheus.Registry) *publicTransactionManagerMetrics {
@@ -49,9 +59,36 @@ func InitMetrics(ctx context.Context, registry *prometheus.Registry) *publicTran
 		Help: "Public transaction manager transactions submitted to the DB", Subsystem: METRICS_SUBSYSTEM})
 	metrics.completedTransactions = prometheus.NewCounter(prometheus.CounterOpts{Name: "completed_txns_total",
 		Help: "Public transaction manager completed transactions", Subsystem: METRICS_SUBSYSTEM})
+	metrics.operationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "operation_duration_seconds",
+		Help: "Duration of public transaction manager operations in seconds", Subsystem: METRICS_SUBSYSTEM, Buckets: durationBuckets},
+		[]string{"operation", "result"})
+	metrics.stageDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "stage_duration_seconds",
+		Help: "Duration of each in-flight transaction stage in seconds", Subsystem: METRICS_SUBSYSTEM, Buckets: durationBuckets},
+		[]string{"stage"})
+	metrics.inflightTxsByStage = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "inflight_txns_by_stage",
+		Help: "Number of in-flight transactions per stage", Subsystem: METRICS_SUBSYSTEM},
+		[]string{"stage"})
+	metrics.inflightTxsFree = prometheus.NewGauge(prometheus.GaugeOpts{Name: "inflight_txns_free",
+		Help: "Number of free slots in the in-flight transaction queue", Subsystem: METRICS_SUBSYSTEM})
+	metrics.completedTxsByStatus = prometheus.NewCounterVec(prometheus.CounterOpts{Name: "completed_txns_by_status_total",
+		Help: "Public transaction manager completed transactions by status", Subsystem: METRICS_SUBSYSTEM},
+		[]string{"status"})
+	metrics.inflightOrchestratorState = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "inflight_orchestrators_by_state",
+		Help: "Number of in-flight orchestrators per state", Subsystem: METRICS_SUBSYSTEM},
+		[]string{"state"})
+	metrics.inflightOrchestratorFree = prometheus.NewGauge(prometheus.GaugeOpts{Name: "inflight_orchestrators_free",
+		Help: "Number of free slots in the orchestrator pool", Subsystem: METRICS_SUBSYSTEM})
 
 	registry.MustRegister(metrics.dbSubmittedTransactions)
 	registry.MustRegister(metrics.completedTransactions)
+	registry.MustRegister(metrics.operationDuration)
+	registry.MustRegister(metrics.stageDuration)
+	registry.MustRegister(metrics.inflightTxsByStage)
+	registry.MustRegister(metrics.inflightTxsFree)
+	registry.MustRegister(metrics.completedTxsByStatus)
+	registry.MustRegister(metrics.inflightOrchestratorState)
+	registry.MustRegister(metrics.inflightOrchestratorFree)
+
 	return metrics
 }
 
@@ -72,21 +109,27 @@ func (ptm *publicTransactionManagerMetrics) IncCompletedTransactionsByN(numberOf
 }
 
 func (ptm *publicTransactionManagerMetrics) RecordOperationMetrics(ctx context.Context, operationName string, operationResult string, durationInSeconds float64) {
-	// TODO
+	ptm.operationDuration.With(prometheus.Labels{"operation": operationName, "result": operationResult}).Observe(durationInSeconds)
 }
 
 func (ptm *publicTransactionManagerMetrics) RecordStageChangeMetrics(ctx context.Context, stage string, durationInSeconds float64) {
-	// TODO
+	ptm.stageDuration.With(prometheus.Labels{"stage": stage}).Observe(durationInSeconds)
 }
 
 func (ptm *publicTransactionManagerMetrics) RecordInFlightTxQueueMetrics(ctx context.Context, usedCountPerStage map[string]int, freeCount int) {
-	// TODO
+	for stage, count := range usedCountPerStage {
+		ptm.inflightTxsByStage.With(prometheus.Labels{"stage": stage}).Set(float64(count))
+	}
+	ptm.inflightTxsFree.Set(float64(freeCount))
 }
 
 func (ptm *publicTransactionManagerMetrics) RecordCompletedTransactionCountMetrics(ctx context.Context, processStatus string) {
-	// TODO
+	ptm.completedTxsByStatus.With(prometheus.Labels{"status": processStatus}).Inc()
 }
 
 func (ptm *publicTransactionManagerMetrics) RecordInFlightOrchestratorPoolMetrics(ctx context.Context, usedCountPerState map[string]int, freeCount int) {
-	// TODO
+	for state, count := range usedCountPerState {
+		ptm.inflightOrchestratorState.With(prometheus.Labels{"state": state}).Set(float64(count))
+	}
+	ptm.inflightOrchestratorFree.Set(float64(freeCount))
 }

--- a/core/go/internal/publictxmgr/metrics/metrics_test.go
+++ b/core/go/internal/publictxmgr/metrics/metrics_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitMetrics(t *testing.T) {
@@ -38,13 +39,147 @@ func TestInitMetrics(t *testing.T) {
 	metrics.IncDBSubmittedTransactionsByN(5)
 
 	metricFamilies, err := registry.Gather()
-	assert.NoError(t, err, "Unexpected error gathering metrics")
+	require.NoError(t, err)
 
-	// Completed transactions metrics
-	assert.Equal(t, metricFamilies[0].GetName(), "public_transaction_manager_completed_txns_total")
-	assert.Equal(t, metricFamilies[0].GetMetric()[0].GetCounter().GetValue(), float64(9))
+	byName := make(map[string]float64)
+	for _, mf := range metricFamilies {
+		if len(mf.GetMetric()) > 0 && mf.GetMetric()[0].GetCounter() != nil {
+			byName[mf.GetName()] = mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	assert.Equal(t, float64(9), byName["public_transaction_manager_completed_txns_total"])
+	assert.Equal(t, float64(7), byName["public_transaction_manager_db_submitted_txns_total"])
+}
 
-	// Submitted transactions metrics
-	assert.Equal(t, metricFamilies[1].GetName(), "public_transaction_manager_db_submitted_txns_total")
-	assert.Equal(t, metricFamilies[1].GetMetric()[0].GetCounter().GetValue(), float64(7))
+func TestRecordOperationMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := InitMetrics(context.Background(), registry)
+
+	metrics.RecordOperationMetrics(context.Background(), "sign", "success", 0.05)
+	metrics.RecordOperationMetrics(context.Background(), "sign", "fail", 0.01)
+	metrics.RecordOperationMetrics(context.Background(), "send", "success", 0.1)
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() == "public_transaction_manager_operation_duration_seconds" {
+			// three distinct label combinations: sign/success, sign/fail, send/success
+			assert.Len(t, mf.GetMetric(), 3)
+			return
+		}
+	}
+	t.Fatal("operation_duration_seconds metric not found")
+}
+
+func TestRecordStageChangeMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := InitMetrics(context.Background(), registry)
+
+	metrics.RecordStageChangeMetrics(context.Background(), "sign", 0.02)
+	metrics.RecordStageChangeMetrics(context.Background(), "submit", 0.15)
+	metrics.RecordStageChangeMetrics(context.Background(), "sign", 0.03)
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() == "public_transaction_manager_stage_duration_seconds" {
+			// two distinct stage label values: "sign" and "submit"
+			assert.Len(t, mf.GetMetric(), 2)
+			for _, m := range mf.GetMetric() {
+				if m.GetLabel()[0].GetValue() == "sign" {
+					assert.Equal(t, uint64(2), m.GetHistogram().GetSampleCount())
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("stage_duration_seconds metric not found")
+}
+
+func TestRecordInFlightTxQueueMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := InitMetrics(context.Background(), registry)
+
+	stageCounts := map[string]int{
+		"sign":   3,
+		"submit": 5,
+	}
+	metrics.RecordInFlightTxQueueMetrics(context.Background(), stageCounts, 12)
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	foundByStage := false
+	foundFree := false
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "public_transaction_manager_inflight_txns_by_stage":
+			assert.Len(t, mf.GetMetric(), 2)
+			foundByStage = true
+		case "public_transaction_manager_inflight_txns_free":
+			assert.Equal(t, float64(12), mf.GetMetric()[0].GetGauge().GetValue())
+			foundFree = true
+		}
+	}
+	assert.True(t, foundByStage, "inflight_txns_by_stage metric not found")
+	assert.True(t, foundFree, "inflight_txns_free metric not found")
+}
+
+func TestRecordCompletedTransactionCountMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := InitMetrics(context.Background(), registry)
+
+	metrics.RecordCompletedTransactionCountMetrics(context.Background(), "success")
+	metrics.RecordCompletedTransactionCountMetrics(context.Background(), "success")
+	metrics.RecordCompletedTransactionCountMetrics(context.Background(), "fail")
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() == "public_transaction_manager_completed_txns_by_status_total" {
+			assert.Len(t, mf.GetMetric(), 2)
+			for _, m := range mf.GetMetric() {
+				if m.GetLabel()[0].GetValue() == "success" {
+					assert.Equal(t, float64(2), m.GetCounter().GetValue())
+				} else {
+					assert.Equal(t, float64(1), m.GetCounter().GetValue())
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("completed_txns_by_status_total metric not found")
+}
+
+func TestRecordInFlightOrchestratorPoolMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := InitMetrics(context.Background(), registry)
+
+	stateCounts := map[string]int{
+		"running": 4,
+		"waiting": 2,
+		"idle":    1,
+	}
+	metrics.RecordInFlightOrchestratorPoolMetrics(context.Background(), stateCounts, 3)
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	foundByState := false
+	foundFree := false
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "public_transaction_manager_inflight_orchestrators_by_state":
+			assert.Len(t, mf.GetMetric(), 3)
+			foundByState = true
+		case "public_transaction_manager_inflight_orchestrators_free":
+			assert.Equal(t, float64(3), mf.GetMetric()[0].GetGauge().GetValue())
+			foundFree = true
+		}
+	}
+	assert.True(t, foundByState, "inflight_orchestrators_by_state metric not found")
+	assert.True(t, foundFree, "inflight_orchestrators_free metric not found")
 }


### PR DESCRIPTION
Five methods in `publictxmgr/metrics` have been no-ops since the interface was first defined. This implements all of them:

- `RecordOperationMetrics` — `HistogramVec` labelled by `operation` and `result`, tracking duration of sign, gas-estimation, and submission operations in seconds
- `RecordStageChangeMetrics` — `HistogramVec` labelled by `stage`, tracking how long a transaction spends in each in-flight stage before transitioning
- `RecordInFlightTxQueueMetrics` — `GaugeVec` labelled by `stage` for per-stage queue depth, plus a `Gauge` for free slots in the orchestrator's in-flight limit
- `RecordCompletedTransactionCountMetrics` — `CounterVec` labelled by `status` (complements the existing `completed_txns_total` with per-status breakdown)
- `RecordInFlightOrchestratorPoolMetrics` — `GaugeVec` labelled by `state` for per-state orchestrator counts, plus a `Gauge` for free pool slots

Bucket ranges for the histograms cover sub-millisecond through 60s, consistent with the operation latencies observed in signing and submission paths.

Tests added for each method, verifying metric registration, label cardinality, and recorded values.