### PR TITLE
Fix transport stop deadlock

### DIFF
--- a/core/go/internal/transportmgr/manager.go
+++ b/core/go/internal/transportmgr/manager.go
@@ -154,6 +154,10 @@ func (tm *transportManager) Start() error {
 }
 
 func (tm *transportManager) Stop() {
+	// Cancel bgCtx first so any goroutines blocked on p.ctx (derived from bgCtx),
+	// such as startSender holding peersLock while waiting on GetNodeTransports or
+	// ActivatePeer, are unblocked before we attempt to acquire peersLock below.
+	tm.cancelCtx()
 
 	peers := tm.listActivePeers()
 	for _, p := range peers {
@@ -170,7 +174,6 @@ func (tm *transportManager) Stop() {
 		tm.cleanupTransport(t)
 	}
 
-	tm.cancelCtx()
 	if tm.peerReaperDone != nil {
 		<-tm.peerReaperDone
 	}

--- a/transports/grpc/internal/grpctransport/grpc_transport.go
+++ b/transports/grpc/internal/grpctransport/grpc_transport.go
@@ -49,8 +49,9 @@ type Server interface {
 type grpcTransport struct {
 	proto.UnimplementedPaladinGRPCTransportServer
 
-	bgCtx     context.Context
-	callbacks plugintk.TransportCallbacks
+	bgCtx       context.Context
+	bgCtxCancel context.CancelFunc
+	callbacks   plugintk.TransportCallbacks
 
 	name               string
 	listener           net.Listener
@@ -73,8 +74,10 @@ func NewPlugin(ctx context.Context) plugintk.PluginBase {
 }
 
 func NewGRPCTransport(callbacks plugintk.TransportCallbacks) plugintk.TransportAPI {
+	bgCtx, bgCtxCancel := context.WithCancel(context.Background())
 	return &grpcTransport{
-		bgCtx:               log.WithComponent(context.Background(), "grpctransport"),
+		bgCtx:               log.WithComponent(bgCtx, "grpctransport"),
+		bgCtxCancel:         bgCtxCancel,
 		callbacks:           callbacks,
 		outboundConnections: make(map[string]*outboundConn),
 	}
@@ -351,6 +354,11 @@ func (t *grpcTransport) StopTransport(ctx context.Context, req *prototk.StopTran
 }
 
 func (t *grpcTransport) shutdownTransport() {
+	// Cancel bgCtx before GracefulStop so any TLS handshake goroutines blocked in
+	// VerifyConnection → getTransportDetails → RequestFromPlugin → inflight.Wait()
+	// are unblocked immediately, allowing GracefulStop to drain cleanly.
+	t.bgCtxCancel()
+
 	t.connLock.Lock()
 	grpcServer := t.grpcServer
 	serverDone := t.serverDone


### PR DESCRIPTION
Fixes two deadlocks in stopping the transport plugin which seem now to be the most common cause of coordination test failures.

- **Transport manager (`manager.go`):** `Stop()` previously called `tm.cancelCtx()` at the end, so any concurrent `connectPeer` call blocked inside `startSender` — waiting on `GetNodeTransports` or `ActivatePeer` while holding the `peersLock` write-lock — would prevent `Stop()` from ever acquiring the read-lock in `listActivePeers`, deadlocking permanently. Moving `tm.cancelCtx()` to the top of `Stop()` cancels `p.ctx` (which derives from `bgCtx`) immediately, unblocking those calls and releasing the lock before it is needed.

- **gRPC transport (`grpc_transport.go`):** `shutdownTransport()` previously called `GracefulStop()` while `bgCtx` was still live, leaving any in-progress TLS handshake goroutine stuck in `VerifyConnection → getTransportDetails → RequestFromPlugin → inflight.Wait()` indefinitely — the inflight request's context derived from the never-cancelled `context.Background()`, and `pr.inflight.Close()` (the call that would have unblocked it) was unreachable because it is deferred until after `closePlugin()` returns. Adding `bgCtxCancel` to the struct and calling it at the top of `shutdownTransport()` propagates cancellation into the inflight request's context, causing `inflight.Wait()` to return immediately, the handshake to fail, and `GracefulStop()` to drain cleanly.