### PR TITLE
Update the integration test GHA with fixed paths & matrix execution

### DIFF
--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -36,24 +36,29 @@ jobs:
       - name: Set matrix
         id: set-matrix
         run: |
-          ALL='{"include":[{"name":"public-contract","config_file":"example-public-contract.yaml"},{"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"},{"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"},{"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}]}'
           case "${{ inputs.test_name }}" in
             all)
-              echo "matrix=$ALL" >> $GITHUB_OUTPUT
+              matrix=$(jq -cn '{include:[
+                {name:"public-contract",               config_file:"example-public-contract.yaml"},
+                {name:"private-transaction-node-restart", config_file:"example-private-transaction-node-restart.yaml"},
+                {name:"privacy-group-contract-deploy", config_file:"example-privacy-group-contract-deploy.yaml"},
+                {name:"noto-revertable-hooks",         config_file:"example-noto-revertable-hooks.yaml"}
+              ]}')
               ;;
             public-contract)
-              echo 'matrix={"include":[{"name":"public-contract","config_file":"example-public-contract.yaml"}]}' >> $GITHUB_OUTPUT
+              matrix=$(jq -cn '{include:[{name:"public-contract",config_file:"example-public-contract.yaml"}]}')
               ;;
             private-transaction-node-restart)
-              echo 'matrix={"include":[{"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"}]}' >> $GITHUB_OUTPUT
+              matrix=$(jq -cn '{include:[{name:"private-transaction-node-restart",config_file:"example-private-transaction-node-restart.yaml"}]}')
               ;;
             privacy-group-contract-deploy)
-              echo 'matrix={"include":[{"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"}]}' >> $GITHUB_OUTPUT
+              matrix=$(jq -cn '{include:[{name:"privacy-group-contract-deploy",config_file:"example-privacy-group-contract-deploy.yaml"}]}')
               ;;
             noto-revertable-hooks)
-              echo 'matrix={"include":[{"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}]}' >> $GITHUB_OUTPUT
+              matrix=$(jq -cn '{include:[{name:"noto-revertable-hooks",config_file:"example-noto-revertable-hooks.yaml"}]}')
               ;;
           esac
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   run-pldtest:
     needs: setup
@@ -82,7 +87,7 @@ jobs:
         if: inputs.length != ''
         run: |
           sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" \
-            paladin/test/config/${{ matrix.test.config_file }}
+            paladin/test/config/${{ matrix.config_file }}
 
       - name: Copy solidity artifacts
         working-directory: paladin
@@ -107,7 +112,7 @@ jobs:
       - name: Run test
         run: |
           ./paladin/test/pldtest/pldtest run \
-            -c paladin/test/config/${{ matrix.test.config_file }} \
+            -c paladin/test/config/${{ matrix.config_file }} \
             -i 0
 
       - name: Cleanup cluster

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -86,6 +86,10 @@ jobs:
           ./gradlew --no-daemon :operator:installOperatorDefault \
             -x :operator:helmUnitTest
 
+      - name: Copy solidity artifacts
+        working-directory: paladin
+        run: ./gradlew --no-daemon :domains:noto:copyInternalSolidity :test:copySolidity
+
       - name: Run test
         run: |
           ./paladin/test/pldtest/pldtest run \

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -70,6 +70,10 @@ jobs:
           sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" \
             paladin/test/config/${{ steps.test-config.outputs.config_file }}
 
+      - name: Copy solidity artifacts
+        working-directory: paladin
+        run: ./gradlew --no-daemon :domains:noto:copyInternalSolidity :test:copySolidity
+
       - name: Build test application
         working-directory: paladin/test
         run: make
@@ -85,10 +89,6 @@ jobs:
         run: |
           ./gradlew --no-daemon :operator:installOperatorDefault \
             -x :operator:helmUnitTest
-
-      - name: Copy solidity artifacts
-        working-directory: paladin
-        run: ./gradlew --no-daemon :domains:noto:copyInternalSolidity :test:copySolidity
 
       - name: Run test
         run: |

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -60,7 +60,7 @@ jobs:
           esac
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-  run-pldtest:
+  run-pld-integration-test:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -109,7 +109,23 @@ jobs:
           ./gradlew --no-daemon :operator:installOperatorDefault \
             -x :operator:helmUnitTest
 
