### PR TITLE
fix: add expiry to assembly and endorsement requests to prevent cascading timeouts

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -16,6 +16,7 @@ package transaction
 
 import (
 	"context"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -126,7 +127,10 @@ func (t *coordinatorTransaction) sendAssembleRequest(ctx context.Context) error 
 			return err
 		}
 
-		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, blockHeight)
+		// Set expiry to now + stateTimeout so the recipient can discard the request if the queue has backed up
+		// beyond the point where the coordinator would still be waiting for the response.
+		expiryMs := time.Now().Add(t.stateTimeout).UnixMilli()
+		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, blockHeight, expiryMs)
 	})
 
 	t.scheduleRequestTimeout(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
@@ -221,7 +221,7 @@ func Test_sendAssembleRequest_Success(t *testing.T) {
 
 	// Mock transport writer - use mock.Anything for idempotency key since it's generated dynamically
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -263,7 +263,7 @@ func Test_sendAssembleRequest_SendAssembleRequestError(t *testing.T) {
 
 	// Mock transport writer to return error - use mock.Anything for idempotency key
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(errors.New("send error"))
 
 	err := txn.sendAssembleRequest(ctx)
@@ -288,7 +288,7 @@ func Test_nudgeAssembleRequest_WithPendingRequest(t *testing.T) {
 	// Create a pending request first
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -297,7 +297,7 @@ func Test_nudgeAssembleRequest_WithPendingRequest(t *testing.T) {
 	// Now nudge it - should succeed since request exists
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err = txn.nudgeAssembleRequest(ctx)
@@ -333,7 +333,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleSuccessEvent_Match(t *
 	// Create a pending request
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -358,7 +358,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleSuccessEvent_NoMatch(t
 	// Create a pending request
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -395,7 +395,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleRevertResponseEvent_Ma
 	// Create a pending request
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -420,7 +420,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleErrorResponseEvent_Mat
 	// Create a pending request
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -446,7 +446,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleErrorResponseEvent_NoM
 	// Create a pending request
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -495,7 +495,7 @@ func Test_action_SendAssembleRequest_Success(t *testing.T) {
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := action_SendAssembleRequest(ctx, txn, nil)
@@ -514,7 +514,7 @@ func Test_action_NudgeAssembleRequest_Success(t *testing.T) {
 	// Create a pending request first
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -523,7 +523,7 @@ func Test_action_NudgeAssembleRequest_Success(t *testing.T) {
 	// Now nudge it
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, txn.pendingAssembleRequest.IdempotencyKey(), txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, txn.pendingAssembleRequest.IdempotencyKey(), txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err = action_NudgeAssembleRequest(ctx, txn, nil)
@@ -600,7 +600,7 @@ func Test_sendAssembleRequest_schedulesTimer(t *testing.T) {
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100), nil)
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100),
+		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything,
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -16,6 +16,7 @@ package transaction
 
 import (
 	"context"
+	"time"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
@@ -149,6 +150,9 @@ func (t *coordinatorTransaction) resetEndorsementRequests(ctx context.Context) {
 }
 
 func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest) error {
+	// Set expiry to now + stateTimeout so the recipient can discard the request if the queue has backed up
+	// beyond the point where the coordinator would still be waiting for the response.
+	expiryMs := time.Now().Add(t.stateTimeout).UnixMilli()
 	err := t.transportWriter.SendEndorsementRequest(
 		ctx,
 		t.pt.ID,
@@ -162,6 +166,7 @@ func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempot
 		toEndorsableList(t.pt.PostAssembly.ReadStates),
 		toEndorsableList(t.pt.PostAssembly.OutputStates),
 		toEndorsableList(t.pt.PostAssembly.InfoStates),
+		expiryMs,
 	)
 	if err != nil {
 		log.L(ctx).Errorf("failed to send endorsement request to party %s: %s", party, err)

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
@@ -58,7 +58,7 @@ func Test_action_NudgeEndorsementRequests_WithUnfulfilledRequirements_Initialize
 		SendEndorsementRequest(
 			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
 			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(nil)
 
 	err := action_NudgeEndorsementRequests(ctx, txn, nil)
@@ -83,7 +83,7 @@ func Test_sendEndorsementRequests_SendEndorsementRequestReturnsError_LogsAndCont
 		SendEndorsementRequest(
 			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
 			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(sendErr)
 
 	err := txn.sendEndorsementRequests(ctx)
@@ -130,13 +130,13 @@ func Test_sendEndorsementRequests_TwoAttestationNames_CreatesMapPerName(t *testi
 		SendEndorsementRequest(
 			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
 			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(nil)
 	mocks.TransportWriter.EXPECT().
 		SendEndorsementRequest(
 			ctx, txn.pt.ID, mock.Anything, "party2", mock.Anything,
 			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(nil)
 
 	err := txn.sendEndorsementRequests(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test_utils.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test_utils.go
@@ -130,6 +130,7 @@ func (r *SentMessageRecorder) SendAssembleRequest(
 	transactionPreassembly *components.TransactionPreAssembly,
 	stateLocks grapher.ExportableStates,
 	blockHeight int64,
+	expiryMs int64,
 ) error {
 	r.hasSentAssembleRequest = true
 	r.sentAssembleRequestIdempotencyKey = idempotencyKey
@@ -151,6 +152,7 @@ func (r *SentMessageRecorder) SendEndorsementRequest(
 	readStates []*prototk.EndorsableState,
 	outputStates []*prototk.EndorsableState,
 	infoStates []*prototk.EndorsableState,
+	expiryMs int64,
 ) error {
 	r.numberOfSentEndorsementRequests++
 	if _, ok := r.numberOfEndorsementRequestsForParty[party]; ok {

--- a/core/go/internal/sequencer/originator/transaction/test_utils.go
+++ b/core/go/internal/sequencer/originator/transaction/test_utils.go
@@ -79,7 +79,7 @@ func (r *SentMessageRecorder) HasSentAssembleErrorResponse() bool {
 	return r.hasSentAssembleErrorResponse
 }
 
-func (r *SentMessageRecorder) SendAssembleRequest(ctx context.Context, assemblingNode string, transactionID uuid.UUID, idempotencyID uuid.UUID, transactionPreassembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64) error {
+func (r *SentMessageRecorder) SendAssembleRequest(ctx context.Context, assemblingNode string, transactionID uuid.UUID, idempotencyID uuid.UUID, transactionPreassembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64, expiryMs int64) error {
 	return nil
 }
 
@@ -91,7 +91,7 @@ func (r *SentMessageRecorder) SendDelegationRequestAcknowledgment(ctx context.Co
 	return nil
 }
 
-func (r *SentMessageRecorder) SendEndorsementRequest(ctx context.Context, transactionId uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState) error {
+func (r *SentMessageRecorder) SendEndorsementRequest(ctx context.Context, transactionId uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState, expiryMs int64) error {
 	return nil
 }
 

--- a/core/go/internal/sequencer/transport/message_types.go
+++ b/core/go/internal/sequencer/transport/message_types.go
@@ -25,6 +25,16 @@ import (
 	"github.com/google/uuid"
 )
 
+// MessageEnvelope wraps a serialised proto payload with optional metadata that cannot
+// be carried inside the proto message itself (e.g. because the proto rawDesc is
+// pre-compiled and cannot be easily extended at runtime).
+// Recipients that do not understand the envelope can fall back to treating the whole
+// byte slice as a raw proto payload (ExpiryMs == 0 ⇒ no expiry check).
+type MessageEnvelope struct {
+	ExpiryMs int64  `json:"expiryMs,omitempty"` // Unix milliseconds; 0 means no expiry
+	Payload  []byte `json:"payload"`            // Serialised proto bytes
+}
+
 const (
 	MessageType_AssembleRequest                  = "AssembleRequest"
 	MessageType_AssembleResponse                 = "AssembleResponse"

--- a/core/go/internal/sequencer/transport/transport_writer.go
+++ b/core/go/internal/sequencer/transport/transport_writer.go
@@ -39,9 +39,9 @@ type TransportWriter interface {
 	WaitForDone(ctx context.Context)
 	SendDelegationRequest(ctx context.Context, coordinatorNode string, transactions []*components.PrivateTransaction, blockHeight uint64) error
 	SendDelegationRequestAcknowledgment(ctx context.Context, delegatingNodeName string, delegationId string, transactionIDs []string, errors []int64) error
-	SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState) error
+	SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState, expiryMs int64) error
 	SendEndorsementResponse(ctx context.Context, transactionId, idempotencyKey, contractAddress string, attResult *prototk.AttestationResult, endorsementResult *components.EndorsementResult, revertReason, endorsementName, party, node string) error
-	SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64) error
+	SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64, expiryMs int64) error
 	SendAssembleResponse(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, postAssembly *components.TransactionPostAssembly, preAssembly *components.TransactionPreAssembly, recipient string) error
 	SendAssembleErrorResponse(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string) error
 	SendHandoverRequest(ctx context.Context, activeCoordinator string, contractAddress *pldtypes.EthAddress) error
@@ -156,7 +156,7 @@ func (tw *transportWriter) SendDelegationRequestAcknowledgment(
 }
 
 // TODO do we have duplication here?  contractAddress and transactionID are in the transactionSpecification
-func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState) error {
+func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState, expiryMs int64) error {
 	attRequestAny, err := anypb.New(attRequest)
 	if err != nil {
 		log.L(ctx).Error("error marshalling attestation request", err)
@@ -246,11 +246,19 @@ func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, txID uuid
 		ReadStates:               readStatesAny,
 		OutputStates:             outputStatesAny,
 		InfoStates:               infoStatesAny,
+		ExpiryMs:                 expiryMs,
 	}
 
 	endorsementRequestBytes, err := proto.Marshal(endorsementRequest)
 	if err != nil {
 		log.L(ctx).Error("error marshalling endorsement request", err)
+		return err
+	}
+
+	// Wrap in a MessageEnvelope so the expiry survives the proto serialisation boundary.
+	envelopeBytes, err := json.Marshal(&MessageEnvelope{ExpiryMs: expiryMs, Payload: endorsementRequestBytes})
+	if err != nil {
+		log.L(ctx).Error("error marshalling endorsement request envelope", err)
 		return err
 	}
 
@@ -263,7 +271,7 @@ func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, txID uuid
 		MessageType: MessageType_EndorsementRequest,
 		Node:        partyNode,
 		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     endorsementRequestBytes,
+		Payload:     envelopeBytes,
 	})
 	return err
 }
@@ -305,7 +313,7 @@ func (tw *transportWriter) SendEndorsementResponse(ctx context.Context, transact
 	return err
 }
 
-func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64) error {
+func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64, expiryMs int64) error {
 
 	log.L(ctx).Tracef("transport writer attempting to send assemble request to assembling node %s", assemblingNode)
 
@@ -328,6 +336,7 @@ func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNo
 		PreAssembly:       preAssemblyBytes,
 		StateLocks:        stateLocksJSON,
 		BlockHeight:       blockHeight,
+		ExpiryMs:          expiryMs,
 	}
 
 	assembleRequestBytes, err := proto.Marshal(assembleRequest)
@@ -336,11 +345,18 @@ func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNo
 		return err
 	}
 
+	// Wrap in a MessageEnvelope so the expiry survives the proto serialisation boundary.
+	envelopeBytes, err := json.Marshal(&MessageEnvelope{ExpiryMs: expiryMs, Payload: assembleRequestBytes})
+	if err != nil {
+		log.L(ctx).Error("error marshalling assemble request envelope", err)
+		return err
+	}
+
 	payload := &components.FireAndForgetMessageSend{
 		MessageType: MessageType_AssembleRequest,
 		Node:        assemblingNode,
 		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     assembleRequestBytes,
+		Payload:     envelopeBytes,
 	}
 
 	err = tw.send(ctx, payload)

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -478,8 +478,13 @@ func TestSendEndorsementRequest_Success(t *testing.T) {
 		if msg.Component.String() != "TRANSACTION_ENGINE" {
 			return false
 		}
+		// Unwrap the MessageEnvelope then unmarshal the inner proto
+		var envelope MessageEnvelope
+		if err := json.Unmarshal(msg.Payload, &envelope); err != nil || envelope.Payload == nil {
+			return false
+		}
 		var endorsementRequest engineProto.EndorsementRequest
-		err := proto.Unmarshal(msg.Payload, &endorsementRequest)
+		err := proto.Unmarshal(envelope.Payload, &endorsementRequest)
 		if err != nil {
 			return false
 		}
@@ -506,7 +511,7 @@ func TestSendEndorsementRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, verifiers, signatures, inputStates, readStates, outputStates, infoStates)
+	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, verifiers, signatures, inputStates, readStates, outputStates, infoStates, 0)
 	require.NoError(t, err)
 	mockTransportManager.AssertExpectations(t)
 }
@@ -540,7 +545,7 @@ func TestSendEndorsementRequest_NodeLookupError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, nil, nil, nil, nil, nil, nil)
+	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, nil, nil, nil, nil, nil, nil, 0)
 	require.Error(t, err)
 	mockTransportManager.AssertNotCalled(t, "Send")
 }
@@ -726,8 +731,13 @@ func TestSendAssembleRequest_Success(t *testing.T) {
 		if msg.Component.String() != "TRANSACTION_ENGINE" {
 			return false
 		}
+		// Unwrap the MessageEnvelope then unmarshal the inner proto
+		var envelope MessageEnvelope
+		if err := json.Unmarshal(msg.Payload, &envelope); err != nil || envelope.Payload == nil {
+			return false
+		}
 		var assembleRequest engineProto.AssembleRequest
-		err := proto.Unmarshal(msg.Payload, &assembleRequest)
+		err := proto.Unmarshal(envelope.Payload, &assembleRequest)
 		if err != nil {
 			return false
 		}
@@ -754,7 +764,7 @@ func TestSendAssembleRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight)
+	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight, 0)
 	require.NoError(t, err)
 	mockTransportManager.AssertExpectations(t)
 }
@@ -789,7 +799,7 @@ func TestSendAssembleRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight)
+	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight, 0)
 	require.Error(t, err)
 	assert.Equal(t, sendError, err)
 	mockTransportManager.AssertExpectations(t)

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -104,8 +104,27 @@ func (sMgr *sequencerManager) parseContractAddressString(ctx context.Context, co
 
 func (sMgr *sequencerManager) handleAssembleRequest(ctx context.Context, message *components.ReceivedMessage) {
 
+	// Unwrap the MessageEnvelope (added for expiry support) if present; fall back to
+	// treating the raw bytes as a proto payload for backwards-compatibility.
+	var expiryMs int64
+	protoPayload := message.Payload
+	var envelope transport.MessageEnvelope
+	if err := json.Unmarshal(message.Payload, &envelope); err == nil && envelope.Payload != nil {
+		expiryMs = envelope.ExpiryMs
+		protoPayload = envelope.Payload
+	}
+
+	// Drop the request if it has already expired — the coordinator is no longer waiting for the response.
+	if expiryMs > 0 && time.Now().UnixMilli() > expiryMs {
+		log.L(ctx).Warnf("dropping expired assemble request (expired at %s, now %s)",
+			time.UnixMilli(expiryMs).UTC().Format(time.RFC3339Nano),
+			time.Now().UTC().Format(time.RFC3339Nano),
+		)
+		return
+	}
+
 	assembleRequest := &engineProto.AssembleRequest{}
-	err := proto.Unmarshal(message.Payload, assembleRequest)
+	err := proto.Unmarshal(protoPayload, assembleRequest)
 	if err != nil {
 		sMgr.logPaladinMessageUnmarshalError(ctx, message, err)
 		return
@@ -461,9 +480,28 @@ func (sMgr *sequencerManager) handleDelegationRequestAcknowledgment(ctx context.
 }
 
 func (sMgr *sequencerManager) handleEndorsementRequest(ctx context.Context, message *components.ReceivedMessage) {
+	// Unwrap the MessageEnvelope (added for expiry support) if present; fall back to
+	// treating the raw bytes as a proto payload for backwards-compatibility.
+	var expiryMs int64
+	protoPayload := message.Payload
+	var envelope transport.MessageEnvelope
+	if err := json.Unmarshal(message.Payload, &envelope); err == nil && envelope.Payload != nil {
+		expiryMs = envelope.ExpiryMs
+		protoPayload = envelope.Payload
+	}
+
+	// Drop the request if it has already expired — the coordinator is no longer waiting for the response.
+	if expiryMs > 0 && time.Now().UnixMilli() > expiryMs {
+		log.L(ctx).Warnf("dropping expired endorsement request (expired at %s, now %s)",
+			time.UnixMilli(expiryMs).UTC().Format(time.RFC3339Nano),
+			time.Now().UTC().Format(time.RFC3339Nano),
+		)
+		return
+	}
+
 	endorsementRequest := &engineProto.EndorsementRequest{}
 
-	err := proto.Unmarshal(message.Payload, endorsementRequest)
+	err := proto.Unmarshal(protoPayload, endorsementRequest)
 	if err != nil {
 		sMgr.logPaladinMessageUnmarshalError(ctx, message, err)
 		return

--- a/core/go/internal/sequencer/transport_client_test.go
+++ b/core/go/internal/sequencer/transport_client_test.go
@@ -2434,3 +2434,77 @@ func TestHandleEndorsementResponse_EndorsementUnmarshalError(t *testing.T) {
 
 	mocks.coordinator.AssertExpectations(t)
 }
+
+func TestHandleAssembleRequest_Expired(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
+
+	txID := uuid.New()
+	requestID := uuid.New()
+	preAssembly := &components.TransactionPreAssembly{}
+	preAssemblyJSON, _ := json.Marshal(preAssembly)
+
+	// Build the inner proto message
+	assembleRequest := &engineProto.AssembleRequest{
+		TransactionId:     txID.String(),
+		AssembleRequestId: requestID.String(),
+		ContractAddress:   contractAddr.String(),
+		PreAssembly:       preAssemblyJSON,
+		StateLocks:        []byte("{}"),
+		BlockHeight:       100,
+	}
+	protoBytes, _ := proto.Marshal(assembleRequest)
+
+	// Wrap in a MessageEnvelope with an expiry 1 second in the past
+	expiredMs := time.Now().Add(-1 * time.Second).UnixMilli()
+	envelopeBytes, _ := json.Marshal(&transport.MessageEnvelope{ExpiryMs: expiredMs, Payload: protoBytes})
+
+	message := &components.ReceivedMessage{
+		FromNode:    "test-node",
+		MessageID:   uuid.New(),
+		MessageType: transport.MessageType_AssembleRequest,
+		Payload:     envelopeBytes,
+	}
+
+	// No originator mock expectations — the request should be silently dropped before LoadSequencer
+	sm.handleAssembleRequest(ctx, message)
+
+	// Assertions: no calls were made to the originator (mocks would fail if unexpected calls occurred)
+	mocks.originator.AssertExpectations(t)
+}
+
+func TestHandleEndorsementRequest_Expired(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
+
+	txID := uuid.New().String()
+
+	// Build the inner proto message
+	endorsementRequest := &engineProto.EndorsementRequest{
+		TransactionId:   txID,
+		ContractAddress: contractAddr.String(),
+	}
+	protoBytes, _ := proto.Marshal(endorsementRequest)
+
+	// Wrap in a MessageEnvelope with an expiry 1 second in the past
+	expiredMs := time.Now().Add(-1 * time.Second).UnixMilli()
+	envelopeBytes, _ := json.Marshal(&transport.MessageEnvelope{ExpiryMs: expiredMs, Payload: protoBytes})
+
+	message := &components.ReceivedMessage{
+		FromNode:    "test-node",
+		MessageID:   uuid.New(),
+		MessageType: transport.MessageType_EndorsementRequest,
+		Payload:     envelopeBytes,
+	}
+
+	// No mock expectations needed — the expiry check fires before DomainManager/GetSmartContractByAddress
+	sm.handleEndorsementRequest(ctx, message)
+
+	// Coordinator and domain manager should not have been touched
+	mocks.coordinator.AssertExpectations(t)
+	mocks.domainManager.AssertExpectations(t)
+}

--- a/core/go/pkg/proto/engine.proto
+++ b/core/go/pkg/proto/engine.proto
@@ -72,6 +72,7 @@ message EndorsementRequest {
     repeated google.protobuf.Any readStates = 10;
     repeated google.protobuf.Any outputStates = 11;
     repeated google.protobuf.Any infoStates = 12;
+    int64 expiry_ms = 13; // Unix timestamp in milliseconds after which the requester will no longer accept the response
 }
 
 message EndorsementResponse {
@@ -110,8 +111,8 @@ message DelegationRequest {
     string delegation_id = 3; //this is used to correlate the acknowledgement back to the delegation. unlike the transport message id / correlation id, this is not unique across retries
     bytes private_transaction = 4; //json serialized copy of the in-memory private transaction object
     int64 block_height = 5; // the block height upon which this delegation was calculated (the highest delegation wins when crossing in the post)
-    
-    
+
+
     // TODO we are using google.protobuf.Any here for TransactionSpecification which is defined in toolkit protos
     // need to figure out the build magic to import these from toolkit protos
     //google.protobuf.Any transaction_specification = 4; // serialized io.kaleido.paladin.toolkit.TransactionSpecification
@@ -162,6 +163,7 @@ message AssembleRequest {
     bytes pre_assembly = 5;
     bytes state_locks = 6;
     int64 block_height = 7;
+    int64 expiry_ms = 8; // Unix timestamp in milliseconds after which the requester will no longer accept the response
 }
 
 message AssembleResponse {


### PR DESCRIPTION

When a sequencer builds up a backlog, stale assembly/endorsement requests can be processed long after the coordinator has stopped waiting, causing cascading stage timeouts and all transactions for a contract to stall.

Fix: the coordinator now stamps each AssembleRequest and EndorsementRequest with an expiry time of  before sending. The recipient unwraps a lightweight MessageEnvelope (JSON wrapper carrying  + the original proto bytes) and silently drops any request whose expiry has already passed, ensuring only the most recent, still-relevant requests are acted upon.

The envelope falls back gracefully to raw-proto for messages from older nodes that do not include it, preserving backwards compatibility.

Closes #1119