### PR TITLE
fix/Add DCO sign-off to release workflow

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -171,7 +171,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add examples/
-        git commit -m "chore: Update SDK version in examples to ${{ needs.setup.outputs.tag }}"
+        git commit -s -m "chore: Update SDK version in examples to ${{ needs.setup.outputs.tag }}"
         git push origin HEAD:refs/heads/release-${{ needs.setup.outputs.tag }}
         echo "NEW_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -228,7 +228,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add examples/
-        git commit -m "chore: Update SDK version in examples to ${{ needs.setup.outputs.tag }}"
+        git commit -s -m "chore: Update SDK version in examples to ${{ needs.setup.outputs.tag }}"
         git push origin HEAD:refs/heads/release-${{ needs.setup.outputs.tag }}
         echo "NEW_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

Release and release-candidate workflows automatically commit SDK version updates under `examples/`. Those commits used `git commit -m` without a DCO sign-off, which conflicts with Paladin’s requirement that every commit include `Signed-off-by` (via `git commit -s`).

This PR adds `-s` to the commit step in both workflows so automated release commits satisfy the Developer Certificate of Origin policy.

Fixes #1199 
## Changes

- `.github/workflows/release.yaml` — use `git commit -s` in the examples version bump step
- `.github/workflows/release-candidate.yaml` — same change

## Why is this needed?

- Keeps bot-created release commits aligned with [contribution guidelines](https://github.com/LFDT-Paladin/paladin/blob/main/doc-site/docs/contributing/how-to-contribute.md)
- Avoids DCO failures if release-branch commits are merged or reviewed via PR