+      # Limit the step to 2 x the chosen test length to prevent a hang resulting in hitting 6h GHA limit
+      - name: Compute test timeout
+        id: test-timeout
+        run: |
+          length="${{ inputs.length }}"
+          if [ -z "$length" ]; then
+            echo "minutes=30" >> $GITHUB_OUTPUT
+          else
+            total_seconds=0
+            [[ "$length" =~ ([0-9]+)h ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]} * 3600))
+            [[ "$length" =~ ([0-9]+)m ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]} * 60))
+            [[ "$length" =~ ([0-9]+)s ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]}))
+            echo "minutes=$(( (total_seconds * 2 + 59) / 60 ))" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run test
+        timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.minutes) }}
         run: |
           ./paladin/test/pldtest/pldtest run \
             -c paladin/test/config/${{ matrix.config_file }} \

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       test_name:
-        description: "Test to run"
+        description: "Test to run (leave as 'all' to run all tests in parallel)"
         required: true
         type: choice
         options:
@@ -28,8 +28,44 @@ on:
         default: ""
 
 jobs:
-  run-pldtest:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          ALL='{"include":[
+            {"name":"public-contract","config_file":"example-public-contract.yaml"},
+            {"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"},
+            {"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"},
+            {"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}
+          ]}'
+          case "${{ inputs.test_name }}" in
+            all)
+              echo "matrix=$ALL" >> $GITHUB_OUTPUT
+              ;;
+            public-contract)
+              echo 'matrix={"include":[{"name":"public-contract","config_file":"example-public-contract.yaml"}]}' >> $GITHUB_OUTPUT
+              ;;
+            private-transaction-node-restart)
+              echo 'matrix={"include":[{"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"}]}' >> $GITHUB_OUTPUT
+              ;;
+            privacy-group-contract-deploy)
+              echo 'matrix={"include":[{"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"}]}' >> $GITHUB_OUTPUT
+              ;;
+            noto-revertable-hooks)
+              echo 'matrix={"include":[{"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}]}' >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+  run-pldtest:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout Paladin branch
         uses: actions/checkout@v4
@@ -47,30 +83,11 @@ jobs:
       - name: Setup kustomize
         uses: imranismail/setup-kustomize@v2
 
-      - name: Resolve test configuration
-        id: test-config
-        run: |
-          case "${{ inputs.test_name }}" in
-            public-contract)
-              echo "config_file=example-public-contract.yaml" >> $GITHUB_OUTPUT
-              ;;
-            private-transaction-node-restart)
-              echo "config_file=example-private-transaction-node-restart.yaml" >> $GITHUB_OUTPUT
-              ;;
-            privacy-group-contract-deploy)
-              echo "config_file=example-privacy-group-contract-deploy.yaml" >> $GITHUB_OUTPUT
-              ;;
-            noto-revertable-hooks)
-              echo "config_file=example-noto-revertable-hooks.yaml" >> $GITHUB_OUTPUT
-              ;;
-          esac
-
       - name: Override test length
         if: inputs.length != ''
         run: |
-          for config in paladin/test/config/example-*.yaml; do
-            sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" "$config"
-          done
+          sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" \
+            paladin/test/config/${{ matrix.test.config_file }}
 
       - name: Copy solidity artifacts
         working-directory: paladin
@@ -94,21 +111,9 @@ jobs:
 
       - name: Run test
         run: |
-          if [ "${{ inputs.test_name }}" = "all" ]; then
-            for config in \
-              example-public-contract.yaml \
-              example-private-transaction-node-restart.yaml \
-              example-privacy-group-contract-deploy.yaml \
-              example-noto-revertable-hooks.yaml; do
-              ./paladin/test/pldtest/pldtest run \
-                -c paladin/test/config/$config \
-                -i 0
-            done
-          else
-            ./paladin/test/pldtest/pldtest run \
-              -c paladin/test/config/${{ steps.test-config.outputs.config_file }} \
-              -i 0
-          fi
+          ./paladin/test/pldtest/pldtest run \
+            -c paladin/test/config/${{ matrix.test.config_file }} \
+            -i 0
 
       - name: Cleanup cluster
         if: always()

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -118,9 +118,9 @@ jobs:
             echo "minutes=30" >> $GITHUB_OUTPUT
           else
             total_seconds=0
-            [[ "$length" =~ ([0-9]+)h ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]} * 3600))
-            [[ "$length" =~ ([0-9]+)m ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]} * 60))
-            [[ "$length" =~ ([0-9]+)s ]] && total_seconds=$((total_seconds + ${BASH_REMATCH[1]}))
+            [[ "$length" =~ ([0-9]+)h ]] && total_seconds=$((total_seconds + BASH_REMATCH[1] * 3600))
+            [[ "$length" =~ ([0-9]+)m ]] && total_seconds=$((total_seconds + BASH_REMATCH[1] * 60))
+            [[ "$length" =~ ([0-9]+)s ]] && total_seconds=$((total_seconds + BASH_REMATCH[1]))
             echo "minutes=$(( (total_seconds * 2 + 59) / 60 ))" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -68,10 +68,10 @@ jobs:
         if: inputs.length != ''
         run: |
           sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" \
-            test/config/${{ steps.test-config.outputs.config_file }}
+            paladin/test/config/${{ steps.test-config.outputs.config_file }}
 
       - name: Build test application
