### PR TITLE
Fix base-ledger revert retry counting across transaction resume

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/confirming.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming.go
@@ -44,6 +44,9 @@ func action_RecordConfirmation(ctx context.Context, t *coordinatorTransaction, e
 		hash = e.Hash
 	case *ConfirmedRevertedEvent:
 		t.revertCount++
+		if e.ObservedRevertCount > t.revertCount {
+			t.revertCount = e.ObservedRevertCount
+		}
 		hash = e.Hash
 		t.revertReason = e.RevertReason
 		if len(e.RevertReason) == 0 {

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
@@ -146,6 +146,27 @@ func Test_action_RecordConfirmation_RevertIncrementsRevertCount(t *testing.T) {
 	assert.Equal(t, 3, txn.revertCount)
 }
 
+func Test_action_RecordConfirmation_UsesObservedRevertCount(t *testing.T) {
+	ctx := t.Context()
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Confirmed).
+		BaseLedgerRevertRetryThreshold(3).
+		Build()
+	revertReason := pldtypes.MustParseHexBytes("0xabcd")
+	mocks.DomainAPI.EXPECT().IsBaseLedgerRevertRetryable(mock.Anything, []byte(revertReason)).Return(true, "", nil)
+	event := &ConfirmedRevertedEvent{
+		BaseCoordinatorEvent: BaseCoordinatorEvent{
+			TransactionID: txn.pt.ID,
+		},
+		RevertReason:        revertReason,
+		ObservedRevertCount: 4,
+	}
+
+	err := action_RecordConfirmation(ctx, txn, event)
+	require.NoError(t, err)
+	assert.Equal(t, 4, txn.revertCount)
+	assert.False(t, txn.lastCanRetryRevert)
+}
+
 func Test_action_RecordConfirmation_SuccessNilHash(t *testing.T) {
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).

--- a/core/go/internal/sequencer/coordinator/transaction/events.go
+++ b/core/go/internal/sequencer/coordinator/transaction/events.go
@@ -242,11 +242,12 @@ func (*ConfirmedSuccessEvent) TypeString() string {
 
 type ConfirmedRevertedEvent struct {
 	BaseCoordinatorEvent
-	Nonce          *pldtypes.HexUint64
-	Hash           pldtypes.Bytes32
-	FailureMessage string
-	RevertReason   pldtypes.HexBytes
-	OnChain        pldtypes.OnChainLocation
+	Nonce               *pldtypes.HexUint64
+	Hash                pldtypes.Bytes32
+	FailureMessage      string
+	RevertReason        pldtypes.HexBytes
+	OnChain             pldtypes.OnChainLocation
+	ObservedRevertCount int
 }
 
 func (*ConfirmedRevertedEvent) Type() EventType {

--- a/core/go/internal/sequencer/coordinator/transaction/events_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/events_test.go
@@ -609,9 +609,10 @@ func TestConfirmedRevertedEvent_Fields(t *testing.T) {
 			},
 			TransactionID: txID,
 		},
-		Nonce:        &nonce,
-		Hash:         hash,
-		RevertReason: revertReason,
+		Nonce:               &nonce,
+		Hash:                hash,
+		RevertReason:        revertReason,
+		ObservedRevertCount: 2,
 	}
 
 	assert.Equal(t, txID, event.GetTransactionID())
@@ -619,6 +620,7 @@ func TestConfirmedRevertedEvent_Fields(t *testing.T) {
 	assert.Equal(t, uint64(42), event.Nonce.Uint64())
 	assert.Equal(t, hash, event.Hash)
 	assert.Equal(t, revertReason, event.RevertReason)
+	assert.Equal(t, 2, event.ObservedRevertCount)
 }
 
 func TestDependencySelectedForAssemblyEvent_Type(t *testing.T) {

--- a/core/go/internal/sequencer/sequencer.go
+++ b/core/go/internal/sequencer/sequencer.go
@@ -703,7 +703,7 @@ func (sMgr *sequencerManager) handleTransactionConfirmedSuccess(ctx context.Cont
 	return nil
 }
 
-func (sMgr *sequencerManager) queueConfirmedRevertedEventToCoordinator(ctx context.Context, contractAddress pldtypes.EthAddress, txID uuid.UUID, revertData pldtypes.HexBytes, onChain pldtypes.OnChainLocation, nonce *pldtypes.HexUint64) error {
+func (sMgr *sequencerManager) queueConfirmedRevertedEventToCoordinator(ctx context.Context, contractAddress pldtypes.EthAddress, txID uuid.UUID, revertData pldtypes.HexBytes, onChain pldtypes.OnChainLocation, nonce *pldtypes.HexUint64, observedRevertCount int) error {
 	sequencer, err := sMgr.GetSequencer(ctx, contractAddress)
 	if err != nil {
 		return err
@@ -723,10 +723,11 @@ func (sMgr *sequencerManager) queueConfirmedRevertedEventToCoordinator(ctx conte
 			},
 			TransactionID: txID,
 		},
-		Hash:         onChain.TransactionHash,
-		RevertReason: revertData,
-		OnChain:      onChain,
-		Nonce:        nonce,
+		Hash:                onChain.TransactionHash,
+		RevertReason:        revertData,
+		OnChain:             onChain,
+		Nonce:               nonce,
+		ObservedRevertCount: observedRevertCount,
 	})
 	return nil
 }
@@ -786,7 +787,6 @@ func (sMgr *sequencerManager) HandleChainedTransactionOutcome(ctx context.Contex
 func (sMgr *sequencerManager) HandleDirectTransactionRevert(ctx context.Context, dbTX persistence.DBTX, failures []*components.PublicTxMatch) error {
 	log.L(sMgr.ctx).Tracef("HandleDirectTransactionRevert %d", len(failures))
 	sMgr.metrics.IncRevertedTransactions()
-	_ = dbTX
 
 	for _, tx := range failures {
 		contractAddress := tx.To
@@ -802,12 +802,30 @@ func (sMgr *sequencerManager) HandleDirectTransactionRevert(ctx context.Context,
 			BlockNumber:      tx.BlockNumber,
 			TransactionIndex: tx.TransactionIndex,
 		}
-		err := sMgr.queueConfirmedRevertedEventToCoordinator(ctx, *contractAddress, tx.TransactionID, tx.RevertReason, onChain, &nonceVal)
+		observedRevertCount, err := sMgr.countPersistedBaseLedgerReverts(ctx, dbTX, tx.TransactionID)
+		if err != nil {
+			return err
+		}
+		err = sMgr.queueConfirmedRevertedEventToCoordinator(ctx, *contractAddress, tx.TransactionID, tx.RevertReason, onChain, &nonceVal, observedRevertCount)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (sMgr *sequencerManager) countPersistedBaseLedgerReverts(ctx context.Context, dbTX persistence.DBTX, txID uuid.UUID) (int, error) {
+	var count int64
+	err := dbTX.DB().
+		WithContext(ctx).
+		Table("public_completions").
+		Joins(`JOIN "public_txn_bindings" ON "public_txn_bindings"."pub_txn_id" = "public_completions"."pub_txn_id"`).
+		Where(`"public_txn_bindings"."transaction" = ?`, txID).
+		Where(`"public_txn_bindings"."tx_type" = ?`, pldapi.TransactionTypePrivate).
+		Where(`"public_completions"."success" = ?`, false).
+		Count(&count).
+		Error
+	return int(count), err
 }
 
 func (sMgr *sequencerManager) BuildNullifiers(ctx context.Context, stateDistributions []*components.StateDistributionWithData) (nullifiers []*components.NullifierUpsert, err error) {


### PR DESCRIPTION
## Summary

Fixes #1175.

This updates direct private transaction base-ledger revert handling so the coordinator uses the persisted count of failed public transaction completions when deciding whether a revert is still retryable.

Previously, the retry count lived only in coordinator memory. If a private transaction was resumed from persistent state, prior base-ledger failures could be forgotten and the transaction could keep being resubmitted on the resume/re-poll interval.

## Changes

- Count persisted failed base-ledger completions for the private transaction.
- Include that observed count on `ConfirmedRevertedEvent`.
- Use the observed count when applying the existing `baseLedgerRevertRetryThreshold`.
- Add unit coverage for restored retry count behavior.

## Testing

- `gofmt`
- `git diff --check`