### PR TITLE
Ensure assemble reverts include the sequencer error code

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -55,7 +55,7 @@ func (t *coordinatorTransaction) applyPostAssembly(ctx context.Context, postAsse
 	t.clearTimeoutSchedules()
 
 	if t.pt.PostAssembly.AssemblyResult == prototk.AssembleTransactionResponse_REVERT {
-		t.revertTransactionFailedAssembly(ctx, *postAssembly.RevertReason)
+		t.revertTransactionFailedAssembly(ctx, i18n.ExpandWithCode(ctx, i18n.MessageKey(msgs.MsgSequencerAssembleRevert), *postAssembly.RevertReason))
 		return nil
 	}
 	if t.pt.PostAssembly.AssemblyResult == prototk.AssembleTransactionResponse_PARK {

--- a/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
@@ -18,6 +18,7 @@ package transaction
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,10 +63,13 @@ func Test_applyPostAssembly_RevertResult(t *testing.T) {
 	}
 	requestID := uuid.New()
 
+	var capturedFailureMessage string
 	mocks.SyncPoints.On("QueueTransactionFinalize",
 		ctx,
 		mock.MatchedBy(func(req *syncpoints.TransactionFinalizeRequest) bool {
-			return req.FailureMessage == revertReason
+			capturedFailureMessage = req.FailureMessage
+			return strings.Contains(req.FailureMessage, "PD012616") &&
+				strings.Contains(req.FailureMessage, revertReason)
 		}),
 		mock.Anything, // onCommit callback
 		mock.Anything, // onRollback callback
@@ -74,6 +78,8 @@ func Test_applyPostAssembly_RevertResult(t *testing.T) {
 	err := txn.applyPostAssembly(ctx, postAssembly, requestID)
 	require.NoError(t, err)
 	assert.Equal(t, postAssembly, txn.pt.PostAssembly)
+	assert.Contains(t, capturedFailureMessage, "PD012616")
+	assert.Contains(t, capturedFailureMessage, revertReason)
 }
 
 func Test_action_AssembleRevertResponse_SetsPostAssemblyAndFinalizes(t *testing.T) {
@@ -85,10 +91,13 @@ func Test_action_AssembleRevertResponse_SetsPostAssemblyAndFinalizes(t *testing.
 		RevertReason:   &revertReason,
 	}
 
+	var capturedFailureMessage string
 	mocks.SyncPoints.On("QueueTransactionFinalize",
 		ctx,
 		mock.MatchedBy(func(req *syncpoints.TransactionFinalizeRequest) bool {
-			return req.FailureMessage == revertReason
+			capturedFailureMessage = req.FailureMessage
+			return strings.Contains(req.FailureMessage, "PD012616") &&
+				strings.Contains(req.FailureMessage, revertReason)
 		}),
 		mock.Anything, // onCommit callback
 		mock.Anything, // onRollback callback
@@ -103,6 +112,8 @@ func Test_action_AssembleRevertResponse_SetsPostAssemblyAndFinalizes(t *testing.
 	err := action_AssembleRevertResponse(ctx, txn, event)
 	require.NoError(t, err)
 	assert.Equal(t, postAssembly, txn.pt.PostAssembly)
+	assert.Contains(t, capturedFailureMessage, "PD012616")
+	assert.Contains(t, capturedFailureMessage, revertReason)
 }
 
 func Test_applyPostAssembly_ParkResult(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/LFDT-Paladin/paladin/issues/1065

This was a regression of the pre-V1 behaviour. The older error code has been replaced in V1  (was `PD011814`, now `PD012616`) but more importantly the V1 code didn't even include the error code.

The PR reinstates https://github.com/LFDT-Paladin/paladin/blob/ec4409b0fedf536c746a093aee5fe1b2058801de/core/go/internal/privatetxnmgr/transaction_flow_mutators.go#L101 albeit with the new code.