-        working-directory: test
+        working-directory: paladin/test
         run: make
 
       - name: Install Kind
@@ -88,8 +88,8 @@ jobs:
 
       - name: Run test
         run: |
-          ./test/pldtest/pldtest run \
-            -c test/config/${{ steps.test-config.outputs.config_file }} \
+          ./paladin/test/pldtest/pldtest run \
+            -c paladin/test/config/${{ steps.test-config.outputs.config_file }} \
             -i 0
 
       - name: Cleanup cluster

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -11,6 +11,7 @@ on:
         required: true
         type: choice
         options:
+          - all
           - public-contract
           - private-transaction-node-restart
           - privacy-group-contract-deploy
@@ -67,8 +68,9 @@ jobs:
       - name: Override test length
         if: inputs.length != ''
         run: |
-          sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" \
-            paladin/test/config/${{ steps.test-config.outputs.config_file }}
+          for config in paladin/test/config/example-*.yaml; do
+            sed -i "s/^\(\s*\)length:.*$/\1length: ${{ inputs.length }}/" "$config"
+          done
 
       - name: Copy solidity artifacts
         working-directory: paladin
@@ -92,9 +94,21 @@ jobs:
 
       - name: Run test
         run: |
-          ./paladin/test/pldtest/pldtest run \
-            -c paladin/test/config/${{ steps.test-config.outputs.config_file }} \
-            -i 0
+          if [ "${{ inputs.test_name }}" = "all" ]; then
+            for config in \
+              example-public-contract.yaml \
+              example-private-transaction-node-restart.yaml \
+              example-privacy-group-contract-deploy.yaml \
+              example-noto-revertable-hooks.yaml; do
+              ./paladin/test/pldtest/pldtest run \
+                -c paladin/test/config/$config \
+                -i 0
+            done
+          else
+            ./paladin/test/pldtest/pldtest run \
+              -c paladin/test/config/${{ steps.test-config.outputs.config_file }} \
+              -i 0
+          fi
 
       - name: Cleanup cluster
         if: always()

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -36,12 +36,7 @@ jobs:
       - name: Set matrix
         id: set-matrix
         run: |
-          ALL='{"include":[
-            {"name":"public-contract","config_file":"example-public-contract.yaml"},
-            {"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"},
-            {"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"},
-            {"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}
-          ]}'
+          ALL='{"include":[{"name":"public-contract","config_file":"example-public-contract.yaml"},{"name":"private-transaction-node-restart","config_file":"example-private-transaction-node-restart.yaml"},{"name":"privacy-group-contract-deploy","config_file":"example-privacy-group-contract-deploy.yaml"},{"name":"noto-revertable-hooks","config_file":"example-noto-revertable-hooks.yaml"}]}'
           case "${{ inputs.test_name }}" in
             all)
               echo "matrix=$ALL" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Copy solidity artifacts
         working-directory: paladin
-        run: ./gradlew --no-daemon :domains:noto:copyInternalSolidity :test:copySolidity
+        run: ./gradlew --no-daemon :toolkit:go:protoc :domains:noto:copyInternalSolidity :domains:noto:copyPkgSolidity :test:copySolidity
 
       - name: Build test application
         working-directory: paladin/test

--- a/.github/workflows/run-pldtest.yaml
+++ b/.github/workflows/run-pldtest.yaml
@@ -1,4 +1,4 @@
-name: "Run integration test"
+name: "Run integration tests"
 
 permissions:
   contents: read
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       test_name:
-        description: "Test configuration to run"
+        description: "Test to run"
         required: true
         type: choice
         options:


### PR DESCRIPTION
Several updates iterating on the initial GHA workflow for running integration tests:
 - Fix some of the paths
 - Make it possible to run all of the tests as a matrix
 - Make the duration of the tests overridable from the default `5m`
 - Have each test step limited to `2 x test_duration` because the test app can hit cases where it hangs forever and runs up against Github's `6h` limit

<img width="448" height="622" alt="image" src="https://github.com/user-attachments/assets/a5a40df7-1660-4140-afd5-e3526e15f535" />

Running these within a GHA to test the workflow has made it apparent that they are by no means 100% reliable. Some are more reliable than others, and I haven't had a successful run of the entire matrix at all.

I think the GHA updates are still valuable, and make it easier to exercise potential fixes for them.
