### PR TITLE
Pull block height to sequencer

### DIFF
--- a/core/go/internal/sequencer/common/engine_integration.go
+++ b/core/go/internal/sequencer/common/engine_integration.go
@@ -39,7 +39,7 @@ type Hooks interface {
 type EngineIntegration interface {
 	WriteStatesForTransaction(ctx context.Context, txn *components.PrivateTransaction) error
 	MapPotentialStates(ctx context.Context, potentialStates []*prototk.NewState, createdByTX *components.PrivateTransaction) (stateUpserts []*components.StateUpsert, err error)
-	GetBlockHeight(ctx context.Context) (int64, error)
+	GetBlockHeight(ctx context.Context) int64
 	//Assemble and sign is a single, synchronous operation that assembles a transaction using the domain smart contract
 	// and then fulfills any signature requests in the attestation plan
 	// there would be a benefit in separating this out to `assemble` and `sign` steps and to make then asynchronous
@@ -93,8 +93,8 @@ func (e *engineIntegration) WriteStatesForTransaction(ctx context.Context, txn *
 
 }
 
-func (e *engineIntegration) GetBlockHeight(ctx context.Context) (int64, error) {
-	return e.environment.GetBlockHeight(), nil
+func (e *engineIntegration) GetBlockHeight(_ context.Context) int64 {
+	return e.environment.GetBlockHeight()
 }
 
 // assemble a transaction that we are not coordinating, using the provided state locks

--- a/core/go/internal/sequencer/common/events.go
+++ b/core/go/internal/sequencer/common/events.go
@@ -27,7 +27,6 @@ type EventType int
 const (
 	Event_HeartbeatInterval         EventType = iota // emitted on a regular basis, interval defined by the sequencer config
 	Event_TransactionStateTransition                 // transaction state machine transition; originator/coordinator handle cleanup and side effects
-	Event_NewBlock                                   // a new block has been confirmed on the base ledger
 	Event_HeartbeatReceived                          // a heartbeat notification was received from the active coordinator
 	Event_EndorserNodesDiscovered                    // pushed by the coordinator to its co-located originator when new endorser nodes are discovered
 )
@@ -73,19 +72,6 @@ func (*TransactionStateTransitionEvent[S]) Type() EventType {
 
 func (*TransactionStateTransitionEvent[S]) TypeString() string {
 	return "Event_TransactionStateTransition"
-}
-
-type NewBlockEvent struct {
-	BaseEvent
-	BlockHeight uint64
-}
-
-func (*NewBlockEvent) Type() EventType {
-	return Event_NewBlock
-}
-
-func (*NewBlockEvent) TypeString() string {
-	return "Event_NewBlock"
 }
 
 type HeartbeatReceivedEvent struct {

--- a/core/go/internal/sequencer/common/selection.go
+++ b/core/go/internal/sequencer/common/selection.go
@@ -99,17 +99,16 @@ func DedupeSortedCoordinatorEndorserNodes(nodes []string) []string {
 }
 
 // ComputeCoordinatorPriorityList returns a priority-ordered list of coordinator nodes for the
-// given block height and range. The node at index 0 is the highest-priority (currently selected)
+// given effective block height. The node at index 0 is the highest-priority (currently selected)
 // coordinator; remaining nodes follow in sorted order. All nodes that call this function with the
-// same pool and block height will independently reach the same result.
+// same pool and effective block height will independently reach the same result.
 //
 // For COORDINATOR_STATIC and COORDINATOR_SENDER modes, the coordinator field is set once at
 // construction/Start time and this function is never invoked.
 func ComputeCoordinatorPriorityList(
 	ctx context.Context,
 	nodePool []string,
-	currentBlockHeight uint64,
-	blockRange uint64,
+	effectiveBlockHeight uint64,
 ) []string {
 	n := len(nodePool)
 	if n == 0 {
@@ -118,11 +117,10 @@ func ComputeCoordinatorPriorityList(
 	if n == 1 {
 		return []string{nodePool[0]}
 	}
-	effectiveBlockNumber := currentBlockHeight - (currentBlockHeight % blockRange)
 
 	// Take a numeric hash of the effective block number
 	h := fnv.New32a()
-	h.Write([]byte(strconv.FormatUint(effectiveBlockNumber, 10)))
+	h.Write([]byte(strconv.FormatUint(effectiveBlockHeight, 10)))
 	p := int(h.Sum32()) % n
 	selected := nodePool[p]
 	log.L(ctx).Debugf("coordinator priority list: selected index %d (%q) from pool %+v", p, selected, nodePool)
@@ -153,12 +151,9 @@ func IsHigherPriority(list []string, node1 string, node2 string) bool {
 	return idx1 < idx2
 }
 
-// DecodeNewBlockHeight extracts the new block height from a NewBlockEvent and determines
-// whether we have entered a new block range epoch. Both coordinator and originator use this
-// to update their block height state consistently.
-func DecodeNewBlockHeight(currentBlockHeight uint64, blockRange uint64, event Event) (uint64, bool) {
-	e := event.(*NewBlockEvent)
-	newHeight := e.BlockHeight
-	onEpochBoundary := newHeight/blockRange != currentBlockHeight/blockRange
-	return newHeight, onEpochBoundary
+// ComputeEffectiveBlockHeight returns the epoch-aligned block height for a given raw block
+// height and epoch width (blockRange). The result is constant within an epoch, changing only
+// when the raw height crosses the next epoch boundary.
+func ComputeEffectiveBlockHeight(height, blockRange uint64) uint64 {
+	return height - (height % blockRange)
 }

--- a/core/go/internal/sequencer/common/selection_test.go
+++ b/core/go/internal/sequencer/common/selection_test.go
@@ -34,7 +34,7 @@ func TestDedupeSortedCoordinatorEndorserNodes_RemovesDuplicatesAndSorts(t *testi
 
 func Test_ComputeCoordinatorPriorityList_SingleNode_ReturnsThatNode(t *testing.T) {
 	ctx := context.Background()
-	list := ComputeCoordinatorPriorityList(ctx, []string{"node1"}, 1000, 100)
+	list := ComputeCoordinatorPriorityList(ctx, []string{"node1"}, 1000)
 	require.Len(t, list, 1)
 	assert.Equal(t, "node1", list[0])
 }
@@ -42,31 +42,33 @@ func Test_ComputeCoordinatorPriorityList_SingleNode_ReturnsThatNode(t *testing.T
 func Test_ComputeCoordinatorPriorityList_MultipleNodes_TopIsInPool(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"node1", "node2", "node3"}
-	list := ComputeCoordinatorPriorityList(ctx, pool, 1000, 100)
+	list := ComputeCoordinatorPriorityList(ctx, pool, 1000)
 	require.Len(t, list, len(pool))
 	assert.Contains(t, pool, list[0], "highest-priority node must be a member of the pool")
 }
 
-func Test_ComputeCoordinatorPriorityList_SameBlockRange_ReturnsSameTop(t *testing.T) {
+func Test_ComputeCoordinatorPriorityList_SameEpoch_ReturnsSameTop(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"node1", "node2", "node3"}
-	blockRange := uint64(100)
+	// heights 1000, 1050, 1099 all map to effective=1000 with blockRange=100
+	effectiveHeight := ComputeEffectiveBlockHeight(1000, 100)
 
-	l1 := ComputeCoordinatorPriorityList(ctx, pool, 1000, blockRange)
-	l2 := ComputeCoordinatorPriorityList(ctx, pool, 1050, blockRange)
-	l3 := ComputeCoordinatorPriorityList(ctx, pool, 1099, blockRange)
+	l1 := ComputeCoordinatorPriorityList(ctx, pool, effectiveHeight)
+	l2 := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(1050, 100))
+	l3 := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(1099, 100))
 
-	assert.Equal(t, l1[0], l2[0], "same block range epoch should produce the same top node")
-	assert.Equal(t, l2[0], l3[0], "same block range epoch should produce the same top node")
+	assert.Equal(t, l1[0], l2[0], "same epoch should produce the same top node")
+	assert.Equal(t, l2[0], l3[0], "same epoch should produce the same top node")
 }
 
-func Test_ComputeCoordinatorPriorityList_DifferentBlockRanges_CanSelectDifferentTopNode(t *testing.T) {
+func Test_ComputeCoordinatorPriorityList_DifferentEpochs_CanSelectDifferentTopNode(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"node1", "node2"}
 	blockRange := uint64(50)
 
-	l1 := ComputeCoordinatorPriorityList(ctx, pool, 100, blockRange)
-	l2 := ComputeCoordinatorPriorityList(ctx, pool, 150, blockRange)
+	// heights 100 and 150 are both epoch-aligned with blockRange=50
+	l1 := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(100, blockRange))
+	l2 := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(150, blockRange))
 
 	assert.Contains(t, pool, l1[0])
 	assert.Contains(t, pool, l2[0])
@@ -75,11 +77,10 @@ func Test_ComputeCoordinatorPriorityList_DifferentBlockRanges_CanSelectDifferent
 func Test_ComputeCoordinatorPriorityList_TwoCallsAgree(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"node1", "node2", "node3"}
-	blockRange := uint64(100)
-	blockHeight := uint64(1000)
+	effectiveHeight := ComputeEffectiveBlockHeight(1000, 100)
 
-	first := ComputeCoordinatorPriorityList(ctx, pool, blockHeight, blockRange)
-	second := ComputeCoordinatorPriorityList(ctx, pool, blockHeight, blockRange)
+	first := ComputeCoordinatorPriorityList(ctx, pool, effectiveHeight)
+	second := ComputeCoordinatorPriorityList(ctx, pool, effectiveHeight)
 
 	assert.Equal(t, first, second, "two independent calls with the same inputs must return the same list")
 }
@@ -88,28 +89,29 @@ func Test_ComputeCoordinatorPriorityList_EpochBoundary_SameBoundaryProducesSameT
 	ctx := context.Background()
 	pool := []string{"a-node", "b-node", "m-node", "z-node"}
 	blockRange := uint64(100)
-	atBoundary := ComputeCoordinatorPriorityList(ctx, pool, 1000, blockRange)
-	atEnd := ComputeCoordinatorPriorityList(ctx, pool, 1099, blockRange)
+	// Both raw heights fall within the same epoch; callers pre-compute effective height.
+	atBoundary := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(1000, blockRange))
+	atEnd := ComputeCoordinatorPriorityList(ctx, pool, ComputeEffectiveBlockHeight(1099, blockRange))
 	assert.Equal(t, atBoundary[0], atEnd[0])
 }
 
 func Test_ComputeCoordinatorPriorityList_IsStableForFixedInputs(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"a", "b", "c", "d", "e"}
-	blockRange := uint64(50)
-	first := ComputeCoordinatorPriorityList(ctx, pool, 75, blockRange)
-	second := ComputeCoordinatorPriorityList(ctx, pool, 75, blockRange)
+	effectiveHeight := ComputeEffectiveBlockHeight(75, 50) // → 50
+	first := ComputeCoordinatorPriorityList(ctx, pool, effectiveHeight)
+	second := ComputeCoordinatorPriorityList(ctx, pool, effectiveHeight)
 	assert.Equal(t, first, second)
 	assert.Contains(t, pool, first[0])
 }
 
 func Test_ComputeCoordinatorPriorityList_WrapAroundOrder(t *testing.T) {
-	// Fix a pool and block height so the hash deterministically picks index 2 ("node3").
+	// Fix a pool and effective block height so the hash deterministically picks index 2 ("node3").
 	// With wrap-around the expected order is [node3, node4, node1, node2].
 	ctx := context.Background()
 	pool := []string{"node1", "node2", "node3", "node4"}
 
-	list := ComputeCoordinatorPriorityList(ctx, pool, 1000, 100)
+	list := ComputeCoordinatorPriorityList(ctx, pool, 1000)
 	require.Len(t, list, len(pool))
 
 	// Locate where the top node sits in the original pool.
@@ -128,17 +130,16 @@ func Test_ComputeCoordinatorPriorityList_WrapAroundOrder(t *testing.T) {
 	}
 }
 
-
 func Test_ComputeCoordinatorPriorityList_EmptyPool_ReturnsNil(t *testing.T) {
 	ctx := context.Background()
-	list := ComputeCoordinatorPriorityList(ctx, nil, 1000, 100)
+	list := ComputeCoordinatorPriorityList(ctx, nil, 1000)
 	assert.Nil(t, list)
 }
 
 func Test_ComputeCoordinatorPriorityList_ListContainsAllPoolNodes(t *testing.T) {
 	ctx := context.Background()
 	pool := []string{"node1", "node2", "node3"}
-	list := ComputeCoordinatorPriorityList(ctx, pool, 1000, 100)
+	list := ComputeCoordinatorPriorityList(ctx, pool, 1000)
 	require.Len(t, list, len(pool))
 	for _, node := range pool {
 		assert.Contains(t, list, node, "all pool nodes must appear in the priority list")
@@ -157,25 +158,19 @@ func Test_PriorityIndexOf_ReturnsLenForUnknownNode(t *testing.T) {
 	assert.Equal(t, len(list), PriorityIndexOf(list, "unknown"))
 }
 
-func Test_DecodeNewBlockHeight_NewEpoch(t *testing.T) {
-	event := &NewBlockEvent{BlockHeight: 100}
-	newHeight, newEpoch := DecodeNewBlockHeight(0, 100, event)
-	require.Equal(t, uint64(100), newHeight)
-	assert.True(t, newEpoch)
+func Test_ComputeEffectiveBlockHeight_AtEpochBoundary(t *testing.T) {
+	// height=100 exactly on a boundary with blockRange=100 → effective=100
+	assert.Equal(t, uint64(100), ComputeEffectiveBlockHeight(100, 100))
 }
 
-func Test_DecodeNewBlockHeight_SameEpoch(t *testing.T) {
-	event := &NewBlockEvent{BlockHeight: 50}
-	newHeight, newEpoch := DecodeNewBlockHeight(0, 100, event)
-	require.Equal(t, uint64(50), newHeight)
-	assert.False(t, newEpoch)
+func Test_ComputeEffectiveBlockHeight_MidEpoch(t *testing.T) {
+	// height=50 within the first epoch of 100 → effective=0
+	assert.Equal(t, uint64(0), ComputeEffectiveBlockHeight(50, 100))
 }
 
-func Test_DecodeNewBlockHeight_SameEpochMidRange(t *testing.T) {
-	event := &NewBlockEvent{BlockHeight: 1099}
-	newHeight, newEpoch := DecodeNewBlockHeight(1000, 100, event)
-	require.Equal(t, uint64(1099), newHeight)
-	assert.False(t, newEpoch)
+func Test_ComputeEffectiveBlockHeight_MidSecondEpoch(t *testing.T) {
+	// height=1099 within the 11th epoch of 100 → effective=1000
+	assert.Equal(t, uint64(1000), ComputeEffectiveBlockHeight(1099, 100))
 }
 
 func TestResolveCoordinatorSelectionConfig_Static_ValidLocator(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/chained_dependencies_test.go
+++ b/core/go/internal/sequencer/coordinator/chained_dependencies_test.go
@@ -79,7 +79,7 @@ func (s *ChainedDependenciesSuite) SetupTest() {
 
 func (s *ChainedDependenciesSuite) buildCoordinator() {
 	s.c, s.mocks = s.builder.Build()
-	s.mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	s.mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	s.mocks.EngineIntegration.On("WriteStatesForTransaction", mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.mocks.EngineIntegration.On("MapPotentialStates", mock.Anything, mock.Anything, mock.Anything).Return(([]*components.StateUpsert)(nil), nil).Maybe()
 	s.mocks.SyncPoints.On("PersistDispatchBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()

--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -191,8 +191,7 @@ func (c *coordinator) updateEndorserCandidates(ctx context.Context, nodes ...str
 		c.coordinatorPriorityList = common.ComputeCoordinatorPriorityList(
 			ctx,
 			c.endorserCandidates,
-			c.currentBlockHeight,
-			c.coordinatorSelectionBlockRange,
+			c.effectiveBlockHeight,
 		)
 		c.notifyOriginator(ctx, &common.EndorserNodesDiscoveredEvent{
 			// Put a copy of the candidates in the event so the originator can't modify the coordinator's internal state.
@@ -224,8 +223,22 @@ func (c *coordinator) getCoordinatorSigningIdentity() string {
 	return c.signingIdentity.value
 }
 
-func (c *coordinator) getCurrentBlockHeight() int64 {
-	return int64(c.currentBlockHeight)
+// getAndRefreshBlockHeight queries the live block height, updates effectiveBlockHeight on epoch
+// change, recomputes the priority list, calls grapher.ForgetLocks, and queues an internal
+// EpochBoundaryReachedEvent so the state machine can perform state-specific epoch work (e.g.
+// signing key rotation in Active). Returns (liveHeight, epochChanged).
+func (c *coordinator) getAndRefreshBlockHeight(ctx context.Context) (int64, bool) {
+	liveHeight := c.engineIntegration.GetBlockHeight(ctx)
+	c.currentBlockHeight = liveHeight
+	c.grapher.ForgetLocks(ctx, uint64(liveHeight))
+	c.calculateCoordinatorPriorities(ctx)
+	newEffective := common.ComputeEffectiveBlockHeight(uint64(liveHeight), c.coordinatorSelectionBlockRange)
+	if newEffective == c.effectiveBlockHeight {
+		return liveHeight, false
+	}
+	c.effectiveBlockHeight = newEffective
+	c.queueEventInternal(ctx, &EpochBoundaryReachedEvent{})
+	return liveHeight, true
 }
 
 func (c *coordinator) newCoordinatorTransaction(ctx context.Context, originator string, originatorNode string, nodeName string, pt *components.PrivateTransaction) transaction.CoordinatorTransaction {
@@ -243,7 +256,7 @@ func (c *coordinator) newCoordinatorTransaction(ctx context.Context, originator 
 		c.getCoordinatorTransactionState,
 		func(ctx context.Context, nodes ...string) { c.updateEndorserCandidates(ctx, nodes...) },
 		c.engineIntegration,
-		c.getCurrentBlockHeight,
+		func(ctx context.Context) int64 { h, _ := c.getAndRefreshBlockHeight(ctx); return h },
 		c.blockHeightTolerance,
 		c.syncPoints,
 		c.components,
@@ -374,7 +387,8 @@ func (c *coordinator) addToDelegatedTransactions(
 	}
 
 	// Acknowledge the delegate request. Optionally errors can be returned which the originator may use to base re-delegate decisions on
-	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementErrors, c.currentBlockHeight)
+	liveHeight, _ := c.getAndRefreshBlockHeight(ctx)
+	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementErrors, uint64(liveHeight))
 	if err != nil {
 		return err
 	}

--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -223,22 +223,24 @@ func (c *coordinator) getCoordinatorSigningIdentity() string {
 	return c.signingIdentity.value
 }
 
-// getAndRefreshBlockHeight queries the live block height, updates effectiveBlockHeight on epoch
-// change, recomputes the priority list, calls grapher.ForgetLocks, and queues an internal
-// EpochBoundaryReachedEvent so the state machine can perform state-specific epoch work (e.g.
-// signing key rotation in Active). Returns (liveHeight, epochChanged).
-func (c *coordinator) getAndRefreshBlockHeight(ctx context.Context) (int64, bool) {
+func action_RefreshBlockHeight(ctx context.Context, c *coordinator, _ common.Event) error {
+	c.refreshBlockHeight(ctx)
+	return nil
+}
+
+// refreshBlockHeight queries the live block height, caches it in c.currentBlockHeight,
+// calls grapher.ForgetLocks, recomputes the priority list, and queues an internal
+// EpochBoundaryReachedEvent when the effective block height advances to a new epoch.
+func (c *coordinator) refreshBlockHeight(ctx context.Context) {
 	liveHeight := c.engineIntegration.GetBlockHeight(ctx)
 	c.currentBlockHeight = liveHeight
 	c.grapher.ForgetLocks(ctx, uint64(liveHeight))
 	c.calculateCoordinatorPriorities(ctx)
 	newEffective := common.ComputeEffectiveBlockHeight(uint64(liveHeight), c.coordinatorSelectionBlockRange)
-	if newEffective == c.effectiveBlockHeight {
-		return liveHeight, false
+	if newEffective != c.effectiveBlockHeight {
+		c.effectiveBlockHeight = newEffective
+		c.queueEventInternal(ctx, &EpochBoundaryReachedEvent{})
 	}
-	c.effectiveBlockHeight = newEffective
-	c.queueEventInternal(ctx, &EpochBoundaryReachedEvent{})
-	return liveHeight, true
 }
 
 func (c *coordinator) newCoordinatorTransaction(ctx context.Context, originator string, originatorNode string, nodeName string, pt *components.PrivateTransaction) transaction.CoordinatorTransaction {
@@ -256,7 +258,8 @@ func (c *coordinator) newCoordinatorTransaction(ctx context.Context, originator 
 		c.getCoordinatorTransactionState,
 		func(ctx context.Context, nodes ...string) { c.updateEndorserCandidates(ctx, nodes...) },
 		c.engineIntegration,
-		func(ctx context.Context) int64 { h, _ := c.getAndRefreshBlockHeight(ctx); return h },
+		c.refreshBlockHeight,                         
+		func() int64 { return c.currentBlockHeight }, 
 		c.blockHeightTolerance,
 		c.syncPoints,
 		c.components,
@@ -387,8 +390,7 @@ func (c *coordinator) addToDelegatedTransactions(
 	}
 
 	// Acknowledge the delegate request. Optionally errors can be returned which the originator may use to base re-delegate decisions on
-	liveHeight, _ := c.getAndRefreshBlockHeight(ctx)
-	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementErrors, uint64(liveHeight))
+	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementErrors, uint64(c.currentBlockHeight))
 	if err != nil {
 		return err
 	}

--- a/core/go/internal/sequencer/coordinator/coordinating_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinating_test.go
@@ -60,6 +60,7 @@ func Test_addToDelegatedTransactions_NewTransactionError_ReturnsError(t *testing
 	assert.Equal(t, 0, len(c.transactionsByID), "transaction should not be added when NewTransaction fails")
 }
 
+
 func Test_addToDelegatedTransactions_AddsTransactionInPreDispatchFlowState(t *testing.T) {
 	ctx := t.Context()
 	originator := "sender@senderNode"
@@ -73,7 +74,8 @@ func Test_addToDelegatedTransactions_AddsTransactionInPreDispatchFlowState(t *te
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -103,7 +105,8 @@ func Test_addToDelegatedTransactions_AddsTransactionInPooledFlowState(t *testing
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -130,7 +133,8 @@ func Test_addToDelegatedTransactions_DuplicateTransaction_SkipsAndReturnsNoError
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -450,7 +454,8 @@ func Test_addToDelegatedTransactions_WhenMaxInflightReached_ReturnsError(t *test
 	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
 		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
 	})
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
@@ -516,7 +521,8 @@ func Test_addToDelegatedTransactions_MaxInflightThree_SlidingWindowKeepsOrder(t 
 	config.MaxDispatchAhead = confutil.P(-1)
 	config.MaxInflightTransactions = confutil.P(3)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	txns := make([]*components.PrivateTransaction, 10)
 	for i := range txns {
 		txns[i] = testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
@@ -559,7 +565,8 @@ func Test_addToDelegatedTransactions_HandleEventError_ContinuesAndReturnsNoError
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn.PreAssembly = nil // Triggers error in action_InitializeForNewAssembly when transitioning to Pooled
 
@@ -583,6 +590,7 @@ func Test_addToDelegatedTransactions_SendDelegationResponseError_ReturnsError(t 
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
 	c, mocks := builder.WithMockTransportWriter().Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("send ack failed"))
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
@@ -664,7 +672,8 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_Estab
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// Create a mock previous transaction in State_Pooled
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()
@@ -699,7 +708,8 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_DoesN
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// Create a mock previous transaction in State_Pooled.
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()
@@ -733,7 +743,8 @@ func Test_addToDelegatedTransactions_MockTransactionHandleEventReturnsError(t *t
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
 	expectedError := fmt.Errorf("handle delegated event failed")
@@ -785,6 +796,7 @@ func Test_addToDelegatedTransactions_SubsequentTransactionGetsPreviousTransactio
 
 	var capturedErrors []int64
 	c, mocks := builder.WithMockTransportWriter().Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(errors []int64) bool {
 		capturedErrors = errors
 		return true
@@ -820,6 +832,7 @@ func Test_addToDelegatedTransactions_ErrorStopsSubsequentTransactionsBeingAccept
 
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 	c, mocks := builder.WithMockTransportWriter().Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Delegate 10 transactions. TX 5 fails at HandleEvent time. 5-10 should not be in the TX list for the coordinator
@@ -886,6 +899,7 @@ func Test_addToDelegatedTransactions_FifthFailsThenFullRetry_PreservesFirstFourA
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 
 	c, mocks := builder.WithMockTransportWriter().Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 	txns := make([]*components.PrivateTransaction, 10)
@@ -1020,7 +1034,8 @@ func Test_addToDelegatedTransactions_PreviousTransactionNotInPreAssemblyState_No
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// Create a mock previous transaction in State_Assembling (not a pre-assembly state)
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()
@@ -1039,6 +1054,24 @@ func Test_addToDelegatedTransactions_PreviousTransactionNotInPreAssemblyState_No
 	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err)
+}
+
+func Test_action_CleanUpTransactionsNotYetDispatched_DrainsPendingDispatchQueueItems(t *testing.T) {
+	ctx := context.Background()
+
+	txPooled := coordinatortransactionmocks.NewCoordinatorTransaction(t)
+	idPooled := uuid.New()
+	txPooled.EXPECT().GetID().Return(idPooled)
+	txPooled.EXPECT().GetCurrentState().Return(transaction.State_Pooled)
+
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).Transactions(txPooled).Build()
+
+	// Pre-populate the dispatch queue with a transaction reference to exercise the drain path.
+	c.dispatchQueue <- txPooled
+
+	err := action_CleanUpTransactionsNotYetDispatched(ctx, c, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(c.dispatchQueue), "dispatch queue must be drained")
 }
 
 func Test_action_CleanUpTransactionsNotYetDispatched_RemovesNonDispatchedTransactions(t *testing.T) {
@@ -1276,15 +1309,14 @@ func Test_updateOriginatorActivity_DoesNotPruneActiveNode(t *testing.T) {
 	assert.Equal(t, 0, c.originatorActivity["node2"])
 }
 
-func Test_action_CalculateCoordinatorPriorities_UpdatesPriorityList(t *testing.T) {
+func Test_calculateCoordinatorPriorities_UpdatesPriorityList(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
 		EndorserCandidates("node1", "node2").
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 
-	err := action_CalculateCoordinatorPriorities(ctx, c, nil)
-	require.NoError(t, err)
+	c.calculateCoordinatorPriorities(ctx)
 	assert.NotEmpty(t, c.coordinatorPriorityList)
 	assert.Contains(t, []string{"node1", "node2"}, c.coordinatorPriorityList[0])
 }

--- a/core/go/internal/sequencer/coordinator/coordinating_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinating_test.go
@@ -74,8 +74,7 @@ func Test_addToDelegatedTransactions_AddsTransactionInPreDispatchFlowState(t *te
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -105,8 +104,7 @@ func Test_addToDelegatedTransactions_AddsTransactionInPooledFlowState(t *testing
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -133,8 +131,7 @@ func Test_addToDelegatedTransactions_DuplicateTransaction_SkipsAndReturnsNoError
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
@@ -454,8 +451,7 @@ func Test_addToDelegatedTransactions_WhenMaxInflightReached_ReturnsError(t *test
 	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
 		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
 	})
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
@@ -521,8 +517,7 @@ func Test_addToDelegatedTransactions_MaxInflightThree_SlidingWindowKeepsOrder(t 
 	config.MaxDispatchAhead = confutil.P(-1)
 	config.MaxInflightTransactions = confutil.P(3)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	txns := make([]*components.PrivateTransaction, 10)
 	for i := range txns {
 		txns[i] = testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
@@ -565,8 +560,7 @@ func Test_addToDelegatedTransactions_HandleEventError_ContinuesAndReturnsNoError
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn.PreAssembly = nil // Triggers error in action_InitializeForNewAssembly when transitioning to Pooled
 
@@ -590,7 +584,6 @@ func Test_addToDelegatedTransactions_SendDelegationResponseError_ReturnsError(t 
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("send ack failed"))
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
@@ -672,8 +665,7 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_Estab
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	// Create a mock previous transaction in State_Pooled
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()
@@ -708,8 +700,7 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_DoesN
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	// Create a mock previous transaction in State_Pooled.
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()
@@ -743,8 +734,7 @@ func Test_addToDelegatedTransactions_MockTransactionHandleEventReturnsError(t *t
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
 	expectedError := fmt.Errorf("handle delegated event failed")
@@ -796,7 +786,6 @@ func Test_addToDelegatedTransactions_SubsequentTransactionGetsPreviousTransactio
 
 	var capturedErrors []int64
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(errors []int64) bool {
 		capturedErrors = errors
 		return true
@@ -832,7 +821,6 @@ func Test_addToDelegatedTransactions_ErrorStopsSubsequentTransactionsBeingAccept
 
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Delegate 10 transactions. TX 5 fails at HandleEvent time. 5-10 should not be in the TX list for the coordinator
@@ -899,7 +887,6 @@ func Test_addToDelegatedTransactions_FifthFailsThenFullRetry_PreservesFirstFourA
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 	txns := make([]*components.PrivateTransaction, 10)
@@ -1034,8 +1021,7 @@ func Test_addToDelegatedTransactions_PreviousTransactionNotInPreAssemblyState_No
 	config := builder.GetSequencerConfig()
 	config.MaxDispatchAhead = confutil.P(-1)
 	builder.OverrideSequencerConfig(config)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 	// Create a mock previous transaction in State_Assembling (not a pre-assembly state)
 	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	previousTxnID := uuid.New()

--- a/core/go/internal/sequencer/coordinator/coordinator.go
+++ b/core/go/internal/sequencer/coordinator/coordinator.go
@@ -82,7 +82,8 @@ type coordinator struct {
 	heartbeatIntervalsSinceLastReceive int
 	transactionsByID                   map[uuid.UUID]transaction.CoordinatorTransaction
 	pooledTransactions                 []transaction.CoordinatorTransaction
-	currentBlockHeight                 uint64
+	currentBlockHeight                 int64
+	effectiveBlockHeight               uint64
 	dependencyTracker                  dependencytracker.DependencyTracker
 	grapher                            grapher.Grapher
 	stateVisibilityTracker             statevisibilitytracker.StateVisibilityStore
@@ -219,11 +220,9 @@ func (c *coordinator) Start(ctx context.Context) error {
 	coordCtx := log.WithLogField(ctx, "role", "coordinator")
 	c.ctx = coordCtx
 
-	blockHeight, err := c.engineIntegration.GetBlockHeight(ctx)
-	if err != nil {
-		return err
-	}
-	c.currentBlockHeight = uint64(blockHeight)
+	blockHeight := c.engineIntegration.GetBlockHeight(ctx)
+	c.currentBlockHeight = blockHeight
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(uint64(blockHeight), c.coordinatorSelectionBlockRange)
 
 	c.started = true
 

--- a/core/go/internal/sequencer/coordinator/coordinator_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_builder_test.go
@@ -48,7 +48,7 @@ type CoordinatorBuilderForTesting struct {
 	sequencerManager                         *componentsmocks.SequencerManager
 	contractAddress                          *pldtypes.EthAddress
 	coordinatorSelectionMode                 *prototk.ContractConfig_CoordinatorSelection
-	currentBlockHeight                       *uint64
+	currentEffectiveBlockHeight              *uint64
 	transactions                             []transaction.CoordinatorTransaction
 	pooledTransactions                       []transaction.CoordinatorTransaction
 	heartbeatsUntilClosingGracePeriodExpires *int
@@ -182,8 +182,8 @@ func (b *CoordinatorBuilderForTesting) GetContractAddress() pldtypes.EthAddress 
 	return *b.contractAddress
 }
 
-func (b *CoordinatorBuilderForTesting) CurrentBlockHeight(currentBlockHeight uint64) *CoordinatorBuilderForTesting {
-	b.currentBlockHeight = &currentBlockHeight
+func (b *CoordinatorBuilderForTesting) CurrentBlockHeight(h uint64) *CoordinatorBuilderForTesting {
+	b.currentEffectiveBlockHeight = &h
 	return b
 }
 
@@ -403,8 +403,9 @@ func (b *CoordinatorBuilderForTesting) Build() (*coordinator, *CoordinatorDepend
 	}
 	coordinator.stateMachineEventLoop.StateMachine().SetCurrentState(b.state)
 
-	if b.currentBlockHeight != nil {
-		coordinator.currentBlockHeight = *b.currentBlockHeight
+	if b.currentEffectiveBlockHeight != nil {
+		coordinator.effectiveBlockHeight = *b.currentEffectiveBlockHeight
+		coordinator.currentBlockHeight = int64(*b.currentEffectiveBlockHeight)
 	}
 	if b.endorserCandidates != nil {
 		coordinator.endorserCandidates = *b.endorserCandidates

--- a/core/go/internal/sequencer/coordinator/coordinator_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test.go
@@ -269,8 +269,7 @@ func TestCoordinator_MaxInflightTransactions(t *testing.T) {
 	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
 		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
 	})
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
+	c, _ := builder.Build()
 
 	// Start by simulating the originator and delegate a transaction to the coordinator
 	for i := range 100 {

--- a/core/go/internal/sequencer/coordinator/coordinator_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test.go
@@ -65,7 +65,7 @@ func TestCoordinator_SingleTransactionLifecycle(t *testing.T) {
 	builder.OverrideSequencerConfig(config)
 	builder.CurrentActiveCoordinator("node1")
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil)
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("WriteStatesForTransaction", mock.Anything, mock.Anything).Return(nil)
 	mocks.EngineIntegration.On("MapPotentialStates", mock.Anything, mock.Anything, mock.Anything).Return(([]*components.StateUpsert)(nil), nil)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -269,7 +269,8 @@ func TestCoordinator_MaxInflightTransactions(t *testing.T) {
 	builder.GetDomainAPI().On("ContractConfig").Return(&prototk.ContractConfig{
 		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
 	})
-	c, _ := builder.Build()
+	c, mocks := builder.Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 
 	// Start by simulating the originator and delegate a transaction to the coordinator
 	for i := range 100 {
@@ -482,7 +483,7 @@ func TestCoordinator_CancelContext_StopsEventLoopAndDispatchLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	// Verify event loop is running
@@ -509,7 +510,7 @@ func TestCoordinator_CancelContext_WaitsForTransportShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle).WithMockTransportWriter()
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	defer func() {
 		cancel()
 		c.WaitForDone(t.Context())
@@ -522,7 +523,7 @@ func TestCoordinator_CancelContext_CompletesSuccessfullyWhenCalledOnce(t *testin
 	ctx, cancel := context.WithCancel(t.Context())
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	cancel()
@@ -537,7 +538,7 @@ func TestCoordinator_CancelContext_StopsLoopsEvenWhenProcessingEvents(t *testing
 	ctx, cancel := context.WithCancel(t.Context())
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	// Queue some events to ensure loops are busy
@@ -557,7 +558,7 @@ func TestCoordinator_CancelContext_WhenAlreadyCancelled_ReturnsImmediately(t *te
 	ctx, cancel := context.WithCancel(t.Context())
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	cancel()
@@ -751,8 +752,7 @@ func TestCoordinator_PropagateEventToAllTransactions_HandleEventReturnsError(t *
 
 func TestStart_Idempotent_SecondCallReturnsNil(t *testing.T) {
 	ctx := context.Background()
-	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).Build()
 	// Mark as already started without launching goroutines
 	c.started = true
 	err := c.Start(ctx)
@@ -783,7 +783,7 @@ func TestCoordinator_WaitForDone_ReturnsEarlyWhenContextCancelled(t *testing.T) 
 	ctx, cancel := context.WithCancel(t.Context())
 
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	defer func() {
@@ -822,18 +822,6 @@ func TestCoordinator_WaitForDone_CtxCancelledWhileDispatchLoopRunning_ReturnsEar
 	case <-time.After(time.Second):
 		t.Fatal("WaitForDone should have returned early when context is cancelled and dispatch loop is running")
 	}
-}
-
-func TestCoordinator_Start_GetBlockHeightError_ReturnsError(t *testing.T) {
-	ctx := context.Background()
-	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
-	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), fmt.Errorf("block height unavailable"))
-
-	err := c.Start(ctx)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "block height unavailable")
-	assert.False(t, c.started, "coordinator should not mark itself as started on error")
 }
 
 func TestNewCoordinator_SenderMode_SetsCurrentActiveCoordinatorToNodeName(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/dispatch_loop_test.go
+++ b/core/go/internal/sequencer/coordinator/dispatch_loop_test.go
@@ -39,7 +39,7 @@ func Test_stopDispatchLoop_StopsRunningLoop(t *testing.T) {
 	defer cancel()
 
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Active).Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil)
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 
 	c.startDispatchLoop()
@@ -67,7 +67,7 @@ func TestDispatchLoop_StopWhileWaitingForInFlightSlot(t *testing.T) {
 	builder.OverrideSequencerConfig(config)
 
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	require.NoError(t, c.Start(ctx))
@@ -101,7 +101,7 @@ func TestDispatchLoop_StopAtSelect(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 	c.startDispatchLoop()
 	cancel()

--- a/core/go/internal/sequencer/coordinator/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/endorsing.go
@@ -25,11 +25,11 @@ import (
 )
 
 // validator_IsEndorsementBlockHeightToleranceExceeded returns true when the absolute difference
-// between this coordinator's current block height and the requesting coordinator's block height
-// exceeds the configured block height tolerance.
-func validator_IsEndorsementBlockHeightToleranceExceeded(ctx context.Context, c *coordinator, event common.Event) (bool, error) {
+// between this coordinator's stored block height (refreshed by action_RefreshBlockHeight)
+// and the requesting coordinator's block height exceeds the configured block height tolerance.
+func validator_IsEndorsementBlockHeightToleranceExceeded(_ context.Context, c *coordinator, event common.Event) (bool, error) {
 	e := event.(*EndorsementRequestReceivedEvent)
-	localHeight := uint64(c.engineIntegration.GetBlockHeight(ctx))
+	localHeight := uint64(c.currentBlockHeight)
 	remoteHeight := uint64(e.CoordinatorBlockHeight)
 	diff := max(localHeight, remoteHeight) - min(localHeight, remoteHeight)
 	return diff > c.blockHeightTolerance, nil
@@ -40,8 +40,7 @@ func validator_IsEndorsementBlockHeightToleranceExceeded(ctx context.Context, c 
 // does not call the domain.
 func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*EndorsementRequestReceivedEvent)
-	blockHeight := c.engineIntegration.GetBlockHeight(ctx)
-	log.L(ctx).Warnf("rejecting endorsement request from %s due to block height tolerance (coordinator=%d, endorser=%d, tolerance=%d)", e.FromNode, e.CoordinatorBlockHeight, blockHeight, c.blockHeightTolerance)
+	log.L(ctx).Warnf("rejecting endorsement request from %s due to block height tolerance (coordinator=%d, endorser=%d, tolerance=%d)", e.FromNode, e.CoordinatorBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
 	return c.transportWriter.SendEndorsementRejection(
 		ctx,
 		e.TransactionId,
@@ -52,7 +51,7 @@ func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, ev
 		e.FromNode,
 		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
 		e.CoordinatorBlockHeight,
-		blockHeight,
+		c.currentBlockHeight,
 		int64(c.blockHeightTolerance),
 	)
 }

--- a/core/go/internal/sequencer/coordinator/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/endorsing.go
@@ -27,10 +27,11 @@ import (
 // validator_IsEndorsementBlockHeightToleranceExceeded returns true when the absolute difference
 // between this coordinator's current block height and the requesting coordinator's block height
 // exceeds the configured block height tolerance.
-func validator_IsEndorsementBlockHeightToleranceExceeded(_ context.Context, c *coordinator, event common.Event) (bool, error) {
+func validator_IsEndorsementBlockHeightToleranceExceeded(ctx context.Context, c *coordinator, event common.Event) (bool, error) {
 	e := event.(*EndorsementRequestReceivedEvent)
-	coordinatorBlockHeight := uint64(e.CoordinatorBlockHeight)
-	diff := max(c.currentBlockHeight, coordinatorBlockHeight) - min(c.currentBlockHeight, coordinatorBlockHeight)
+	localHeight := uint64(c.engineIntegration.GetBlockHeight(ctx))
+	remoteHeight := uint64(e.CoordinatorBlockHeight)
+	diff := max(localHeight, remoteHeight) - min(localHeight, remoteHeight)
 	return diff > c.blockHeightTolerance, nil
 }
 
@@ -39,7 +40,8 @@ func validator_IsEndorsementBlockHeightToleranceExceeded(_ context.Context, c *c
 // does not call the domain.
 func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*EndorsementRequestReceivedEvent)
-	log.L(ctx).Warnf("rejecting endorsement request from %s due to block height tolerance (coordinator=%d, endorser=%d, tolerance=%d)", e.FromNode, e.CoordinatorBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
+	blockHeight := c.engineIntegration.GetBlockHeight(ctx)
+	log.L(ctx).Warnf("rejecting endorsement request from %s due to block height tolerance (coordinator=%d, endorser=%d, tolerance=%d)", e.FromNode, e.CoordinatorBlockHeight, blockHeight, c.blockHeightTolerance)
 	return c.transportWriter.SendEndorsementRejection(
 		ctx,
 		e.TransactionId,
@@ -50,7 +52,7 @@ func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, ev
 		e.FromNode,
 		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
 		e.CoordinatorBlockHeight,
-		int64(c.currentBlockHeight),
+		blockHeight,
 		int64(c.blockHeightTolerance),
 	)
 }

--- a/core/go/internal/sequencer/coordinator/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/endorsing_test.go
@@ -150,6 +150,24 @@ func Test_validator_IsEndorsementRequestFromSelf_DifferentNode_ReturnsFalse(t *t
 	assert.False(t, result, "request from a different node should not match")
 }
 
+
+func Test_handleEndorsementRequest_SendEndorsementErrorFails_LogsAndContinues(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Observing).
+		WithMockTransportWriter().
+		Build()
+
+	// Trigger sendErr via a party identity error (empty identity), and have SendEndorsementError itself fail.
+	mocks.TransportWriter.EXPECT().
+		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		Return(fmt.Errorf("transport failure"))
+
+	event := buildEndorsementEvent("node2")
+	event.Party = "@node2" // empty identity — triggers sendErr immediately
+	c.handleEndorsementRequest(ctx, event)
+	// Should not panic; the SendEndorsementError error is only logged.
+}
+
 // --- action_UpdateActiveCoordinatorFromEndorsementRequest tests ---
 
 func Test_action_UpdateActiveCoordinatorFromEndorsementRequest_SetsFromNode(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/events.go
+++ b/core/go/internal/sequencer/coordinator/events.go
@@ -123,3 +123,12 @@ func (*EndorsementRequestReceivedEvent) Type() EventType {
 func (*EndorsementRequestReceivedEvent) TypeString() string {
 	return "Event_EndorsementRequestReceived"
 }
+
+type EpochBoundaryReachedEvent struct {
+	common.BaseEvent
+}
+
+func (*EpochBoundaryReachedEvent) Type() EventType { return Event_EpochBoundaryReached }
+func (*EpochBoundaryReachedEvent) TypeString() string {
+	return "Event_EpochBoundaryReached"
+}

--- a/core/go/internal/sequencer/coordinator/events_test.go
+++ b/core/go/internal/sequencer/coordinator/events_test.go
@@ -75,36 +75,6 @@ func TestTransactionsDelegatedEvent_Fields(t *testing.T) {
 	assert.Equal(t, txID, event.Transactions[0].ID)
 }
 
-func TestNewBlockEvent_Type(t *testing.T) {
-	event := &common.NewBlockEvent{}
-	assert.Equal(t, common.Event_NewBlock, event.Type())
-}
-
-func TestNewBlockEvent_TypeString(t *testing.T) {
-	event := &common.NewBlockEvent{}
-	assert.Equal(t, "Event_NewBlock", event.TypeString())
-}
-
-func TestNewBlockEvent_GetEventTime(t *testing.T) {
-	event := &common.NewBlockEvent{
-		BaseEvent: common.BaseEvent{
-			EventTime: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
-		},
-	}
-	assert.Equal(t, time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC), event.GetEventTime())
-}
-
-func TestNewBlockEvent_Fields(t *testing.T) {
-	blockHeight := uint64(200)
-	event := &common.NewBlockEvent{
-		BaseEvent: common.BaseEvent{
-			EventTime: time.Now(),
-		},
-		BlockHeight: blockHeight,
-	}
-	assert.Equal(t, blockHeight, event.BlockHeight)
-}
-
 func TestEvent_InterfaceCompliance(t *testing.T) {
 	// Test that all events with BaseEvent implement the Event interface
 	events := []Event{

--- a/core/go/internal/sequencer/coordinator/inactive.go
+++ b/core/go/internal/sequencer/coordinator/inactive.go
@@ -42,11 +42,11 @@ func validator_IsHandoverRequestFromHigherPriorityCoordinator(_ context.Context,
 }
 
 // validator_IsDelegationBlockHeightToleranceExceeded returns true when the absolute difference
-// between this coordinator's current block height and the originator's block height exceeds the
-// configured block height tolerance.
-func validator_IsDelegationBlockHeightToleranceExceeded(ctx context.Context, c *coordinator, event common.Event) (bool, error) {
+// between this coordinator's stored block height (refreshed by action_RefreshBlockHeight)
+// and the originator's block height exceeds the configured block height tolerance.
+func validator_IsDelegationBlockHeightToleranceExceeded(_ context.Context, c *coordinator, event common.Event) (bool, error) {
 	e := event.(*TransactionsDelegatedEvent)
-	ch := uint64(c.engineIntegration.GetBlockHeight(ctx))
+	ch := uint64(c.currentBlockHeight)
 	oh := e.OriginatorsBlockHeight
 	diff := max(ch, oh) - min(ch, oh)
 	return diff > c.blockHeightTolerance, nil
@@ -56,10 +56,9 @@ func validator_IsDelegationBlockHeightToleranceExceeded(ctx context.Context, c *
 // height difference exceeds the configured tolerance.
 func action_RejectDelegationRequestBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*TransactionsDelegatedEvent)
-	blockHeight := c.engineIntegration.GetBlockHeight(ctx)
 	c.recordOriginatorActivity(e.FromNode)
 	log.L(ctx).Warnf("rejecting delegation from %s due to block height tolerance (originator=%d, coordinator=%d, tolerance=%d)",
-		e.FromNode, e.OriginatorsBlockHeight, blockHeight, c.blockHeightTolerance)
+		e.FromNode, e.OriginatorsBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
 	return c.transportWriter.SendDelegationRejection(
 		ctx,
 		e.FromNode,
@@ -67,7 +66,7 @@ func action_RejectDelegationRequestBlockHeight(ctx context.Context, c *coordinat
 		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
 		"", // no active coordinator redirect for block height rejections
 		int64(e.OriginatorsBlockHeight),
-		blockHeight,
+		c.currentBlockHeight,
 		int64(c.blockHeightTolerance),
 	)
 }
@@ -82,7 +81,7 @@ func action_RejectDelegationRequest(ctx context.Context, c *coordinator, event c
 		engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
 		c.currentActiveCoordinator,
 		int64(e.OriginatorsBlockHeight),
-		c.engineIntegration.GetBlockHeight(ctx),
+		c.currentBlockHeight,
 		0, // tolerance not relevant for non-block-height rejections
 	)
 }

--- a/core/go/internal/sequencer/coordinator/inactive.go
+++ b/core/go/internal/sequencer/coordinator/inactive.go
@@ -44,9 +44,9 @@ func validator_IsHandoverRequestFromHigherPriorityCoordinator(_ context.Context,
 // validator_IsDelegationBlockHeightToleranceExceeded returns true when the absolute difference
 // between this coordinator's current block height and the originator's block height exceeds the
 // configured block height tolerance.
-func validator_IsDelegationBlockHeightToleranceExceeded(_ context.Context, c *coordinator, event common.Event) (bool, error) {
+func validator_IsDelegationBlockHeightToleranceExceeded(ctx context.Context, c *coordinator, event common.Event) (bool, error) {
 	e := event.(*TransactionsDelegatedEvent)
-	ch := c.currentBlockHeight
+	ch := uint64(c.engineIntegration.GetBlockHeight(ctx))
 	oh := e.OriginatorsBlockHeight
 	diff := max(ch, oh) - min(ch, oh)
 	return diff > c.blockHeightTolerance, nil
@@ -56,9 +56,10 @@ func validator_IsDelegationBlockHeightToleranceExceeded(_ context.Context, c *co
 // height difference exceeds the configured tolerance.
 func action_RejectDelegationRequestBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*TransactionsDelegatedEvent)
+	blockHeight := c.engineIntegration.GetBlockHeight(ctx)
 	c.recordOriginatorActivity(e.FromNode)
 	log.L(ctx).Warnf("rejecting delegation from %s due to block height tolerance (originator=%d, coordinator=%d, tolerance=%d)",
-		e.FromNode, e.OriginatorsBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
+		e.FromNode, e.OriginatorsBlockHeight, blockHeight, c.blockHeightTolerance)
 	return c.transportWriter.SendDelegationRejection(
 		ctx,
 		e.FromNode,
@@ -66,7 +67,7 @@ func action_RejectDelegationRequestBlockHeight(ctx context.Context, c *coordinat
 		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
 		"", // no active coordinator redirect for block height rejections
 		int64(e.OriginatorsBlockHeight),
-		int64(c.currentBlockHeight),
+		blockHeight,
 		int64(c.blockHeightTolerance),
 	)
 }
@@ -81,7 +82,7 @@ func action_RejectDelegationRequest(ctx context.Context, c *coordinator, event c
 		engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
 		c.currentActiveCoordinator,
 		int64(e.OriginatorsBlockHeight),
-		int64(c.currentBlockHeight),
+		c.engineIntegration.GetBlockHeight(ctx),
 		0, // tolerance not relevant for non-block-height rejections
 	)
 }

--- a/core/go/internal/sequencer/coordinator/inactive_test.go
+++ b/core/go/internal/sequencer/coordinator/inactive_test.go
@@ -24,7 +24,6 @@ import (
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,11 +105,11 @@ func Test_action_RejectDelegationRequestBlockHeight_Success(t *testing.T) {
 	ctx := context.Background()
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).
 		BlockHeightTolerance(10).
+		CurrentBlockHeight(200).
 		WithMockTransportWriter().
 		Build()
 
 	fromNode := "remoteNode"
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(200))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
 		ctx, fromNode, "del-789",
 		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
@@ -134,7 +133,6 @@ func Test_action_RejectDelegationRequest_Success(t *testing.T) {
 
 	delegationID := "del-123"
 	fromNode := "remoteNode"
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(nil)
 
 	event := &TransactionsDelegatedEvent{
@@ -152,7 +150,6 @@ func Test_action_RejectDelegationRequest_PropagatesError(t *testing.T) {
 	delegationID := "del-456"
 	fromNode := "remoteNode"
 	expectedErr := fmt.Errorf("transport error")
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(expectedErr)
 
 	event := &TransactionsDelegatedEvent{

--- a/core/go/internal/sequencer/coordinator/inactive_test.go
+++ b/core/go/internal/sequencer/coordinator/inactive_test.go
@@ -24,6 +24,7 @@ import (
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,13 +101,41 @@ func Test_guard_InactiveGracePeriodExceeded_Exceeded(t *testing.T) {
 	assert.True(t, guard_InactiveGracePeriodExceeded(ctx, c))
 }
 
+
+func Test_action_RejectDelegationRequestBlockHeight_Success(t *testing.T) {
+	ctx := context.Background()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	fromNode := "remoteNode"
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(200))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		ctx, fromNode, "del-789",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"",
+		int64(100), int64(200), int64(10),
+	).Return(nil)
+
+	event := &TransactionsDelegatedEvent{
+		FromNode:               fromNode,
+		DelegationID:           "del-789",
+		OriginatorsBlockHeight: 100,
+	}
+	err := action_RejectDelegationRequestBlockHeight(ctx, c, event)
+	require.NoError(t, err)
+}
+
+
 func Test_action_RejectDelegationRequest_Success(t *testing.T) {
 	ctx := context.Background()
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).WithMockTransportWriter().Build()
 
 	delegationID := "del-123"
 	fromNode := "remoteNode"
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(c.currentBlockHeight), int64(0)).Return(nil)
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(nil)
 
 	event := &TransactionsDelegatedEvent{
 		FromNode:     fromNode,
@@ -123,7 +152,8 @@ func Test_action_RejectDelegationRequest_PropagatesError(t *testing.T) {
 	delegationID := "del-456"
 	fromNode := "remoteNode"
 	expectedErr := fmt.Errorf("transport error")
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(c.currentBlockHeight), int64(0)).Return(expectedErr)
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(expectedErr)
 
 	event := &TransactionsDelegatedEvent{
 		FromNode:     fromNode,

--- a/core/go/internal/sequencer/coordinator/selection.go
+++ b/core/go/internal/sequencer/coordinator/selection.go
@@ -22,28 +22,20 @@ import (
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 )
 
-// action_CalculateCoordinatorPriorities recomputes the coordinator priority list for the current
-// block height and epoch. No-op in STATIC and SENDER modes.
 func action_CalculateCoordinatorPriorities(ctx context.Context, c *coordinator, _ common.Event) error {
+	c.calculateCoordinatorPriorities(ctx)
+	return nil
+}
+
+// calculateCoordinatorPriorities recomputes the coordinator priority list for the current
+// effectiveBlockHeight. No-op in STATIC and SENDER modes.
+func (c *coordinator) calculateCoordinatorPriorities(ctx context.Context) {
 	if c.coordinatorSelection != prototk.ContractConfig_COORDINATOR_ENDORSER {
-		return nil
+		return
 	}
 	c.coordinatorPriorityList = common.ComputeCoordinatorPriorityList(
 		ctx,
 		c.endorserCandidates,
-		c.currentBlockHeight,
-		c.coordinatorSelectionBlockRange,
+		c.effectiveBlockHeight,
 	)
-	return nil
-}
-
-func validator_IsOnEpochBoundary(_ context.Context, c *coordinator, event common.Event) (bool, error) {
-	_, isOnBoundary := common.DecodeNewBlockHeight(c.currentBlockHeight, c.coordinatorSelectionBlockRange, event)
-	return isOnBoundary, nil
-}
-
-func action_UpdateBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
-	c.currentBlockHeight, _ = common.DecodeNewBlockHeight(c.currentBlockHeight, c.coordinatorSelectionBlockRange, event)
-	c.grapher.ForgetLocks(ctx, c.currentBlockHeight)
-	return nil
 }

--- a/core/go/internal/sequencer/coordinator/selection_test.go
+++ b/core/go/internal/sequencer/coordinator/selection_test.go
@@ -111,7 +111,7 @@ func Test_calculateCoordinatorPriorities_SenderMode_NoOp(t *testing.T) {
 }
 
 
-func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
+func Test_refreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
 	ctx := context.Background()
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).
 		EndorserCandidates("node1").
@@ -121,8 +121,7 @@ func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(1000))
 
-	liveHeight, epochChanged := c.getAndRefreshBlockHeight(ctx)
-	assert.Equal(t, int64(1000), liveHeight)
-	assert.True(t, epochChanged)
+	c.refreshBlockHeight(ctx)
+	assert.Equal(t, int64(1000), c.currentBlockHeight)
 	assert.Equal(t, uint64(1000), c.effectiveBlockHeight)
 }

--- a/core/go/internal/sequencer/coordinator/selection_test.go
+++ b/core/go/internal/sequencer/coordinator/selection_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/mock"
 )
 
-func Test_action_CalculateCoordinatorPriorities_SingleNodeInPool_SetsPriorityList(t *testing.T) {
+func Test_calculateCoordinatorPriorities_SingleNodeInPool_SetsPriorityList(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
 		EndorserCandidates("node1").
@@ -34,11 +34,11 @@ func Test_action_CalculateCoordinatorPriorities_SingleNodeInPool_SetsPriorityLis
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.calculateCoordinatorPriorities(ctx)
 	assert.Equal(t, []string{"node1"}, c.coordinatorPriorityList)
 }
 
-func Test_action_CalculateCoordinatorPriorities_MultipleNodesInPool_SetsNonEmptyPriorityList(t *testing.T) {
+func Test_calculateCoordinatorPriorities_MultipleNodesInPool_SetsNonEmptyPriorityList(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
 		EndorserCandidates("node1", "node2", "node3").
@@ -47,12 +47,12 @@ func Test_action_CalculateCoordinatorPriorities_MultipleNodesInPool_SetsNonEmpty
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.calculateCoordinatorPriorities(ctx)
 	assert.NotEmpty(t, c.coordinatorPriorityList)
 	assert.Contains(t, []string{"node1", "node2", "node3"}, c.coordinatorPriorityList[0])
 }
 
-func Test_action_CalculateCoordinatorPriorities_BlockHeightRounding_SameRangeSamePriorityList(t *testing.T) {
+func Test_calculateCoordinatorPriorities_BlockHeightRounding_SameRangeSamePriorityList(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
 		EndorserCandidates("node1", "node2", "node3").
@@ -60,27 +60,27 @@ func Test_action_CalculateCoordinatorPriorities_BlockHeightRounding_SameRangeSam
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 1000}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(1000, 100)
+	c.calculateCoordinatorPriorities(ctx)
 	list1 := c.coordinatorPriorityList[0]
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 1001}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(1001, 100)
+	c.calculateCoordinatorPriorities(ctx)
 	list2 := c.coordinatorPriorityList[0]
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 1099}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(1099, 100)
+	c.calculateCoordinatorPriorities(ctx)
 	list3 := c.coordinatorPriorityList[0]
 
 	assert.Equal(t, list1, list2)
 	assert.Equal(t, list2, list3)
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 1100}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(1100, 100)
+	c.calculateCoordinatorPriorities(ctx)
 	assert.Contains(t, []string{"node1", "node2", "node3"}, c.coordinatorPriorityList[0])
 }
 
-func Test_action_CalculateCoordinatorPriorities_DifferentBlockRanges_CanSelectDifferentPriorityHeads(t *testing.T) {
+func Test_calculateCoordinatorPriorities_DifferentBlockRanges_CanSelectDifferentPriorityHeads(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
 		EndorserCandidates("node1", "node2").
@@ -88,33 +88,41 @@ func Test_action_CalculateCoordinatorPriorities_DifferentBlockRanges_CanSelectDi
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 100}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(100, 50)
+	c.calculateCoordinatorPriorities(ctx)
 	head1 := c.coordinatorPriorityList[0]
 
-	require.NoError(t, action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 150}))
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(150, 50)
+	c.calculateCoordinatorPriorities(ctx)
 	head2 := c.coordinatorPriorityList[0]
 
 	assert.Contains(t, []string{"node1", "node2"}, head1)
 	assert.Contains(t, []string{"node1", "node2"}, head2)
 }
 
-func Test_action_CalculateCoordinatorPriorities_SenderMode_NoOp(t *testing.T) {
+func Test_calculateCoordinatorPriorities_SenderMode_NoOp(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
 		CurrentActiveCoordinator("node1").
 		Build()
 
-	require.NoError(t, action_CalculateCoordinatorPriorities(ctx, c, nil))
+	c.calculateCoordinatorPriorities(ctx)
 	assert.Empty(t, c.coordinatorPriorityList, "SENDER mode must not compute a priority list")
 }
 
-func Test_action_UpdateBlockHeight_SetsCurrentBlockHeight(t *testing.T) {
-	ctx := context.Background()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).Build()
 
-	err := action_UpdateBlockHeight(ctx, c, &common.NewBlockEvent{BlockHeight: 1000})
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1000), c.currentBlockHeight)
+func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
+	ctx := context.Background()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).
+		EndorserCandidates("node1").
+		CoordinatorSelectionBlockRange(100).
+		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(1000))
+
+	liveHeight, epochChanged := c.getAndRefreshBlockHeight(ctx)
+	assert.Equal(t, int64(1000), liveHeight)
+	assert.True(t, epochChanged)
+	assert.Equal(t, uint64(1000), c.effectiveBlockHeight)
 }

--- a/core/go/internal/sequencer/coordinator/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/snapshot.go
@@ -137,7 +137,7 @@ func (c *coordinator) getSnapshot(ctx context.Context) *common.CoordinatorSnapsh
 		PooledTransactions:     pooledTransactions,
 		ConfirmedTransactions:  confirmedTransactions,
 		CoordinatorState:       coordinatorState,
-		BlockHeight:            c.currentBlockHeight,
+		BlockHeight:            uint64(c.currentBlockHeight),
 		EndorserCandidates:     c.endorserCandidates,
 	}
 }

--- a/core/go/internal/sequencer/coordinator/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/state_machine.go
@@ -101,6 +101,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -118,13 +121,17 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
 					// Any node in Idle accepts a delegation and becomes the active coordinator.
 					// A higher-priority node that later announces itself will trigger preemption from Active.
+					Validator:   statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
 					Actions:     []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 					Transitions: []Transition{{To: State_Active}},
 				}},
@@ -150,6 +157,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -179,11 +189,15 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
 					Actions: []ActionRule{
 						{
 							// This node is higher-priority than the current active coordinator — initiate a handover.
@@ -312,6 +326,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -362,13 +379,17 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
 					// Accept delegations while in Elect so originators are not bounced while we wait.
-					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
+					Actions:   []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 				}},
 			},
 			common.Event_TransactionStateTransition: {
@@ -482,6 +503,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -528,12 +552,16 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
-					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
+					Actions:   []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 				}},
 			},
 			common.Event_TransactionStateTransition: {
@@ -638,6 +666,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -692,12 +723,16 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
-					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
+					Actions:   []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 				}},
 			},
 			common.Event_TransactionStateTransition: {
@@ -822,6 +857,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -869,13 +907,17 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
 					// Still the active coordinator — accept delegations normally- we can process transactions, just not dispatch them
-					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
+					Actions:   []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 				}},
 			},
 			common.Event_TransactionStateTransition: {
@@ -949,6 +991,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{
 						Action: action_AddEndorsementRequestSenderToEndorserCandidates,
 						If:     guard_IsCoordinatorEndorserSelectionMode,
@@ -965,11 +1010,15 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
 					Actions: []ActionRule{
 						{
 							// This node is now higher-priority than the current active coordinator we stepped down for
@@ -1036,6 +1085,9 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_EndorsementRequestReceived: {
 				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Actions: []ActionRule{{Action: action_AddEndorsementRequestSenderToEndorserCandidates, If: guard_IsCoordinatorEndorserSelectionMode}},
 				}, {
 					Validator: validator_IsEndorsementBlockHeightToleranceExceeded,
@@ -1078,11 +1130,15 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_TransactionsDelegated: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh stored block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					Validator: validator_IsDelegationBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
+					Validator: statemachine.ValidatorNot(validator_IsDelegationBlockHeightToleranceExceeded),
 					Actions: []ActionRule{{
 						// Current active coordinator is still live and higher priority; redirect the originator.
 						If: statemachine.GuardAnd(

--- a/core/go/internal/sequencer/coordinator/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/state_machine.go
@@ -51,6 +51,7 @@ const (
 	Event_HandoverRequest            // pushed by transport_client when a CoordinatorHandoverRequest message is received from a higher-priority node
 	Event_RestartDispatchLoop        // queued internally after an in-place key rotation so the loop restarts after TransactionStateTransitionEvents are processed
 	Event_EndorsementRequestReceived // pushed by transport_client when an EndorsementRequest message arrives for this coordinator
+	Event_EpochBoundaryReached       // queued internally by getAndRefreshBlockHeight when the effective block height advances to a new epoch
 )
 
 // Type aliases for the generic statemachine types, specialized for coordinator
@@ -128,19 +129,6 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Active}},
 				}},
 			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
-				}},
-			},
 		},
 	},
 	State_Observing: {
@@ -212,19 +200,6 @@ var stateDefinitionsMap = StateDefinitions{
 						To: State_Elect,
 						If: guard_IsHigherPriorityThanCurrentActive,
 					}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 		},
@@ -396,19 +371,6 @@ var stateDefinitionsMap = StateDefinitions{
 					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
 				}},
 			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
-				}},
-			},
 			common.Event_TransactionStateTransition: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
@@ -572,19 +534,6 @@ var stateDefinitionsMap = StateDefinitions{
 					Actions:   []ActionRule{{Action: action_RejectDelegationRequestBlockHeight}},
 				}, {
 					Actions: []ActionRule{{Action: action_ProcessDelegatedTransactions}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 			common.Event_TransactionStateTransition: {
@@ -783,21 +732,16 @@ var stateDefinitionsMap = StateDefinitions{
 					Actions:   []ActionRule{{Action: action_CleanUpTransaction}},
 				}},
 			},
-			common.Event_NewBlock: {
+			Event_EpochBoundaryReached: {
+				// getAndRefreshBlockHeight queues this event when the effective block height advances to a new
+				// epoch. We need to rotate the coordinator signing key.
+				// If the key has been used AND we have unconfirmed dispatched transactions we need to
+				// take the more expensive route of flushing the dispatched transactions before we can
+				// start signing with the new key. The dispatch loop must be stopped in order to reliably
+				// make this decision. Otherwise we can rotate the key in place and restart the dispatch loop.
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					// We're at an epoch boundary we need to rotate the coordinator signing key
-					// If the key has been used AND we have unconfirmed dispatched transactions we need to
-					// take the more expensive route of flushing the dispatched transactions before we can
-					// start signing with the new key. The dispatch loop must be stopped in order to reliably
-					// make this decision. Otherwise we can rotate the key in place and restart the dispatch loop.
-					Validator: validator_IsOnEpochBoundary,
 					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
 						{Action: action_StopDispatchLoop},
 						{If: statemachine.GuardNot(guard_MustFlushToRotateSigningIdentity), Action: action_NewSigningIdentity},
 						// Queueing this event gives the coordinator a chance to process any state transition events before
@@ -966,19 +910,6 @@ var stateDefinitionsMap = StateDefinitions{
 					}},
 				}},
 			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
-				}},
-			},
 		},
 	},
 	State_Closing_Flush: {
@@ -1079,19 +1010,6 @@ var stateDefinitionsMap = StateDefinitions{
 						To: State_Closing,
 						If: statemachine.GuardNot(guard_HasUnconfirmedDispatchedTransactions),
 					}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 		},
@@ -1198,19 +1116,6 @@ var stateDefinitionsMap = StateDefinitions{
 				Handlers: []EventHandler{{
 					Validator: validator_TransactionStateTransitionTo(transaction.State_Final),
 					Actions:   []ActionRule{{Action: action_CleanUpTransaction}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Validator: statemachine.ValidatorNot(validator_IsOnEpochBoundary),
-					Actions:   []ActionRule{{Action: action_UpdateBlockHeight}},
-				}, {
-					Validator: validator_IsOnEpochBoundary,
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 		},

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -63,7 +63,7 @@ func Test_queueEventInternal_QueuesPriorityEvent(t *testing.T) {
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	ctx, cancel := context.WithCancel(t.Context())
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 	defer func() {
 		cancel()
@@ -80,7 +80,7 @@ func Test_TryQueueEvent_QueuesToEventLoop(t *testing.T) {
 	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
 	ctx, cancel := context.WithCancel(t.Context())
 	c, mocks := builder.Build()
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.Start(ctx))
 	defer func() {
 		cancel()
@@ -105,7 +105,7 @@ func TestCoordinator_WhenCreated_TransitionsToIdle(t *testing.T) {
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &CoordinatorCreatedEvent{}))
 	assert.Equal(t, State_Idle, c.GetCurrentState())
-	assert.NotEmpty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must populate the priority list")
+	assert.NotEmpty(t, c.coordinatorPriorityList, "calculateCoordinatorPriorities must populate the priority list")
 }
 
 func TestCoordinator_WhenIdle_TransitionsToObserving_OnHeartbeatFromCurrentActive(t *testing.T) {
@@ -168,6 +168,7 @@ func TestCoordinator_WhenIdleAndTransactionsDelegatedToSelf_TransitionsToActive(
 		EndorserCandidates("node2"). // gives action_SendHeartbeat a recipient
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	event := &TransactionsDelegatedEvent{
 		FromNode:     "senderNode",
 		Originator:   "sender@senderNode",
@@ -180,37 +181,6 @@ func TestCoordinator_WhenIdleAndTransactionsDelegatedToSelf_TransitionsToActive(
 	assert.True(t, mocks.SentMessageRecorder.HasSentHeartbeat(), "OnTransitionTo Active must send an immediate heartbeat")
 }
 
-func TestCoordinator_WhenIdle_NewBlock_NewEpoch_UpdatesPriorityListAndStaysIdle(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
-		NodeName("node1").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	assert.Equal(t, State_Idle, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.NotEmpty(t, c.coordinatorPriorityList, "priority list must be populated by action_CalculateCoordinatorPriorities")
-}
-
-func TestCoordinator_WhenIdle_NewBlock_NotNewEpoch_UpdatesBlockHeightAndStaysIdle(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
-		NodeName("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	// Block 120 is in the same epoch as 100 (both in epoch 100/50 = 2), so guard_IsOnEpochBoundary = false.
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 120}))
-	assert.Equal(t, State_Idle, c.GetCurrentState())
-	assert.Equal(t, uint64(120), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.Empty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must NOT run within the same epoch")
-}
 
 func TestCoordinator_WhenIdle_EndorsementRequestReceived_UpdatesActiveCoordinatorAndTransitionsToObserving(t *testing.T) {
 	ctx := t.Context()
@@ -239,6 +209,7 @@ func TestCoordinator_WhenIdle_EndorsementRequestReceived_BlockHeightToleranceExc
 		Build()
 
 	// Block height difference (100 - 0 = 100) exceeds tolerance (10) → rejection.
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -298,6 +269,7 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_HigherPriority_Transiti
 		CoordinatorPriorityList("node1", "node2", "node3").
 		WithMockTransportWriter().
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_ProcessDelegatedTransactions sends an acknowledgment.
 	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	// OnTransitionTo Elect fires action_SendHandoverRequest.
@@ -320,6 +292,7 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_LowerPriority_RejectsAn
 		CoordinatorPriorityList("node1", "node2", "node3").
 		WithMockTransportWriter().
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_RejectDelegationRequest sends a rejection naming the current active coordinator.
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-1", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -332,36 +305,6 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_LowerPriority_RejectsAn
 	assert.Equal(t, State_Observing, c.GetCurrentState())
 }
 
-func TestCoordinator_WhenObserving_NewBlock_UpdatesPriorityListAndStaysObserving(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Observing).
-		NodeName("node2").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	// NewBlock at 150: epoch 100/50=2 → 150/50=3 — crosses boundary; action_CalculateCoordinatorPriorities fires
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	// No transition to Elect — epoch change alone does not initiate a handover.
-	assert.Equal(t, State_Observing, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.NotEmpty(t, c.coordinatorPriorityList, "priority list must be populated by action_CalculateCoordinatorPriorities")
-}
-
-func TestCoordinator_WhenObserving_NewBlock_NotNewEpoch_UpdatesBlockHeightAndStaysObserving(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Observing).
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		Build()
-	// Block 120 is in the same epoch as 100 → guard_IsOnEpochBoundary = false.
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 120}))
-	assert.Equal(t, State_Observing, c.GetCurrentState())
-	assert.Equal(t, uint64(120), c.currentBlockHeight)
-	assert.Empty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must NOT run within the same epoch")
-}
 
 func TestCoordinator_WhenObserving_EndorsementRequestReceived_UpdatesActiveCoordinatorAndStaysObserving(t *testing.T) {
 	ctx := t.Context()
@@ -389,6 +332,7 @@ func TestCoordinator_WhenObserving_EndorsementRequestReceived_BlockHeightToleran
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -696,10 +640,11 @@ func TestCoordinator_WhenElect_HandoverRequest_HigherPriority_NoDispatched_Trans
 
 func TestCoordinator_WhenElect_DelegatedTransactions_AcceptsAndStaysElect(t *testing.T) {
 	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Elect).
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Elect).
 		NodeName("node1").
 		CurrentActiveCoordinator("node2").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -708,23 +653,6 @@ func TestCoordinator_WhenElect_DelegatedTransactions_AcceptsAndStaysElect(t *tes
 	assert.Equal(t, State_Elect, c.GetCurrentState())
 }
 
-func TestCoordinator_WhenElect_NewBlock_UpdatesPriorityListAndStaysElect(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Elect).
-		NodeName("node1").
-		CurrentActiveCoordinator("prev").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	// No transition — epoch change has no exit condition in Elect.
-	assert.Equal(t, State_Elect, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	// action_CalculateCoordinatorPriorities updated the priority list
-	assert.NotEmpty(t, c.coordinatorPriorityList)
-}
 
 func TestCoordinator_WhenElect_TransactionStateTransition_ToFinal_CleansUpAndStaysElect(t *testing.T) {
 	ctx := t.Context()
@@ -832,6 +760,7 @@ func TestCoordinator_WhenElect_EndorsementRequestReceived_LowerPriority_RejectsA
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
@@ -858,6 +787,7 @@ func TestCoordinator_WhenElect_EndorsementRequestReceived_BlockHeightToleranceEx
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -1133,10 +1063,11 @@ func TestCoordinator_WhenPrepared_HandoverRequest_HigherPriority_NoDispatched_Tr
 
 func TestCoordinator_WhenPrepared_DelegatedTransactions_AcceptsAndStaysPrepared(t *testing.T) {
 	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Prepared).
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Prepared).
 		NodeName("node1").
 		CurrentActiveCoordinator("node2").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -1145,21 +1076,6 @@ func TestCoordinator_WhenPrepared_DelegatedTransactions_AcceptsAndStaysPrepared(
 	assert.Equal(t, State_Prepared, c.GetCurrentState())
 }
 
-func TestCoordinator_WhenPrepared_NewBlock_NewEpoch_UpdatesPriorityListAndStaysPrepared(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Prepared).
-		NodeName("node1").
-		CurrentActiveCoordinator("node2").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	assert.Equal(t, State_Prepared, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.NotEmpty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must have run")
-}
 
 func TestCoordinator_WhenPrepared_TransactionStateTransition_ToFinal_CleansUpAndStaysPrepared(t *testing.T) {
 	ctx := t.Context()
@@ -1289,6 +1205,7 @@ func TestCoordinator_WhenPrepared_EndorsementRequestReceived_LowerPriority_Rejec
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
@@ -1313,6 +1230,7 @@ func TestCoordinator_WhenPrepared_EndorsementRequestReceived_BlockHeightToleranc
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -1483,10 +1401,11 @@ func TestCoordinator_WhenActive_HandoverRequest_HigherPriority_NoDispatched_Tran
 
 func TestCoordinator_WhenActive_DelegatedTransactions_AcceptsAndStaysActive(t *testing.T) {
 	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Active).
 		NodeName("node1").
 		CurrentActiveCoordinator("node1").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -1614,12 +1533,13 @@ func TestCoordinator_WhenActiveAndEpochChangesWithSigningUsedAndInflightDispatch
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
 		NodeName("node1").
 		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
+		CurrentBlockHeight(150). // effectiveBlockHeight is already updated by getAndRefreshBlockHeight
 		CoordinatorSelectionBlockRange(50).
 		SigningIdentityUsed(true). // a transaction used the signing identity since the last rotation
 		Transactions(txDispatched).
 		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
+	// EpochBoundaryReachedEvent is queued by getAndRefreshBlockHeight when the epoch changes.
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &EpochBoundaryReachedEvent{}))
 	// guard_SigningIdentityUsed = true, guard_FlushComplete = false → key-rotation Active_Flush
 	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
 }
@@ -1634,7 +1554,7 @@ func TestCoordinator_WhenActiveAndEpochChangesWithSigningUsedAndOnlyPooledTxs_Ro
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
 		NodeName("node2").
 		CurrentActiveCoordinator("node2").
-		CurrentBlockHeight(100).
+		CurrentBlockHeight(150). // effectiveBlockHeight is already updated by getAndRefreshBlockHeight
 		CoordinatorSelectionBlockRange(50).
 		SigningIdentityUsed(true). // a transaction retrieved the signing identity since the last rotation
 		PooledTransactions(pooledTx).
@@ -1642,7 +1562,8 @@ func TestCoordinator_WhenActiveAndEpochChangesWithSigningUsedAndOnlyPooledTxs_Ro
 		Build()
 	prevIdentity := c.signingIdentity.value
 	require.Equal(t, 1, len(c.transactionsByID), "pooled tx must be registered before event")
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
+	// EpochBoundaryReachedEvent is queued by getAndRefreshBlockHeight when the epoch changes.
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &EpochBoundaryReachedEvent{}))
 	// guard_SigningIdentityUsed = true, guard_FlushComplete = true → action_NewSigningIdentity (in-place rotation)
 	assert.Equal(t, State_Active, c.GetCurrentState(), "key-rotation does not change state when flush is already complete")
 	// action_NewSigningIdentity rotated the key in place
@@ -1658,36 +1579,22 @@ func TestCoordinator_WhenActiveAndEpochChanges_SigningNotUsed_StaysActiveAndRota
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
 		NodeName("node1").
 		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
+		CurrentBlockHeight(150). // effectiveBlockHeight is already updated by getAndRefreshBlockHeight
 		CoordinatorSelectionBlockRange(50).
 		EndorserCandidates("node1", "node2", "node3").
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		Build()
 	prevIdentity := c.signingIdentity.value
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
+	// EpochBoundaryReachedEvent is queued by getAndRefreshBlockHeight when the epoch changes.
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &EpochBoundaryReachedEvent{}))
 	assert.Equal(t, State_Active, c.GetCurrentState())
 	// Key is rotated on every epoch boundary, even when it was not used
 	assert.NotEqual(t, prevIdentity, c.signingIdentity.value, "signing identity must be rotated on every epoch boundary")
-	// action_CalculateCoordinatorPriorities updated the priority list
-	assert.NotEmpty(t, c.coordinatorPriorityList, "priority list must be populated")
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "block height must be updated")
+	// Note: calculateCoordinatorPriorities is called in getAndRefreshBlockHeight (before the event),
+	// not in the EpochBoundaryReachedEvent handler. effectiveBlockHeight is already set.
+	assert.Equal(t, uint64(150), c.effectiveBlockHeight, "effective block height must have been set by builder")
 }
 
-func TestCoordinator_WhenActive_NewBlock_NotNewEpoch_UpdatesBlockHeightOnlyAndStaysActive(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Active).
-		NodeName("node1").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50). // epoch = 100/50 = 2
-		Build()
-	prevPriorityList := c.coordinatorPriorityList
-	// BlockHeight 120 is in the same epoch as 100 (120/50 = 2 == 100/50 = 2)
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 120}))
-	assert.Equal(t, State_Active, c.GetCurrentState())
-	assert.Equal(t, uint64(120), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.Equal(t, prevPriorityList, c.coordinatorPriorityList, "priority list must not change within an epoch")
-}
 
 func TestCoordinator_WhenActive_RestartDispatchLoop_StaysActive(t *testing.T) {
 	ctx := t.Context()
@@ -1761,6 +1668,7 @@ func TestCoordinator_WhenActive_EndorsementRequestReceived_LowerPriority_Rejects
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
@@ -1789,6 +1697,7 @@ func TestCoordinator_WhenActive_EndorsementRequestReceived_BlockHeightToleranceE
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -1887,10 +1796,11 @@ func TestCoordinator_WhenActiveFLush_HandoverRequest_HigherPriority_NoDispatched
 
 func TestCoordinator_WhenActiveFLush_DelegatedTransactions_AcceptsAndStaysActiveFLush(t *testing.T) {
 	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Active_Flush).
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Active_Flush).
 		NodeName("node1").
 		CurrentActiveCoordinator("node1").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -2001,41 +1911,6 @@ func TestCoordinator_WhenActiveFLush_TransactionStateTransition_ToFinal_WithMore
 	assert.Equal(t, 1, len(c.transactionsByID))
 }
 
-func TestCoordinator_WhenActiveFlushing_AndNewEpochArrives_UpdatesHeightAndPriorityListButStaysActiveFLush(t *testing.T) {
-	ctx := t.Context()
-	txDispatched, _ := newDispatchedTxMock(t)
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Active_Flush).
-		NodeName("node1").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Transactions(txDispatched).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight)
-	assert.NotEmpty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must recompute the priority list")
-}
-
-func TestCoordinator_WhenActiveFLush_NewBlock_NotNewEpoch_UpdatesBlockHeightAndStaysActiveFLush(t *testing.T) {
-	ctx := t.Context()
-	txDispatched, _ := newDispatchedTxMock(t)
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Active_Flush).
-		NodeName("node1").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50). // epoch = 100/50 = 2
-		Transactions(txDispatched).
-		Build()
-	prevPriorityList := c.coordinatorPriorityList
-	// BlockHeight 120 is in the same epoch as 100 (120/50 = 2)
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 120}))
-	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
-	assert.Equal(t, uint64(120), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.Equal(t, prevPriorityList, c.coordinatorPriorityList, "priority list must not change within an epoch")
-}
 
 func TestCoordinator_WhenActiveFLush_EndorsementRequestReceived_HigherPriority_TransitionsToClosingFlush(t *testing.T) {
 	ctx := t.Context()
@@ -2079,6 +1954,7 @@ func TestCoordinator_WhenActiveFlush_EndorsementRequestReceived_LowerPriority_Re
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
@@ -2103,6 +1979,7 @@ func TestCoordinator_WhenActiveFLush_EndorsementRequestReceived_BlockHeightToler
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -2200,6 +2077,7 @@ func TestCoordinator_WhenClosingFlush_DelegatedTransactions_HigherPriority_Trans
 		WithMockTransportWriter().
 		Transactions(txDispatched).
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
@@ -2220,6 +2098,7 @@ func TestCoordinator_WhenClosingFlush_DelegatedTransactions_LowerPriority_Reject
 		WithMockTransportWriter().
 		Transactions(txDispatched).
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-2", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
@@ -2286,23 +2165,6 @@ func TestCoordinator_WhenClosingFlush_TransactionStateTransition_ToFinal_WithMor
 	assert.Equal(t, 1, len(c.transactionsByID))
 }
 
-func TestCoordinator_WhenClosingFlush_NewBlock_UpdatesBlockHeightAndStaysClosingFlush(t *testing.T) {
-	ctx := t.Context()
-	txDispatched, _ := newDispatchedTxMock(t)
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing_Flush).
-		NodeName("node1").
-		CurrentActiveCoordinator("node2").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Transactions(txDispatched).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	assert.Equal(t, State_Closing_Flush, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	assert.NotEmpty(t, c.coordinatorPriorityList, "action_CalculateCoordinatorPriorities must have run on epoch boundary")
-}
 
 func TestCoordinator_WhenClosingFlushCompletesAndNotCurrentCoordinator_EnteringClosingEmitsImmediateHeartbeat(t *testing.T) {
 	ctx := t.Context()
@@ -2350,6 +2212,7 @@ func TestCoordinator_WhenClosingFlush_EndorsementRequestReceived_BlockHeightTole
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -2512,6 +2375,7 @@ func TestCoordinator_WhenClosing_DelegationRequest_HigherPriorityThanCurrentActi
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		WithMockTransportWriter().
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_ProcessDelegatedTransactions always sends an acknowledgment (even for empty transaction lists).
 	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil)
@@ -2536,6 +2400,7 @@ func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoord
 		InactiveGracePeriod(5). // 0 < 5 → not exceeded
 		WithMockTransportWriter().
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-3", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
@@ -2548,13 +2413,14 @@ func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoord
 
 func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoordinatorGone_TransitionsToActive(t *testing.T) {
 	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Closing).
 		NodeName("node3").
 		CurrentActiveCoordinator("node1").
 		CoordinatorPriorityList("node1", "node2", "node3").
 		HeartbeatIntervalsSinceLastReceive(5).
 		InactiveGracePeriod(5). // 5 >= 5 → exceeded
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -2586,23 +2452,6 @@ func TestCoordinator_WhenClosing_TransactionStateTransition_ToFinal_CleansUpAndS
 	assert.Empty(t, c.transactionsByID, "action_CleanUpTransaction must remove the finalised transaction")
 }
 
-func TestCoordinator_WhenClosing_NewBlock_UpdatesPriorityListAndStaysClosing(t *testing.T) {
-	ctx := t.Context()
-	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
-		NodeName("node2").
-		CurrentActiveCoordinator("node1").
-		CurrentBlockHeight(100).
-		CoordinatorSelectionBlockRange(50).
-		EndorserCandidates("node1", "node2", "node3").
-		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
-		Build()
-	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 150}))
-	// No transition — epoch change alone has no exit condition in Closing.
-	assert.Equal(t, State_Closing, c.GetCurrentState())
-	assert.Equal(t, uint64(150), c.currentBlockHeight, "action_UpdateBlockHeight must have run")
-	// action_CalculateCoordinatorPriorities re-ran and updated the priority list
-	assert.NotEmpty(t, c.coordinatorPriorityList, "priority list must be populated")
-}
 
 func TestCoordinator_WhenClosing_EndorsementRequestReceived_UpdatesActiveCoordinatorAndStaysClosing(t *testing.T) {
 	ctx := t.Context()
@@ -2630,6 +2479,7 @@ func TestCoordinator_WhenClosing_EndorsementRequestReceived_BlockHeightTolerance
 		WithMockTransportWriter().
 		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
@@ -2682,8 +2532,8 @@ func TestCoordinator_PreProcessEvent_OwnHeartbeat_IsFilteredOut(t *testing.T) {
 }
 
 // newLowerPriorityEndorsementEvent creates a minimal EndorsementRequestReceivedEvent that passes
-// the block height check (CoordinatorBlockHeight matches currentBlockHeight=0) but fails the
-// higher-priority check, triggering action_RejectEndorsementEndorserIsActiveCoordinator.
+// the block height check (CoordinatorBlockHeight=0 is within tolerance of the live height=0) but
+// fails the higher-priority check, triggering action_RejectEndorsementEndorserIsActiveCoordinator.
 func newLowerPriorityEndorsementEvent(fromNode string) *EndorsementRequestReceivedEvent {
 	return &EndorsementRequestReceivedEvent{
 		FromNode:                  fromNode,
@@ -2692,12 +2542,12 @@ func newLowerPriorityEndorsementEvent(fromNode string) *EndorsementRequestReceiv
 		Party:                     "party@" + fromNode,
 		PrivateEndorsementRequest: &components.PrivateTransactionEndorseRequest{},
 		AttestationRequest:        &prototk.AttestationRequest{Name: "att-lp"},
-		CoordinatorBlockHeight:    0, // matches currentBlockHeight=0, so block height check passes
+		CoordinatorBlockHeight:    0, // within tolerance of live height=0, so block height check passes
 	}
 }
 
 // newBlockHeightExceedingEndorsementEvent creates a minimal EndorsementRequestReceivedEvent
-// where CoordinatorBlockHeight=0. When the coordinator's currentBlockHeight is 100 and
+// where CoordinatorBlockHeight=0. When the coordinator's live block height is 100 and
 // blockHeightTolerance is 10, the difference (100) exceeds the tolerance, triggering
 // action_RejectEndorsementBlockHeight instead of action_HandleEndorsementRequest.
 // No key-manager mock is needed because the background goroutine never launches.
@@ -2709,7 +2559,7 @@ func newBlockHeightExceedingEndorsementEvent(fromNode string) *EndorsementReques
 		Party:                     "party@" + fromNode,
 		PrivateEndorsementRequest: &components.PrivateTransactionEndorseRequest{},
 		AttestationRequest:        &prototk.AttestationRequest{Name: "att-bh"},
-		CoordinatorBlockHeight:    0, // far from the coordinator's currentBlockHeight of 100
+		CoordinatorBlockHeight:    0, // far from the coordinator's live height of 100
 	}
 }
 
@@ -2725,6 +2575,9 @@ func newEndorsementEventForStateMachineTest(t *testing.T, fromNode string, mocks
 	mockKeyManager.On("ResolveKeyNewDatabaseTX", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("test: goroutine exit early")).Maybe()
 	mocks.AllComponents.On("KeyManager").Return(mockKeyManager).Maybe()
+
+	// Block-height tolerance validators (MatchAll) call GetBlockHeight for every endorsement event.
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 
 	return &EndorsementRequestReceivedEvent{
 		FromNode:                  fromNode,

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/grapher"
-	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/statevisibilitytracker"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/statemachine"
 	"github.com/LFDT-Paladin/paladin/core/mocks/componentsmocks"
 	"github.com/LFDT-Paladin/paladin/core/mocks/coordinatortransactionmocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
@@ -181,6 +181,28 @@ func TestCoordinator_WhenIdleAndTransactionsDelegatedToSelf_TransitionsToActive(
 	assert.True(t, mocks.SentMessageRecorder.HasSentHeartbeat(), "OnTransitionTo Active must send an immediate heartbeat")
 }
 
+func TestCoordinator_WhenIdle_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysIdle(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Idle).
+		NodeName("node1").
+		CurrentActiveCoordinator("node1").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	// action_RefreshBlockHeight fetches the live height and stores it in c.currentBlockHeight.
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	// diff = |100 - 0| = 100 > 10 → block height rejection.
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "node2", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("node2")))
+	assert.Equal(t, State_Idle, c.GetCurrentState())
+}
 
 func TestCoordinator_WhenIdle_EndorsementRequestReceived_UpdatesActiveCoordinatorAndTransitionsToObserving(t *testing.T) {
 	ctx := t.Context()
@@ -305,6 +327,29 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_LowerPriority_RejectsAn
 	assert.Equal(t, State_Observing, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenObserving_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysObserving(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Observing).
+		NodeName("node2").
+		CurrentActiveCoordinator("node1").
+		CoordinatorPriorityList("node1", "node2").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Observing, c.GetCurrentState())
+	// active coordinator must not be updated on a block height rejection
+	assert.Equal(t, "node1", c.currentActiveCoordinator)
+}
 
 func TestCoordinator_WhenObserving_EndorsementRequestReceived_UpdatesActiveCoordinatorAndStaysObserving(t *testing.T) {
 	ctx := t.Context()
@@ -653,6 +698,29 @@ func TestCoordinator_WhenElect_DelegatedTransactions_AcceptsAndStaysElect(t *tes
 	assert.Equal(t, State_Elect, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenElect_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysElect(t *testing.T) {
+	// Block height check is evaluated before any delegation processing — even a valid originator
+	// is rejected if the height difference exceeds tolerance.
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Elect).
+		NodeName("node1").
+		CurrentActiveCoordinator("node2").
+		CoordinatorPriorityList("node1", "node2").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Elect, c.GetCurrentState())
+}
 
 func TestCoordinator_WhenElect_TransactionStateTransition_ToFinal_CleansUpAndStaysElect(t *testing.T) {
 	ctx := t.Context()
@@ -1076,6 +1144,27 @@ func TestCoordinator_WhenPrepared_DelegatedTransactions_AcceptsAndStaysPrepared(
 	assert.Equal(t, State_Prepared, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenPrepared_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysPrepared(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Prepared).
+		NodeName("node1").
+		CurrentActiveCoordinator("node2").
+		CoordinatorPriorityList("node1", "node2").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Prepared, c.GetCurrentState())
+}
 
 func TestCoordinator_WhenPrepared_TransactionStateTransition_ToFinal_CleansUpAndStaysPrepared(t *testing.T) {
 	ctx := t.Context()
@@ -1414,6 +1503,27 @@ func TestCoordinator_WhenActive_DelegatedTransactions_AcceptsAndStaysActive(t *t
 	assert.Equal(t, State_Active, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenActive_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysActive(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Active).
+		NodeName("node1").
+		CurrentActiveCoordinator("node1").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Active, c.GetCurrentState())
+}
+
 func TestCoordinator_WhenActive_TransactionStateTransition_DispatchedToPooled_WithAssembling_CancelsAssembling(t *testing.T) {
 	ctx := t.Context()
 	txAssembling := coordinatortransactionmocks.NewCoordinatorTransaction(t)
@@ -1594,7 +1704,6 @@ func TestCoordinator_WhenActiveAndEpochChanges_SigningNotUsed_StaysActiveAndRota
 	// not in the EpochBoundaryReachedEvent handler. effectiveBlockHeight is already set.
 	assert.Equal(t, uint64(150), c.effectiveBlockHeight, "effective block height must have been set by builder")
 }
-
 
 func TestCoordinator_WhenActive_RestartDispatchLoop_StaysActive(t *testing.T) {
 	ctx := t.Context()
@@ -1809,6 +1918,27 @@ func TestCoordinator_WhenActiveFLush_DelegatedTransactions_AcceptsAndStaysActive
 	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenActiveFLush_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysActiveFlush(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Active_Flush).
+		NodeName("node1").
+		CurrentActiveCoordinator("node1").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
+}
+
 func TestCoordinator_WhenActiveFLushCompletesAndStillCurrentCoordinator_TransitionsToActive(t *testing.T) {
 	ctx := t.Context()
 	txDispatched, txID := newDispatchedTxMock(t)
@@ -1910,7 +2040,6 @@ func TestCoordinator_WhenActiveFLush_TransactionStateTransition_ToFinal_WithMore
 	assert.Equal(t, State_Active_Flush, c.GetCurrentState())
 	assert.Equal(t, 1, len(c.transactionsByID))
 }
-
 
 func TestCoordinator_WhenActiveFLush_EndorsementRequestReceived_HigherPriority_TransitionsToClosingFlush(t *testing.T) {
 	ctx := t.Context()
@@ -2108,6 +2237,30 @@ func TestCoordinator_WhenClosingFlush_DelegatedTransactions_LowerPriority_Reject
 	assert.Equal(t, State_Closing_Flush, c.GetCurrentState())
 }
 
+func TestCoordinator_WhenClosingFlush_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysClosingFlush(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Closing_Flush).
+		NodeName("node2").
+		CurrentActiveCoordinator("node1").
+		CoordinatorPriorityList("node1", "node2").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Closing_Flush, c.GetCurrentState())
+	// active coordinator must not be updated on a block height rejection
+	assert.Equal(t, "node1", c.currentActiveCoordinator)
+}
+
 func TestCoordinator_WhenClosingFlushCompletesAndNotCurrentCoordinator_TransitionsToClosing(t *testing.T) {
 	ctx := t.Context()
 	txDispatched, txID := newDispatchedTxMock(t)
@@ -2164,7 +2317,6 @@ func TestCoordinator_WhenClosingFlush_TransactionStateTransition_ToFinal_WithMor
 	assert.Equal(t, State_Closing_Flush, c.GetCurrentState())
 	assert.Equal(t, 1, len(c.transactionsByID))
 }
-
 
 func TestCoordinator_WhenClosingFlushCompletesAndNotCurrentCoordinator_EnteringClosingEmitsImmediateHeartbeat(t *testing.T) {
 	ctx := t.Context()
@@ -2432,6 +2584,30 @@ func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoord
 	assert.NotEmpty(t, c.signingIdentity.value, "OnTransitionTo Active must call action_NewSigningIdentity")
 }
 
+func TestCoordinator_WhenClosing_TransactionsDelegated_BlockHeightToleranceExceeded_RejectsAndStaysClosing(t *testing.T) {
+	ctx := t.Context()
+	c, mocks := NewCoordinatorBuilderForTesting(t, State_Closing).
+		NodeName("node2").
+		CurrentActiveCoordinator("node1").
+		CoordinatorPriorityList("node1", "node2").
+		CurrentBlockHeight(100).
+		BlockHeightTolerance(10).
+		WithMockTransportWriter().
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, "originator-node", "del-bh-test",
+		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		"", int64(0), int64(100), int64(10),
+	).Return(nil)
+
+	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
+	assert.Equal(t, State_Closing, c.GetCurrentState())
+	// active coordinator must not be updated on a block height rejection
+	assert.Equal(t, "node1", c.currentActiveCoordinator)
+}
+
 func TestCoordinator_WhenClosing_TransactionStateTransition_ToFinal_CleansUpAndStaysClosing(t *testing.T) {
 	ctx := t.Context()
 	txFinal := coordinatortransactionmocks.NewCoordinatorTransaction(t)
@@ -2451,7 +2627,6 @@ func TestCoordinator_WhenClosing_TransactionStateTransition_ToFinal_CleansUpAndS
 	assert.Equal(t, State_Closing, c.GetCurrentState())
 	assert.Empty(t, c.transactionsByID, "action_CleanUpTransaction must remove the finalised transaction")
 }
-
 
 func TestCoordinator_WhenClosing_EndorsementRequestReceived_UpdatesActiveCoordinatorAndStaysClosing(t *testing.T) {
 	ctx := t.Context()
@@ -2563,6 +2738,19 @@ func newBlockHeightExceedingEndorsementEvent(fromNode string) *EndorsementReques
 	}
 }
 
+// newDelegationBlockHeightExceedingEvent creates a TransactionsDelegatedEvent where
+// OriginatorsBlockHeight=0. When the coordinator's stored block height is 100 and
+// blockHeightTolerance is 10, the difference (100) exceeds the tolerance, triggering
+// action_RejectDelegationRequestBlockHeight instead of action_ProcessDelegatedTransactions.
+func newDelegationBlockHeightExceedingEvent(fromNode string) *TransactionsDelegatedEvent {
+	return &TransactionsDelegatedEvent{
+		FromNode:               fromNode,
+		Originator:             "sender@" + fromNode,
+		DelegationID:           "del-bh-test",
+		OriginatorsBlockHeight: 0, // far from coordinator's stored height of 100
+	}
+}
+
 // newEndorsementEventForStateMachineTest creates an EndorsementRequestReceivedEvent and
 // wires the coordinator's mocks so the background endorsement goroutine exits immediately
 // (at party key resolution) without touching SendEndorsementResponse.  All mock expectations
@@ -2576,7 +2764,7 @@ func newEndorsementEventForStateMachineTest(t *testing.T, fromNode string, mocks
 		Return(nil, fmt.Errorf("test: goroutine exit early")).Maybe()
 	mocks.AllComponents.On("KeyManager").Return(mockKeyManager).Maybe()
 
-	// Block-height tolerance validators (MatchAll) call GetBlockHeight for every endorsement event.
+	// action_RefreshBlockHeight calls GetBlockHeight for every endorsement and delegation event.
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 
 	return &EndorsementRequestReceivedEvent{

--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -122,7 +122,7 @@ func (t *coordinatorTransaction) sendAssembleRequest(ctx context.Context) error 
 			return err
 		}
 
-		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getCurrentBlockHeight(), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
+		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getBlockHeight(ctx), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
 	})
 
 	t.scheduleRequestTimeout(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -122,7 +122,7 @@ func (t *coordinatorTransaction) sendAssembleRequest(ctx context.Context) error 
 			return err
 		}
 
-		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getCurrentBlockHeight(ctx), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
+		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getBlockHeight(), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
 	})
 
 	t.scheduleRequestTimeout(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -122,7 +122,7 @@ func (t *coordinatorTransaction) sendAssembleRequest(ctx context.Context) error 
 			return err
 		}
 
-		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getBlockHeight(ctx), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
+		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getCurrentBlockHeight(ctx), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
 	})
 
 	t.scheduleRequestTimeout(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -220,7 +220,7 @@ func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempot
 		toEndorsableList(t.pt.PostAssembly.OutputStates),
 		toEndorsableList(t.pt.PostAssembly.InfoStates),
 		t.clock.Now().Add(t.stateTimeout),
-		t.getBlockHeight(ctx),
+		t.getCurrentBlockHeight(ctx),
 		int64(t.blockHeightTolerance),
 	)
 	if err != nil {

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -206,7 +206,6 @@ func (t *coordinatorTransaction) resetEndorsementRequests(ctx context.Context) {
 }
 
 func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest) error {
-	blockHeight := t.getCurrentBlockHeight()
 	err := t.transportWriter.SendEndorsementRequest(
 		ctx,
 		t.pt.ID,
@@ -221,7 +220,7 @@ func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempot
 		toEndorsableList(t.pt.PostAssembly.OutputStates),
 		toEndorsableList(t.pt.PostAssembly.InfoStates),
 		t.clock.Now().Add(t.stateTimeout),
-		blockHeight,
+		t.getBlockHeight(ctx),
 		int64(t.blockHeightTolerance),
 	)
 	if err != nil {

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -220,7 +220,7 @@ func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempot
 		toEndorsableList(t.pt.PostAssembly.OutputStates),
 		toEndorsableList(t.pt.PostAssembly.InfoStates),
 		t.clock.Now().Add(t.stateTimeout),
-		t.getCurrentBlockHeight(ctx),
+		t.getBlockHeight(),
 		int64(t.blockHeightTolerance),
 	)
 	if err != nil {
@@ -244,6 +244,11 @@ func toEndorsableList(states []*components.FullState) []*prototk.EndorsableState
 func action_Endorsed(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*EndorsedEvent)
 	return t.applyEndorsement(ctx, e.Endorsement, e.RequestID)
+}
+
+func action_RefreshBlockHeight(ctx context.Context, txn *coordinatorTransaction, _ common.Event) error {
+	txn.refreshBlockHeight(ctx)
+	return nil
 }
 
 func action_SendEndorsementRequests(ctx context.Context, txn *coordinatorTransaction, _ common.Event) error {

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/mocks/graphermocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -330,6 +331,56 @@ func Test_EndorsementCompletion_ResetsRequests_OnTransitionToBlocked(t *testing.
 // ── Endorsement Threshold Tests ───────────────────────────────────────────────
 
 // threshold=0 (unset): all parties must endorse — preserves existing behaviour.
+func Test_unfulfilledEndorsementRequirements_NilPostAssembly_ReturnsEmpty(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).Build()
+	txn.pt.PostAssembly = nil
+	unfulfilled := txn.unfulfilledEndorsementRequirements(ctx)
+	assert.Empty(t, unfulfilled)
+}
+
+func Test_extractEndorserNodes_NilPostAssembly_ReturnsEmpty(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).Build()
+	txn.pt.PostAssembly = nil
+	nodes := txn.extractEndorserNodes(ctx)
+	assert.Empty(t, nodes)
+}
+
+
+func Test_action_RecordEndorseFailure_EndorserIsActiveCoordinator_LogsWarning(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		AddPendingEndorsementRequest().
+		Build()
+
+	event := &EndorseRequestRejectedEvent{
+		AttestationRequestName: "endorse-0",
+		Party:                  "party1@node2",
+		RejectionReason:        engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
+	}
+	err := action_RecordEndorseFailure(ctx, txn, event)
+	require.NoError(t, err)
+}
+
+func Test_action_RecordEndorseFailure_BlockHeightTolerance_LogsWarning(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		AddPendingEndorsementRequest().
+		Build()
+
+	event := &EndorseRequestRejectedEvent{
+		AttestationRequestName: "endorse-0",
+		Party:                  "party1@node2",
+		RejectionReason:        engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		CoordinatorBlockHeight: 100,
+		EndorserBlockHeight:    200,
+		BlockHeightTolerance:   10,
+	}
+	err := action_RecordEndorseFailure(ctx, txn, event)
+	require.NoError(t, err)
+}
+
 func Test_unfulfilledEndorsementRequirements_ThresholdUnset_AllPartiesRequired(t *testing.T) {
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).Build()

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -253,6 +253,7 @@ var stateDefinitionsMap = StateDefinitions{
 	State_Assembling: {
 		OnTransitionTo: []ActionRule{
 			{Action: action_ScheduleStateTimeout},
+			{Action: action_RefreshBlockHeight},
 			{Action: action_SendAssembleRequest},
 		},
 		Events: map[EventType]EventHandlers{
@@ -415,6 +416,7 @@ var stateDefinitionsMap = StateDefinitions{
 		OnTransitionTo: []ActionRule{
 			{Action: action_ScheduleStateTimeout},
 			{Action: action_ComputeEndorseTolerances},
+			{Action: action_RefreshBlockHeight},
 			{Action: action_SendEndorsementRequests},
 		},
 		Events: map[EventType]EventHandlers{

--- a/core/go/internal/sequencer/coordinator/transaction/transaction.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction.go
@@ -94,7 +94,7 @@ type coordinatorTransaction struct {
 	stateVisibilityTracker            statevisibilitytracker.StateVisibilityStore
 	dependencyTracker                 dependencytracker.DependencyTracker
 	engineIntegration                 common.EngineIntegration
-	getCurrentBlockHeight             func() int64 // returns the coordinator's tracked block height
+	getBlockHeight                    func(ctx context.Context) int64
 	blockHeightTolerance              uint64
 	syncPoints                        syncpoints.SyncPoints
 	components                        components.AllComponents
@@ -120,7 +120,7 @@ func NewTransaction(ctx context.Context,
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getCurrentBlockHeight func() int64,
+	getBlockHeight func(ctx context.Context) int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -150,7 +150,7 @@ func NewTransaction(ctx context.Context,
 		getCoordinatorTransactionState,
 		notifyEndorserCandidates,
 		engineIntegration,
-		getCurrentBlockHeight,
+		getBlockHeight,
 		blockHeightTolerance,
 		syncPoints,
 		allComponents,
@@ -182,7 +182,7 @@ func newTransaction(
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getCurrentBlockHeight func() int64,
+	getBlockHeight func(ctx context.Context) int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -212,7 +212,7 @@ func newTransaction(
 		getCoordinatorTransactionState:    getCoordinatorTransactionState,
 		notifyEndorserCandidates:          notifyEndorserCandidates,
 		engineIntegration:                 engineIntegration,
-		getCurrentBlockHeight:             getCurrentBlockHeight,
+		getBlockHeight:                    getBlockHeight,
 		blockHeightTolerance:              blockHeightTolerance,
 		syncPoints:                        syncPoints,
 		components:                        allComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction.go
@@ -94,7 +94,7 @@ type coordinatorTransaction struct {
 	stateVisibilityTracker            statevisibilitytracker.StateVisibilityStore
 	dependencyTracker                 dependencytracker.DependencyTracker
 	engineIntegration                 common.EngineIntegration
-	getBlockHeight                    func(ctx context.Context) int64
+	getCurrentBlockHeight             func(ctx context.Context) int64
 	blockHeightTolerance              uint64
 	syncPoints                        syncpoints.SyncPoints
 	components                        components.AllComponents
@@ -120,7 +120,7 @@ func NewTransaction(ctx context.Context,
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getBlockHeight func(ctx context.Context) int64,
+	getCurrentBlockHeight func(ctx context.Context) int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -150,7 +150,7 @@ func NewTransaction(ctx context.Context,
 		getCoordinatorTransactionState,
 		notifyEndorserCandidates,
 		engineIntegration,
-		getBlockHeight,
+		getCurrentBlockHeight,
 		blockHeightTolerance,
 		syncPoints,
 		allComponents,
@@ -182,7 +182,7 @@ func newTransaction(
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getBlockHeight func(ctx context.Context) int64,
+	getCurrentBlockHeight func(ctx context.Context) int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -212,7 +212,7 @@ func newTransaction(
 		getCoordinatorTransactionState:    getCoordinatorTransactionState,
 		notifyEndorserCandidates:          notifyEndorserCandidates,
 		engineIntegration:                 engineIntegration,
-		getBlockHeight:                    getBlockHeight,
+		getCurrentBlockHeight:             getCurrentBlockHeight,
 		blockHeightTolerance:              blockHeightTolerance,
 		syncPoints:                        syncPoints,
 		components:                        allComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction.go
@@ -94,7 +94,8 @@ type coordinatorTransaction struct {
 	stateVisibilityTracker            statevisibilitytracker.StateVisibilityStore
 	dependencyTracker                 dependencytracker.DependencyTracker
 	engineIntegration                 common.EngineIntegration
-	getCurrentBlockHeight             func(ctx context.Context) int64
+	refreshBlockHeight                func(context.Context)
+	getBlockHeight                    func() int64
 	blockHeightTolerance              uint64
 	syncPoints                        syncpoints.SyncPoints
 	components                        components.AllComponents
@@ -120,7 +121,8 @@ func NewTransaction(ctx context.Context,
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getCurrentBlockHeight func(ctx context.Context) int64,
+	refreshBlockHeight func(context.Context),
+	getBlockHeight func() int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -150,7 +152,8 @@ func NewTransaction(ctx context.Context,
 		getCoordinatorTransactionState,
 		notifyEndorserCandidates,
 		engineIntegration,
-		getCurrentBlockHeight,
+		refreshBlockHeight,
+		getBlockHeight,
 		blockHeightTolerance,
 		syncPoints,
 		allComponents,
@@ -182,7 +185,8 @@ func newTransaction(
 	getCoordinatorTransactionState func(context.Context, uuid.UUID) (State, bool),
 	notifyEndorserCandidates func(context.Context, ...string),
 	engineIntegration common.EngineIntegration,
-	getCurrentBlockHeight func(ctx context.Context) int64,
+	refreshBlockHeight func(context.Context),
+	getBlockHeight func() int64,
 	blockHeightTolerance uint64,
 	syncPoints syncpoints.SyncPoints,
 	allComponents components.AllComponents,
@@ -212,7 +216,8 @@ func newTransaction(
 		getCoordinatorTransactionState:    getCoordinatorTransactionState,
 		notifyEndorserCandidates:          notifyEndorserCandidates,
 		engineIntegration:                 engineIntegration,
-		getCurrentBlockHeight:             getCurrentBlockHeight,
+		getBlockHeight:                    getBlockHeight,
+		refreshBlockHeight:                refreshBlockHeight,
 		blockHeightTolerance:              blockHeightTolerance,
 		syncPoints:                        syncPoints,
 		components:                        allComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
@@ -541,8 +541,8 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 		coordinatorTransactionStateLookup(b.coordinatorTransactions),
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		mocks.EngineIntegration,
-		func(_ context.Context) {},              // refreshBlockHeight: no-op in tests
-		func() int64 { return b.currentBlockHeight }, // getBlockHeight: returns builder-configured cached value
+		func(_ context.Context) {},
+		func() int64 { return b.currentBlockHeight },
 		b.blockHeightTolerance,
 		mocks.SyncPoints,
 		mocks.AllComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
@@ -541,7 +541,8 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 		coordinatorTransactionStateLookup(b.coordinatorTransactions),
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		mocks.EngineIntegration,
-		func(_ context.Context) int64 { return b.currentBlockHeight },
+		func(_ context.Context) {},              // refreshBlockHeight: no-op in tests
+		func() int64 { return b.currentBlockHeight }, // getBlockHeight: returns builder-configured cached value
 		b.blockHeightTolerance,
 		mocks.SyncPoints,
 		mocks.AllComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
@@ -541,7 +541,7 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 		coordinatorTransactionStateLookup(b.coordinatorTransactions),
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		mocks.EngineIntegration,
-		func() int64 { return b.currentBlockHeight },
+		func(_ context.Context) int64 { return b.currentBlockHeight },
 		b.blockHeightTolerance,
 		mocks.SyncPoints,
 		mocks.AllComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
@@ -261,7 +261,7 @@ func TestNewTransaction_Success_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func() int64 { return 0 },
+		func(_ context.Context) int64 { return 0 },
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,
@@ -312,7 +312,7 @@ func TestNewTransaction_PublicAPI_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func() int64 { return 0 },
+		func(_ context.Context) int64 { return 0 },
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
@@ -261,8 +261,8 @@ func TestNewTransaction_Success_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func(_ context.Context) {}, // refreshBlockHeight: no-op
-		func() int64 { return 0 }, // getBlockHeight
+		func(_ context.Context) {},
+		func() int64 { return 0 },
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,
@@ -313,8 +313,8 @@ func TestNewTransaction_PublicAPI_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func(_ context.Context) {}, // refreshBlockHeight: no-op
-		func() int64 { return 0 }, // getBlockHeight
+		func(_ context.Context) {},
+		func() int64 { return 0 },
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_test.go
@@ -261,7 +261,8 @@ func TestNewTransaction_Success_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func(_ context.Context) int64 { return 0 },
+		func(_ context.Context) {}, // refreshBlockHeight: no-op
+		func() int64 { return 0 }, // getBlockHeight
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,
@@ -312,7 +313,8 @@ func TestNewTransaction_PublicAPI_ReturnsTransaction(t *testing.T) {
 		func(ctx context.Context, id uuid.UUID) (State, bool) { return State(0), false },
 		func(context.Context, ...string) {}, // notifyEndorserCandidates
 		sequencercommonmocks.NewEngineIntegration(t),
-		func(_ context.Context) int64 { return 0 },
+		func(_ context.Context) {}, // refreshBlockHeight: no-op
+		func() int64 { return 0 }, // getBlockHeight
 		0,
 		&syncpointsmocks.SyncPoints{},
 		allComponents,

--- a/core/go/internal/sequencer/originator/events_test.go
+++ b/core/go/internal/sequencer/originator/events_test.go
@@ -18,19 +18,8 @@ package originator
 import (
 	"testing"
 
-	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/stretchr/testify/assert"
 )
-
-func Test_NewBlockEvent_Type(t *testing.T) {
-	event := &common.NewBlockEvent{}
-	assert.Equal(t, common.Event_NewBlock, event.Type())
-}
-
-func Test_NewBlockEvent_TypeString(t *testing.T) {
-	event := &common.NewBlockEvent{}
-	assert.Equal(t, "Event_NewBlock", event.TypeString())
-}
 
 func Test_OriginatorEvents_InterfaceCompliance(t *testing.T) {
 	events := []Event{

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 
+	"slices"
+
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
@@ -27,7 +29,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/originator/transaction"
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
-	"slices"
 )
 
 func validator_IsDelegationBlockHeightRejection(_ context.Context, _ *originator, event common.Event) (bool, error) {
@@ -50,8 +51,16 @@ func action_TransactionCreated(ctx context.Context, o *originator, event common.
 	return o.addToTransactions(ctx, e.Transaction, o.newOriginatorTransaction)
 }
 
-func (o *originator) getCurrentBlockHeight() int64 {
-	return int64(o.currentBlockHeight)
+// getAndRefreshBlockHeight queries the live block height, updates effectiveBlockHeight when the
+// epoch changes, and recomputes the priority list.
+func (o *originator) getAndRefreshBlockHeight(ctx context.Context) int64 {
+	liveHeight := o.engineIntegration.GetBlockHeight(ctx)
+	newEffective := common.ComputeEffectiveBlockHeight(uint64(liveHeight), o.blockRange)
+	if newEffective != o.effectiveBlockHeight {
+		o.effectiveBlockHeight = newEffective
+		o.calculateCoordinatorPriorities(ctx)
+	}
+	return liveHeight
 }
 
 func (o *originator) newOriginatorTransaction(ctx context.Context, pt *components.PrivateTransaction) (transaction.OriginatorTransaction, error) {
@@ -62,7 +71,7 @@ func (o *originator) newOriginatorTransaction(ctx context.Context, pt *component
 		o.queueEventInternal,
 		o.engineIntegration,
 		o.metrics,
-		o.getCurrentBlockHeight,
+		o.getAndRefreshBlockHeight,
 	)
 }
 
@@ -90,6 +99,8 @@ func (o *originator) addToTransactions(
 }
 
 func sendDelegationRequest(ctx context.Context, o *originator) error {
+	liveHeight := o.getAndRefreshBlockHeight(ctx)
+
 	// Re-delegate all transactions in the order they were created on the originating node.
 	transactionsToDelegate := make([]*components.PrivateTransaction, 0)
 	for _, txn := range o.transactionsOrdered {
@@ -108,11 +119,18 @@ func sendDelegationRequest(ctx context.Context, o *originator) error {
 
 	log.L(ctx).Debugf("sending delegation request for %d transactions", len(o.transactionsOrdered))
 
-	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, transactionsToDelegate, o.currentBlockHeight)
+	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, transactionsToDelegate, uint64(liveHeight))
 }
 
 func action_SendDelegationRequest(ctx context.Context, o *originator, _ common.Event) error {
 	return sendDelegationRequest(ctx, o)
+}
+
+// action_RefreshBlockHeight queries the live block height and updates effectiveBlockHeight and the
+// priority list if the epoch has changed.
+func action_RefreshBlockHeight(ctx context.Context, o *originator, _ common.Event) error {
+	o.getAndRefreshBlockHeight(ctx)
+	return nil
 }
 
 // resetFailoverIndex sets failoverIndex so the next failover walk step targets the
@@ -264,26 +282,21 @@ func (o *originator) removeTransaction(ctx context.Context, txnID uuid.UUID) {
 	}
 }
 
-func action_UpdateBlockHeight(_ context.Context, o *originator, event common.Event) error {
-	o.currentBlockHeight, o.onEpochBoundary = common.DecodeNewBlockHeight(o.currentBlockHeight, o.blockRange, event)
+func action_CalculateCoordinatorPriorities(ctx context.Context, o *originator, _ common.Event) error {
+	o.calculateCoordinatorPriorities(ctx)
 	return nil
 }
 
-func guard_IsOnEpochBoundary(_ context.Context, o *originator) bool {
-	return o.onEpochBoundary
-}
-
-// action_CalculateCoordinatorPriorities recomputes coordinatorPriorityList from the current
-// endorserCandidates and block height. No-op when endorserCandidates is empty (STATIC/SENDER modes).
-func action_CalculateCoordinatorPriorities(ctx context.Context, o *originator, _ common.Event) error {
+// calculateCoordinatorPriorities recomputes coordinatorPriorityList from the current
+// endorserCandidates and effectiveBlockHeight. No-op when endorserCandidates is empty (STATIC/SENDER modes).
+func (o *originator) calculateCoordinatorPriorities(ctx context.Context) {
 	if len(o.endorserCandidates) == 0 {
-		return nil
+		return
 	}
 	o.coordinatorPriorityList = common.ComputeCoordinatorPriorityList(
 		ctx,
 		o.endorserCandidates,
-		o.currentBlockHeight,
-		o.blockRange,
+		o.effectiveBlockHeight,
 	)
 	if o.currentActiveCoordinator == "" {
 		// this should really only run on start up - after that we never unset the current active coordinator
@@ -292,7 +305,6 @@ func action_CalculateCoordinatorPriorities(ctx context.Context, o *originator, _
 	// whenever we have a new coordinator priority list we want to make sure that a failover walk through the
 	// list, if required, starts from the beginning
 	o.resetFailoverIndex()
-	return nil
 }
 
 // action_UpdateEndorserCandidates replaces the endorser candidates with the full sorted+deduped
@@ -333,8 +345,7 @@ func action_UpdateEndorserCandidatesFromHeartbeat(ctx context.Context, o *origin
 	o.coordinatorPriorityList = common.ComputeCoordinatorPriorityList(
 		ctx,
 		o.endorserCandidates,
-		o.currentBlockHeight,
-		o.blockRange,
+		o.effectiveBlockHeight,
 	)
 	o.resetFailoverIndex()
 	return nil

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -51,16 +51,16 @@ func action_TransactionCreated(ctx context.Context, o *originator, event common.
 	return o.addToTransactions(ctx, e.Transaction, o.newOriginatorTransaction)
 }
 
-// getAndRefreshBlockHeight queries the live block height, updates effectiveBlockHeight when the
-// epoch changes, and recomputes the priority list.
-func (o *originator) getAndRefreshBlockHeight(ctx context.Context) int64 {
+// refreshBlockHeight queries the live block height, updates currentBlockHeight, and updates
+// effectiveBlockHeight (recalculating coordinator priorities) when the epoch changes.
+func (o *originator) refreshBlockHeight(ctx context.Context) {
 	liveHeight := o.engineIntegration.GetBlockHeight(ctx)
+	o.currentBlockHeight = liveHeight
 	newEffective := common.ComputeEffectiveBlockHeight(uint64(liveHeight), o.blockRange)
 	if newEffective != o.effectiveBlockHeight {
 		o.effectiveBlockHeight = newEffective
 		o.calculateCoordinatorPriorities(ctx)
 	}
-	return liveHeight
 }
 
 func (o *originator) newOriginatorTransaction(ctx context.Context, pt *components.PrivateTransaction) (transaction.OriginatorTransaction, error) {
@@ -71,7 +71,8 @@ func (o *originator) newOriginatorTransaction(ctx context.Context, pt *component
 		o.queueEventInternal,
 		o.engineIntegration,
 		o.metrics,
-		o.getAndRefreshBlockHeight,
+		func(ctx context.Context) { o.refreshBlockHeight(ctx) },
+		func() int64 { return o.currentBlockHeight },
 	)
 }
 
@@ -99,8 +100,6 @@ func (o *originator) addToTransactions(
 }
 
 func sendDelegationRequest(ctx context.Context, o *originator) error {
-	liveHeight := o.getAndRefreshBlockHeight(ctx)
-
 	// Re-delegate all transactions in the order they were created on the originating node.
 	transactionsToDelegate := make([]*components.PrivateTransaction, 0)
 	for _, txn := range o.transactionsOrdered {
@@ -119,7 +118,7 @@ func sendDelegationRequest(ctx context.Context, o *originator) error {
 
 	log.L(ctx).Debugf("sending delegation request for %d transactions", len(o.transactionsOrdered))
 
-	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, transactionsToDelegate, uint64(liveHeight))
+	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, transactionsToDelegate, uint64(o.currentBlockHeight))
 }
 
 func action_SendDelegationRequest(ctx context.Context, o *originator, _ common.Event) error {
@@ -129,7 +128,7 @@ func action_SendDelegationRequest(ctx context.Context, o *originator, _ common.E
 // action_RefreshBlockHeight queries the live block height and updates effectiveBlockHeight and the
 // priority list if the epoch has changed.
 func action_RefreshBlockHeight(ctx context.Context, o *originator, _ common.Event) error {
-	o.getAndRefreshBlockHeight(ctx)
+	o.refreshBlockHeight(ctx)
 	return nil
 }
 

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -30,8 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
-func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
+func Test_refreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
 	ctx := context.Background()
 	o, mocks := NewOriginatorBuilderForTesting(t, State_Idle).
 		BlockRange(100).
@@ -39,8 +38,8 @@ func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(1000))
 
-	liveHeight := o.getAndRefreshBlockHeight(ctx)
-	assert.Equal(t, int64(1000), liveHeight)
+	o.refreshBlockHeight(ctx)
+	assert.Equal(t, int64(1000), o.currentBlockHeight)
 	assert.Equal(t, uint64(1000), o.effectiveBlockHeight)
 }
 
@@ -302,11 +301,10 @@ func Test_sendDelegationRequest_HandleEventError_ReturnsWrappedError(t *testing.
 	mockTxn.On("GetPrivateTransaction").Return(pt)
 	mockTxn.On("GetID").Return(txnID)
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(expectedErr)
-	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		Transactions(mockTxn).
 		CurrentActiveCoordinator("coordinator@coordinatorNode").
 		Build()
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	err := sendDelegationRequest(ctx, o)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error handling delegated event for transaction")
@@ -404,7 +402,6 @@ func Test_sendDelegationRequest_TransportError_ReturnsError(t *testing.T) {
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	o, mocks := builder.Transactions(mockTxn).CurrentActiveCoordinator("coordinator@node1").Build()
 
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("transport error"))
@@ -620,7 +617,6 @@ func Test_action_FailoverToNextCoordinator_WithPriorityList_AdvancesCoordinatorA
 		WithMockTransportWriter(t).
 		Build()
 
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "B", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -649,7 +645,6 @@ func Test_action_FailoverToNextCoordinator_WrapAround_CyclesBackToStart(t *testi
 		WithMockTransportWriter(t).
 		Build()
 
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "C", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -677,7 +672,6 @@ func Test_action_FailoverToNextCoordinator_EmptyPriorityList_DelegatesWithoutRes
 		WithMockTransportWriter(t).
 		Build()
 
-	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "static-coordinator", mock.Anything, mock.Anything).
 		Return(nil).Once()

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -30,12 +30,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_action_UpdateBlockHeight_SetsCurrentBlockHeight(t *testing.T) {
+
+func Test_getAndRefreshBlockHeight_SetsEffectiveBlockHeight(t *testing.T) {
 	ctx := context.Background()
-	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).Build()
-	err := action_UpdateBlockHeight(ctx, o, &common.NewBlockEvent{BlockHeight: 1000})
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1000), o.currentBlockHeight)
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Idle).
+		BlockRange(100).
+		Build()
+
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(1000))
+
+	liveHeight := o.getAndRefreshBlockHeight(ctx)
+	assert.Equal(t, int64(1000), liveHeight)
+	assert.Equal(t, uint64(1000), o.effectiveBlockHeight)
 }
 
 func Test_action_UpdateEndorserCandidates_ReplacesCandidates(t *testing.T) {
@@ -296,10 +302,11 @@ func Test_sendDelegationRequest_HandleEventError_ReturnsWrappedError(t *testing.
 	mockTxn.On("GetPrivateTransaction").Return(pt)
 	mockTxn.On("GetID").Return(txnID)
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(expectedErr)
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
 		Transactions(mockTxn).
 		CurrentActiveCoordinator("coordinator@coordinatorNode").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	err := sendDelegationRequest(ctx, o)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error handling delegated event for transaction")
@@ -397,6 +404,7 @@ func Test_sendDelegationRequest_TransportError_ReturnsError(t *testing.T) {
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	o, mocks := builder.Transactions(mockTxn).CurrentActiveCoordinator("coordinator@node1").Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("transport error"))
@@ -456,6 +464,27 @@ func Test_action_UpdateEndorserCandidatesFromHeartbeat_NoOpWhenSenderAlreadyKnow
 
 	assert.Len(t, o.endorserCandidates, 2, "duplicate must not be added")
 	assert.Len(t, o.coordinatorPriorityList, before, "priority list must be unchanged when pool does not grow")
+}
+
+func Test_action_UpdateEndorserCandidatesFromHeartbeat_UsesSnapshotCandidatesWhenPresent(t *testing.T) {
+	ctx := context.Background()
+	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).
+		WithEndorserCandidates("node1").
+		CoordinatorPriorityList("node1").
+		CurrentActiveCoordinator("node1").
+		Build()
+
+	err := action_UpdateEndorserCandidatesFromHeartbeat(ctx, o, &common.HeartbeatReceivedEvent{
+		FromNode: "node2",
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			CoordinatorState:   common.CoordinatorState_Active,
+			EndorserCandidates: []string{"node1", "node2", "node3"},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"node1", "node2", "node3"}, o.endorserCandidates,
+		"snapshot candidates must supersede the sender-only candidate list")
 }
 
 func Test_action_UpdateEndorserCandidatesFromHeartbeat_NoOpInSenderMode(t *testing.T) {
@@ -582,16 +611,16 @@ func Test_action_FailoverToNextCoordinator_WithPriorityList_AdvancesCoordinatorA
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetPrivateTransaction").Return(pt)
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
-	builder := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
 		CoordinatorPriorityList("A", "B", "C").
 		CurrentActiveCoordinator("A").
 		FailoverIndex(1).
-		WithMockTransportWriter(t)
-	o, mocks := builder.Build()
-	o.transactionsByID[txID] = mockTxn
-	o.transactionsOrdered = []transaction.OriginatorTransaction{mockTxn}
-	o.heartbeatIntervalsSinceLastReceive = 5
+		HeartbeatIntervalsSinceLastReceive(5).
+		Transactions(mockTxn).
+		WithMockTransportWriter(t).
+		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "B", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -612,15 +641,15 @@ func Test_action_FailoverToNextCoordinator_WrapAround_CyclesBackToStart(t *testi
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetPrivateTransaction").Return(pt)
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
-	builder := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
 		CoordinatorPriorityList("A", "B", "C").
 		CurrentActiveCoordinator("B").
 		FailoverIndex(2). // pointing to last slot
-		WithMockTransportWriter(t)
-	o, mocks := builder.Build()
-	o.transactionsByID[txID] = mockTxn
-	o.transactionsOrdered = []transaction.OriginatorTransaction{mockTxn}
+		Transactions(mockTxn).
+		WithMockTransportWriter(t).
+		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "C", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -640,15 +669,15 @@ func Test_action_FailoverToNextCoordinator_EmptyPriorityList_DelegatesWithoutRes
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetPrivateTransaction").Return(pt)
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
-	builder := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
 		CurrentActiveCoordinator("static-coordinator").
 		FailoverIndex(0).
-		WithMockTransportWriter(t)
-	o, mocks := builder.Build()
-	o.transactionsByID[txID] = mockTxn
-	o.transactionsOrdered = []transaction.OriginatorTransaction{mockTxn}
-	o.heartbeatIntervalsSinceLastReceive = 3
+		HeartbeatIntervalsSinceLastReceive(3).
+		Transactions(mockTxn).
+		WithMockTransportWriter(t).
+		Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "static-coordinator", mock.Anything, mock.Anything).
 		Return(nil).Once()

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -66,10 +66,9 @@ type originator struct {
 	heartbeatIntervalsSinceLastReceive int
 	transactionsByID                   map[uuid.UUID]transaction.OriginatorTransaction
 	transactionsOrdered                []transaction.OriginatorTransaction
-	currentBlockHeight                 uint64
-	onEpochBoundary                    bool
+	effectiveBlockHeight               uint64
 	endorserCandidates                 []string // COORDINATOR_ENDORSER mode: deduped+sorted candidate pool; updated when EndorserNodesDiscoveredEvent arrives
-	coordinatorPriorityList            []string // COORDINATOR_ENDORSER mode: priority-ordered list computed independently from endorserCandidates + currentBlockHeight + blockRangeSize
+	coordinatorPriorityList            []string // COORDINATOR_ENDORSER mode: priority-ordered list computed independently from endorserCandidates + effectiveBlockHeight + blockRangeSize
 	failoverIndex                      int      // COORDINATOR_ENDORSER mode:t he next position in coordinatorPriorityList to try when the current active coordinator exceeds the inactive grace period
 
 	/* Config */
@@ -126,11 +125,8 @@ func (o *originator) Start(ctx context.Context) error {
 	}
 	o.ctx = log.WithLogField(ctx, "role", "originator")
 
-	blockHeight, err := o.engineIntegration.GetBlockHeight(ctx)
-	if err != nil {
-		return err
-	}
-	o.currentBlockHeight = uint64(blockHeight)
+	blockHeight := o.engineIntegration.GetBlockHeight(ctx)
+	o.effectiveBlockHeight = common.ComputeEffectiveBlockHeight(uint64(blockHeight), o.blockRange)
 
 	o.started = true
 

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -67,6 +67,7 @@ type originator struct {
 	transactionsByID                   map[uuid.UUID]transaction.OriginatorTransaction
 	transactionsOrdered                []transaction.OriginatorTransaction
 	effectiveBlockHeight               uint64
+	currentBlockHeight                 int64
 	endorserCandidates                 []string // COORDINATOR_ENDORSER mode: deduped+sorted candidate pool; updated when EndorserNodesDiscoveredEvent arrives
 	coordinatorPriorityList            []string // COORDINATOR_ENDORSER mode: priority-ordered list computed independently from endorserCandidates + effectiveBlockHeight + blockRangeSize
 	failoverIndex                      int      // COORDINATOR_ENDORSER mode:t he next position in coordinatorPriorityList to try when the current active coordinator exceeds the inactive grace period

--- a/core/go/internal/sequencer/originator/originator_builder_test.go
+++ b/core/go/internal/sequencer/originator/originator_builder_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/mocks/sequencertransportmocks"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -48,7 +47,7 @@ type OriginatorBuilderForTesting struct {
 	metrics                            metrics.DistributedSequencerMetrics
 	sequencerConfig                    *pldconf.SequencerConfig
 	blockRange                         *uint64
-	currentBlockHeight                 *uint64
+	currentEffectiveBlockHeight        *uint64
 	endorserCandidates                 []string
 	coordinatorPriorityList            []string
 	currentActiveCoordinator           *string
@@ -111,7 +110,7 @@ func (b *OriginatorBuilderForTesting) BlockRange(n uint64) *OriginatorBuilderFor
 }
 
 func (b *OriginatorBuilderForTesting) CurrentBlockHeight(n uint64) *OriginatorBuilderForTesting {
-	b.currentBlockHeight = &n
+	b.currentEffectiveBlockHeight = &n
 	return b
 }
 
@@ -179,9 +178,6 @@ func (b *OriginatorBuilderForTesting) Build() (*originator, *OriginatorDependenc
 		SentMessageRecorder: testutil.NewSentMessageRecorder(),
 		EngineIntegration:   sequencercommonmocks.NewEngineIntegration(b.t),
 	}
-	// Default stub so tests that call Start() don't need to set up GetBlockHeight explicitly.
-	// Individual tests can override this with a more specific expectation.
-	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0), nil).Maybe()
 
 	if b.useMockTransportWriter {
 		mocks.TransportWriter = sequencertransportmocks.NewTransportWriter(b.t)
@@ -226,8 +222,8 @@ func (b *OriginatorBuilderForTesting) Build() (*originator, *OriginatorDependenc
 	if b.blockRange != nil {
 		originator.blockRange = *b.blockRange
 	}
-	if b.currentBlockHeight != nil {
-		originator.currentBlockHeight = *b.currentBlockHeight
+	if b.currentEffectiveBlockHeight != nil {
+		originator.effectiveBlockHeight = *b.currentEffectiveBlockHeight
 	}
 	if b.endorserCandidates != nil {
 		originator.endorserCandidates = b.endorserCandidates

--- a/core/go/internal/sequencer/originator/originator_test.go
+++ b/core/go/internal/sequencer/originator/originator_test.go
@@ -16,7 +16,6 @@ package originator
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -24,12 +23,12 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/metrics"
-	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/originator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/statemachine"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/testutil"
 	"github.com/LFDT-Paladin/paladin/core/mocks/originatortransactionmocks"
 	"github.com/LFDT-Paladin/paladin/core/mocks/sequencercommonmocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
@@ -45,6 +44,7 @@ func TestOriginator_SingleTransactionLifecycle(t *testing.T) {
 	coordinatorNode := "coordinatorNode"
 	builder := NewOriginatorBuilderForTesting(t, State_Idle).CurrentActiveCoordinator(coordinatorNode)
 	o, mocks := builder.Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	require.NoError(t, o.Start(ctx))
 	defer func() {
 		cancel()
@@ -197,6 +197,7 @@ func TestOriginator_EventLoop_ErrorHandling(t *testing.T) {
 	originatorLocator := "sender@senderNode"
 	builder := NewOriginatorBuilderForTesting(t, State_Observing)
 	o, mocks := builder.Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	// Process a TransactionCreatedEvent with a nil transaction to trigger an error
 	_ = o.stateMachineEventLoop.ProcessEvent(ctx, &TransactionCreatedEvent{Transaction: nil})
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originatorLocator).NumberOfRequiredEndorsers(1)
@@ -291,7 +292,8 @@ func Test_GetTxStatus_UnknownTransactionReturnsUnknown(t *testing.T) {
 
 func TestOriginator_Start_Idempotent(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
-	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).Build()
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Idle).Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	require.NoError(t, o.Start(ctx))
 	defer func() {
 		cancel()
@@ -301,19 +303,6 @@ func TestOriginator_Start_Idempotent(t *testing.T) {
 	require.NoError(t, o.Start(ctx))
 }
 
-func TestOriginator_Start_GetBlockHeightError(t *testing.T) {
-	ctx := t.Context()
-	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).Build()
-
-	mockEI := sequencercommonmocks.NewEngineIntegration(t)
-	mockEI.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0), fmt.Errorf("block height error"))
-	o.engineIntegration = mockEI
-
-	err := o.Start(ctx)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "block height error")
-	assert.False(t, o.started)
-}
 
 func TestOriginator_WaitForDone_NotStarted_ReturnsImmediately(t *testing.T) {
 	ctx := t.Context()

--- a/core/go/internal/sequencer/originator/state_machine.go
+++ b/core/go/internal/sequencer/originator/state_machine.go
@@ -92,21 +92,16 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Validator: validator_TransactionDoesNotExist,
-					Actions:   []ActionRule{{Action: action_TransactionCreated}},
+					Actions: []ActionRule{
+						{Action: action_TransactionCreated},
+						// If we are idle we have not been receiving heartbeats from a coordinator so we
+						// need to make sure our delegation goes to the current top priority coordinator
+						{Action: action_RefreshBlockHeight},
+						{Action: action_ResetToTopPriorityCoordinator},
+					},
 					Transitions: []Transition{{
 						To: State_Sending,
 					}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{If: guard_IsOnEpochBoundary, Action: action_CalculateCoordinatorPriorities},
-						// Re-align to the new epoch's top-priority coordinator while still idle.
-						{If: guard_IsOnEpochBoundary, Action: action_ResetToTopPriorityCoordinator},
-					},
 				}},
 			},
 			common.Event_EndorserNodesDiscovered: {
@@ -163,15 +158,6 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{
 						To: State_Sending,
 					}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{If: guard_IsOnEpochBoundary, Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 			common.Event_EndorserNodesDiscovered: {
@@ -298,15 +284,6 @@ var stateDefinitionsMap = StateDefinitions{
 						validator_OriginatorTransactionStateTransitionToReverted,
 					),
 					Actions: []ActionRule{{Action: action_FinalizeTransaction}},
-				}},
-			},
-			common.Event_NewBlock: {
-				Match: statemachine.MatchFirst,
-				Handlers: []EventHandler{{
-					Actions: []ActionRule{
-						{Action: action_UpdateBlockHeight},
-						{If: guard_IsOnEpochBoundary, Action: action_CalculateCoordinatorPriorities},
-					},
 				}},
 			},
 			common.Event_EndorserNodesDiscovered: {

--- a/core/go/internal/sequencer/originator/state_machine.go
+++ b/core/go/internal/sequencer/originator/state_machine.go
@@ -189,6 +189,7 @@ var stateDefinitionsMap = StateDefinitions{
 			// Delegate immediately to the current active coordinator on entering Sending.
 			// If the coordinator is still in Elect or Prepared it will accept the delegation
 			// and manage the handover itself.
+			{Action: action_RefreshBlockHeight},
 			{Action: action_SendDelegationRequest},
 		},
 		Events: map[EventType]EventHandlers{
@@ -198,6 +199,7 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_TransactionDoesNotExist,
 					Actions: []ActionRule{
 						{Action: action_TransactionCreated},
+						{Action: action_RefreshBlockHeight},
 						{Action: action_SendDelegationRequest},
 					},
 				}},
@@ -237,20 +239,27 @@ var stateDefinitionsMap = StateDefinitions{
 						validator_IsFromCurrentCoordinator,
 						validator_HasDroppedTransactions,
 					),
-					Actions: []ActionRule{{Action: action_SendDelegationRequest}},
+					Actions: []ActionRule{
+						{Action: action_RefreshBlockHeight},
+						{Action: action_SendDelegationRequest},
+					},
 				}},
 			},
 			common.Event_HeartbeatInterval: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Actions: []ActionRule{
-						{Action: action_IncrementHeartbeatIntervalCounts},
-						// When the active coordinator has been silent too long, failover to the next
-						// highest-priority candidate if one is available. Otherwise redelegate to the same node.
-						{
-							If:     guard_InactiveGracePeriodExceeded,
-							Action: action_FailoverToNextCoordinator,
-						},
+					{Action: action_IncrementHeartbeatIntervalCounts},
+					// When the active coordinator has been silent too long, failover to the next
+					// highest-priority candidate if one is available. Otherwise redelegate to the same node.
+					{
+						If:     guard_InactiveGracePeriodExceeded,
+						Action: action_RefreshBlockHeight,
+					},
+					{
+						If:     guard_InactiveGracePeriodExceeded,
+						Action: action_FailoverToNextCoordinator,
+					},
 					},
 				}},
 			},
@@ -266,6 +275,7 @@ var stateDefinitionsMap = StateDefinitions{
 					Actions: []ActionRule{
 						{Action: action_HandleDelegationRejected},
 						// We always redelegate immediately, regardless of whether the current active coordinator has changed
+						{Action: action_RefreshBlockHeight},
 						{Action: action_SendDelegationRequest},
 					},
 				}},

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -84,22 +84,30 @@ func TestStateMachine_Idle_OnTransitionTo_NoEndorserMode_NoChange(t *testing.T) 
 	assert.Equal(t, 3, o.failoverIndex, "failoverIndex must not change when priority list is empty")
 }
 
-// NewBlock on an epoch boundary while already Idle resets to top-priority coordinator, giving a
-// fresh start for any subsequent Sending entry.
-func TestStateMachine_Idle_NewBlock_EpochBoundary_EndorserMode_ResetsToTopPriority(t *testing.T) {
+// TransactionCreated in Idle with an epoch boundary resets to top-priority coordinator before
+// delegating, giving a fresh start for any subsequent Sending entry.
+func TestStateMachine_Idle_TransactionCreated_EpochBoundary_EndorserMode_ResetsToTopPriority(t *testing.T) {
 	ctx := context.Background()
-	// blockRange=10, currentHeight=5 → epoch 0; newHeight=10 → epoch 1 ⇒ boundary.
-	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).
+	// blockRange=10, currentEffective=0 (epoch 0); newHeight=10 → epoch 1 ⇒ boundary.
+	builder := NewOriginatorBuilderForTesting(t, State_Idle).
 		CurrentActiveCoordinator("C").
 		CoordinatorPriorityList("A", "B", "C").
-		CurrentBlockHeight(5).
 		BlockRange(10).
-		Build()
+		CurrentBlockHeight(0).
+		WithMockTransportWriter(t)
+	o, mocks := builder.Build()
 
-	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 10}))
+	// action_refreshBlockHeight + sendDelegationRequest (OnTransitionTo Sending) both query GetBlockHeight.
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(10)).Times(2)
+	mocks.TransportWriter.EXPECT().
+		SendDelegationRequest(mock.Anything, "A", mock.Anything, mock.Anything).
+		Return(nil).Once()
 
-	assert.Equal(t, State_Idle, o.GetCurrentState())
-	assert.Equal(t, "A", o.currentActiveCoordinator, "must reset to top priority on epoch boundary while idle")
+	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator("sender@node1").Build()
+	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &TransactionCreatedEvent{Transaction: txn}))
+
+	assert.Equal(t, State_Sending, o.GetCurrentState())
+	assert.Equal(t, "A", o.currentActiveCoordinator, "must reset to top priority on epoch boundary before sending")
 	assert.Equal(t, 1, o.failoverIndex, "failoverIndex must be 1 after reset to top priority")
 }
 
@@ -110,9 +118,9 @@ func TestStateMachine_Idle_HeartbeatReceived_ActiveState_TransitionsToObserving(
 	builder := NewOriginatorBuilderForTesting(t, State_Idle).
 		CurrentActiveCoordinator("old-coordinator").
 		CoordinatorPriorityList("node2", "node1").
-		NodeName("node1")
+		NodeName("node1").
+		HeartbeatIntervalsSinceLastReceive(5)
 	o, _ := builder.Build()
-	o.heartbeatIntervalsSinceLastReceive = 5
 	ca := builder.GetContractAddress()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{
@@ -200,6 +208,8 @@ func TestStateMachine_Idle_TransactionCreated_TransitionsToSending_SendsDelegati
 		WithMockTransportWriter(t)
 	o, mocks := builder.Build()
 
+	// action_refreshBlockHeight (in Idle) + sendDelegationRequest (OnTransitionTo Sending)
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Times(2)
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -229,16 +239,6 @@ func TestStateMachine_Idle_TransactionCreated_DuplicateID_StaysIdle(t *testing.T
 	assert.Len(t, o.transactionsByID, 1, "duplicate transaction must not be double-tracked")
 }
 
-// NewBlock event in Idle updates currentBlockHeight; stays Idle.
-func TestStateMachine_Idle_NewBlock_UpdatesBlockHeight_StaysIdle(t *testing.T) {
-	ctx := context.Background()
-	o, _ := NewOriginatorBuilderForTesting(t, State_Idle).CurrentBlockHeight(100).Build()
-
-	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 200}))
-
-	assert.Equal(t, State_Idle, o.GetCurrentState())
-	assert.Equal(t, uint64(200), o.currentBlockHeight)
-}
 
 // EndorserNodesDiscovered in Idle updates endorserCandidates, recomputes the priority list, and
 // resets currentActiveCoordinator to priorityList[0] via action_ResetToTopPriorityCoordinator.
@@ -320,6 +320,7 @@ func TestStateMachine_Observing_TransactionCreated_TransitionsToSending_SendsDel
 		WithMockTransportWriter(t)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -338,9 +339,9 @@ func TestStateMachine_Observing_HeartbeatReceived_ActiveState_UpdatesCoordinator
 	builder := NewOriginatorBuilderForTesting(t, State_Observing).
 		CurrentActiveCoordinator("old-coordinator").
 		CoordinatorPriorityList("other-node", "new-coordinator").
-		FailoverIndex(1)
+		FailoverIndex(1).
+		HeartbeatIntervalsSinceLastReceive(3)
 	o, _ := builder.Build()
-	o.heartbeatIntervalsSinceLastReceive = 3
 	ca := builder.GetContractAddress()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{
@@ -363,9 +364,9 @@ func TestStateMachine_Observing_HeartbeatReceived_ActiveState_UpdatesCoordinator
 func TestStateMachine_Observing_HeartbeatReceived_ActiveFlushState_ResetsTimerAndUpdatesCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewOriginatorBuilderForTesting(t, State_Observing).
-		CurrentActiveCoordinator("existing-coordinator")
+		CurrentActiveCoordinator("existing-coordinator").
+		HeartbeatIntervalsSinceLastReceive(3)
 	o, _ := builder.Build()
-	o.heartbeatIntervalsSinceLastReceive = 3
 	ca := builder.GetContractAddress()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{
@@ -385,9 +386,9 @@ func TestStateMachine_Observing_HeartbeatReceived_ActiveFlushState_ResetsTimerAn
 func TestStateMachine_Observing_HeartbeatReceived_ClosingState_NoTimerResetAndNoCoordinatorUpdate(t *testing.T) {
 	ctx := context.Background()
 	builder := NewOriginatorBuilderForTesting(t, State_Observing).
-		CurrentActiveCoordinator("existing-coordinator")
+		CurrentActiveCoordinator("existing-coordinator").
+		HeartbeatIntervalsSinceLastReceive(3)
 	o, _ := builder.Build()
-	o.heartbeatIntervalsSinceLastReceive = 3
 	ca := builder.GetContractAddress()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{
@@ -484,14 +485,6 @@ func TestStateMachine_Observing_TransactionCreated_DuplicateID_StaysObserving(t 
 	assert.Len(t, o.transactionsByID, 1, "duplicate must not be tracked twice")
 }
 
-// NewBlock event in Observing updates currentBlockHeight; stays Observing.
-func TestStateMachine_Observing_NewBlock_UpdatesBlockHeight_StaysObserving(t *testing.T) {
-	ctx := context.Background()
-	o, _ := NewOriginatorBuilderForTesting(t, State_Observing).CurrentBlockHeight(10).Build()
-	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 20}))
-	assert.Equal(t, State_Observing, o.GetCurrentState())
-	assert.Equal(t, uint64(20), o.currentBlockHeight)
-}
 
 // TransactionStateTransition to Final in Observing removes the transaction from memory.
 func TestStateMachine_Observing_TransactionStateTransition_ToFinal_CleansUpTransaction(t *testing.T) {
@@ -553,6 +546,7 @@ func TestStateMachine_Sending_TransactionCreated_CreatesTxnAndDelegates(t *testi
 		WithMockTransportWriter(t)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -598,6 +592,7 @@ func TestStateMachine_Sending_HeartbeatReceived_DroppedTransaction_Redelegates(t
 	o, mocks := builder.Build()
 	ca := builder.GetContractAddress()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -661,6 +656,7 @@ func TestStateMachine_Sending_HeartbeatReceived_HigherPriorityActiveNode_Redirec
 	o, mocks := builder.Build()
 	ca := builder.GetContractAddress()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -710,6 +706,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_NoEndorserMode_Red
 		Transactions(mockTxn)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -740,6 +737,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_Failo
 		Transactions(mockTxn)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "B", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -771,6 +769,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_WrapA
 		Transactions(mockTxn)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "C", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -800,6 +799,7 @@ func TestStateMachine_Sending_DelegationRejected_HigherPriority_RedirectsAndRede
 		Transactions(mockTxn)
 	o, mocks := builder.Build()
 
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "node1", mock.Anything, mock.Anything).
 		Return(nil).Once()
@@ -815,13 +815,14 @@ func TestStateMachine_Sending_DelegationRejected_HigherPriority_RedirectsAndRede
 	assert.Equal(t, 1, o.failoverIndex, "failoverIndex must be recalibrated to 1 when active is top priority")
 }
 
-// DelegationRejected in Sending with lower-priority named coordinator → no redirect; no redelegate.
+// DelegationRejected in Sending with lower-priority named coordinator → no redirect; redelegates to same coordinator.
 func TestStateMachine_Sending_DelegationRejected_LowerPriority_NoChange(t *testing.T) {
 	ctx := context.Background()
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
 		CurrentActiveCoordinator("node1").
 		CoordinatorPriorityList("node1", "node2", "node3").
 		Build()
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &DelegationRequestRejectedEvent{
 		RejectionReason:   engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
@@ -913,22 +914,6 @@ func TestStateMachine_Sending_EndorserNodesDiscovered_UpdatesCandidatesAndRecomp
 	assert.ElementsMatch(t, []string{"new-node1", "new-node2"}, o.coordinatorPriorityList)
 }
 
-// NewBlock event in Sending updates currentBlockHeight; stays Sending.
-func TestStateMachine_Sending_NewBlock_UpdatesBlockHeight_StaysSending(t *testing.T) {
-	ctx := context.Background()
-	txID := uuid.New()
-	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
-	mockTxn.On("GetID").Return(txID)
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		CurrentBlockHeight(50).
-		Transactions(mockTxn).
-		Build()
-
-	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.NewBlockEvent{BlockHeight: 100}))
-
-	assert.Equal(t, State_Sending, o.GetCurrentState())
-	assert.Equal(t, uint64(100), o.currentBlockHeight)
-}
 
 // HeartbeatReceived in Sending from a new node → endorser pool grows and priority list is recomputed.
 func TestStateMachine_Sending_HeartbeatReceived_NewSender_UpdatesEndorserCandidates(t *testing.T) {
@@ -1001,6 +986,7 @@ func TestStateMachine_Sending_HeartbeatReceived_Step3_GraceExceeded_SwitchesCoor
 	// Step 3 fires: switches to "node3" (live, not current, grace exceeded).
 	// Step 4 then fires because currentActiveCoordinator is now "node3".
 	// Step 5 fires because empty snapshot means txID is dropped → redelegate.
+	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
 		SendDelegationRequest(mock.Anything, "node3", mock.Anything, mock.Anything).
 		Return(nil).Once()

--- a/core/go/internal/sequencer/originator/transaction/assembling.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling.go
@@ -164,10 +164,6 @@ func action_SendAssembleError(ctx context.Context, txn *originatorTransaction, _
 	return txn.transportWriter.SendAssembleError(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.currentDelegate)
 }
 
-// action_RefreshBlockHeight calls refreshBlockHeight on the originator, caching the result
-// in o.currentBlockHeight. It must be the first handler in every Event_AssembleRequestReceived
-// handler set so that validator_AssembleBlockHeightToleranceExceeded and
-// action_SendAssembleBlockHeightRejection always operate on a freshly-fetched, consistent value.
 func action_RefreshBlockHeight(ctx context.Context, t *originatorTransaction, _ common.Event) error {
 	t.refreshBlockHeight(ctx)
 	return nil

--- a/core/go/internal/sequencer/originator/transaction/assembling.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling.go
@@ -164,12 +164,21 @@ func action_SendAssembleError(ctx context.Context, txn *originatorTransaction, _
 	return txn.transportWriter.SendAssembleError(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.currentDelegate)
 }
 
+// action_RefreshBlockHeight calls refreshBlockHeight on the originator, caching the result
+// in o.currentBlockHeight. It must be the first handler in every Event_AssembleRequestReceived
+// handler set so that validator_AssembleBlockHeightToleranceExceeded and
+// action_SendAssembleBlockHeightRejection always operate on a freshly-fetched, consistent value.
+func action_RefreshBlockHeight(ctx context.Context, t *originatorTransaction, _ common.Event) error {
+	t.refreshBlockHeight(ctx)
+	return nil
+}
+
 // validator_AssembleBlockHeightToleranceExceeded returns true when the absolute difference between
 // the coordinator's block height (from the assemble request) and this originator's block height
 // exceeds the tolerance carried on the event.
-func validator_AssembleBlockHeightToleranceExceeded(ctx context.Context, t *originatorTransaction, event common.Event) (bool, error) {
+func validator_AssembleBlockHeightToleranceExceeded(_ context.Context, t *originatorTransaction, event common.Event) (bool, error) {
 	e := event.(*AssembleRequestReceivedEvent)
-	receiverBH := uint64(t.getCurrentBlockHeight(ctx))
+	receiverBH := uint64(t.getBlockHeight())
 	coordinatorBH := uint64(e.CoordinatorsBlockHeight)
 	diff := max(receiverBH, coordinatorBH) - min(receiverBH, coordinatorBH)
 	return diff > uint64(e.BlockHeightTolerance), nil
@@ -179,7 +188,7 @@ func validator_AssembleBlockHeightToleranceExceeded(ctx context.Context, t *orig
 // difference between coordinator and originator exceeds the tolerance carried on the event.
 func action_SendAssembleBlockHeightRejection(ctx context.Context, t *originatorTransaction, event common.Event) error {
 	e := event.(*AssembleRequestReceivedEvent)
-	receiverBlockHeight := t.getCurrentBlockHeight(ctx)
+	receiverBlockHeight := t.getBlockHeight()
 	log.L(ctx).Warnf("rejecting assemble request from coordinator due to block height tolerance (coordinator=%d, assembler=%d, tolerance=%d)",
 		e.CoordinatorsBlockHeight, receiverBlockHeight, e.BlockHeightTolerance)
 	return t.transportWriter.SendAssembleRejection(

--- a/core/go/internal/sequencer/originator/transaction/assembling.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling.go
@@ -167,9 +167,9 @@ func action_SendAssembleError(ctx context.Context, txn *originatorTransaction, _
 // validator_AssembleBlockHeightToleranceExceeded returns true when the absolute difference between
 // the coordinator's block height (from the assemble request) and this originator's block height
 // exceeds the tolerance carried on the event.
-func validator_AssembleBlockHeightToleranceExceeded(_ context.Context, t *originatorTransaction, event common.Event) (bool, error) {
+func validator_AssembleBlockHeightToleranceExceeded(ctx context.Context, t *originatorTransaction, event common.Event) (bool, error) {
 	e := event.(*AssembleRequestReceivedEvent)
-	receiverBH := uint64(t.getCurrentBlockHeight())
+	receiverBH := uint64(t.getCurrentBlockHeight(ctx))
 	coordinatorBH := uint64(e.CoordinatorsBlockHeight)
 	diff := max(receiverBH, coordinatorBH) - min(receiverBH, coordinatorBH)
 	return diff > uint64(e.BlockHeightTolerance), nil
@@ -179,7 +179,7 @@ func validator_AssembleBlockHeightToleranceExceeded(_ context.Context, t *origin
 // difference between coordinator and originator exceeds the tolerance carried on the event.
 func action_SendAssembleBlockHeightRejection(ctx context.Context, t *originatorTransaction, event common.Event) error {
 	e := event.(*AssembleRequestReceivedEvent)
-	receiverBlockHeight := t.getCurrentBlockHeight()
+	receiverBlockHeight := t.getCurrentBlockHeight(ctx)
 	log.L(ctx).Warnf("rejecting assemble request from coordinator due to block height tolerance (coordinator=%d, assembler=%d, tolerance=%d)",
 		e.CoordinatorsBlockHeight, receiverBlockHeight, e.BlockHeightTolerance)
 	return t.transportWriter.SendAssembleRejection(

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -143,8 +143,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -153,6 +156,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and transition.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
 					Transitions: []Transition{
 						{
@@ -251,8 +259,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -261,6 +272,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					// For some reason we've been asked to assemble again. We must not have moved to endorsement gathering,
 					// reverted, or parked. This could be because of a temporary issue preventing assembly (e.g. we couldn't
 					// resolve a remote verifier while it was offline). Assuming this is a new request, action it.
@@ -298,8 +314,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -308,6 +327,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{
 						{Action: action_AssembleRequestReceived},
 						//We thought we had got as far as endorsement but it seems like the coordinator had not got the response in time and has resent the assemble request, we simply reply with the same response as before
@@ -375,8 +399,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -385,6 +412,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{
 						{Action: action_AssembleRequestReceived},
 						//We thought we had got as far as prepared but it seems like the coordinator had not got the response in time and has resent the assemble request, we simply reply with the same response as before
@@ -486,8 +518,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -496,6 +531,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					// The coordinator must have decided that it was necessary to re-assemble with different available
 					// states so we go back to assembling state for another attempt
 					Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
@@ -558,8 +598,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -568,6 +611,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					// The coordinator must have decided that it was necessary to re-assemble with different available
 					// states so we go back to assembling state for another attempt
 					Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
@@ -628,8 +676,11 @@ var stateDefinitionsMap = StateDefinitions{
 			// reverted. We need to accomodate the coordinator getting there first and sending a new assemble request
 			// before we receive the revert and moved back to delegated.
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -638,6 +689,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and transition.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
 					Transitions: []Transition{
 						{
@@ -673,8 +729,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -683,6 +742,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{
 						{
 							Action: action_AssembleRequestReceived,
@@ -729,8 +793,11 @@ var stateDefinitionsMap = StateDefinitions{
 				}},
 			},
 			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchFirst,
+				Match: statemachine.MatchAll,
 				Handlers: []EventHandler{{
+					// Always runs first: refresh the cached block height before any validator reads it.
+					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+				}, {
 					// Assemble request is not from the current delegate; reject without entering the assembly flow.
 					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
 					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
@@ -739,6 +806,11 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_AssembleBlockHeightToleranceExceeded,
 					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
 				}, {
+					// Both checks pass: assemble and proceed.
+					Validator: statemachine.ValidatorAnd(
+						validator_AssembleRequestFromCurrentDelegate,
+						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+					),
 					Actions: []ActionRule{
 						{Action: action_AssembleRequestReceived},
 						{

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -68,7 +68,7 @@ type originatorTransaction struct {
 	nonce                            *uint64
 	metrics                          metrics.DistributedSequencerMetrics
 	lastReceivedWillRetry            bool
-	getCurrentBlockHeight            func() int64 // returns the originator's tracked block height
+	getCurrentBlockHeight            func(context.Context) int64 // returns the originator's tracked block height
 }
 
 func NewTransaction(
@@ -78,7 +78,7 @@ func NewTransaction(
 	queueEventForOriginator func(context.Context, common.Event),
 	engineIntegration common.EngineIntegration,
 	metrics metrics.DistributedSequencerMetrics,
-	getCurrentBlockHeight func() int64,
+	getCurrentBlockHeight func(context.Context) int64,
 ) (OriginatorTransaction, error) {
 	if pt == nil {
 		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "cannot create transaction without private tx")
@@ -100,7 +100,7 @@ func newTransaction(
 	transportWriter transport.TransportWriter,
 	queueEventForOriginator func(context.Context, common.Event),
 	metrics metrics.DistributedSequencerMetrics,
-	getCurrentBlockHeight func() int64,
+	getCurrentBlockHeight func(context.Context) int64,
 ) *originatorTransaction {
 	txn := &originatorTransaction{
 		pt:                      pt,

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -68,7 +68,8 @@ type originatorTransaction struct {
 	nonce                            *uint64
 	metrics                          metrics.DistributedSequencerMetrics
 	lastReceivedWillRetry            bool
-	getCurrentBlockHeight            func(context.Context) int64 // returns the originator's tracked block height
+	refreshBlockHeight               func(context.Context)
+	getBlockHeight                   func() int64
 }
 
 func NewTransaction(
@@ -78,7 +79,8 @@ func NewTransaction(
 	queueEventForOriginator func(context.Context, common.Event),
 	engineIntegration common.EngineIntegration,
 	metrics metrics.DistributedSequencerMetrics,
-	getCurrentBlockHeight func(context.Context) int64,
+	refreshBlockHeight func(context.Context),
+	getBlockHeight func() int64,
 ) (OriginatorTransaction, error) {
 	if pt == nil {
 		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "cannot create transaction without private tx")
@@ -90,7 +92,8 @@ func NewTransaction(
 		transportWriter,
 		queueEventForOriginator,
 		metrics,
-		getCurrentBlockHeight,
+		refreshBlockHeight,
+		getBlockHeight,
 	), nil
 }
 
@@ -100,7 +103,8 @@ func newTransaction(
 	transportWriter transport.TransportWriter,
 	queueEventForOriginator func(context.Context, common.Event),
 	metrics metrics.DistributedSequencerMetrics,
-	getCurrentBlockHeight func(context.Context) int64,
+	refreshBlockHeight func(context.Context),
+	getBlockHeight func() int64,
 ) *originatorTransaction {
 	txn := &originatorTransaction{
 		pt:                      pt,
@@ -108,7 +112,8 @@ func newTransaction(
 		transportWriter:         transportWriter,
 		queueEventForOriginator: queueEventForOriginator,
 		metrics:                 metrics,
-		getCurrentBlockHeight:   getCurrentBlockHeight,
+		refreshBlockHeight:      refreshBlockHeight,
+		getBlockHeight:          getBlockHeight,
 	}
 	txn.initializeStateMachine(State_Initial)
 	return txn

--- a/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
@@ -178,7 +178,8 @@ func (b *TransactionBuilderForTesting) Build() *originatorTransaction {
 		transportWriter,
 		b.queueEventForOriginator,
 		b.metrics,
-		func(_ context.Context) int64 { return b.currentBlockHeight })
+		func(_ context.Context) {},
+		func() int64 { return b.currentBlockHeight })
 
 	txn.stateMachine.SetCurrentState(b.state)
 

--- a/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
@@ -178,7 +178,7 @@ func (b *TransactionBuilderForTesting) Build() *originatorTransaction {
 		transportWriter,
 		b.queueEventForOriginator,
 		b.metrics,
-		func() int64 { return b.currentBlockHeight })
+		func(_ context.Context) int64 { return b.currentBlockHeight })
 
 	txn.stateMachine.SetCurrentState(b.state)
 

--- a/core/go/internal/sequencer/originator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestNewTransaction_NilPrivateTransaction_ReturnsError(t *testing.T) {
 	ctx := context.Background()
-	_, err := NewTransaction(ctx, nil, nil, nil, nil, nil, func() int64 { return 0 })
+	_, err := NewTransaction(ctx, nil, nil, nil, nil, nil, func(_ context.Context) int64 { return 0 })
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot create transaction without private tx")
 }
@@ -46,7 +46,7 @@ func TestNewTransaction_Success_ReturnsOriginatorTransaction(t *testing.T) {
 	queue := func(context.Context, common.Event) {}
 	m := metrics.InitMetrics(context.Background(), prometheus.NewRegistry())
 
-	ot, err := NewTransaction(ctx, pt, recorder, queue, engine, m, func() int64 { return 0 })
+	ot, err := NewTransaction(ctx, pt, recorder, queue, engine, m, func(_ context.Context) int64 { return 0 })
 	require.NoError(t, err)
 	require.NotNil(t, ot)
 	assert.Equal(t, pt.ID, ot.GetID())

--- a/core/go/internal/sequencer/originator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestNewTransaction_NilPrivateTransaction_ReturnsError(t *testing.T) {
 	ctx := context.Background()
-	_, err := NewTransaction(ctx, nil, nil, nil, nil, nil, func(_ context.Context) int64 { return 0 })
+	_, err := NewTransaction(ctx, nil, nil, nil, nil, nil, func(_ context.Context) {}, func() int64 { return 0 })
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot create transaction without private tx")
 }
@@ -46,7 +46,7 @@ func TestNewTransaction_Success_ReturnsOriginatorTransaction(t *testing.T) {
 	queue := func(context.Context, common.Event) {}
 	m := metrics.InitMetrics(context.Background(), prometheus.NewRegistry())
 
-	ot, err := NewTransaction(ctx, pt, recorder, queue, engine, m, func(_ context.Context) int64 { return 0 })
+	ot, err := NewTransaction(ctx, pt, recorder, queue, engine, m, func(_ context.Context) {}, func() int64 { return 0 })
 	require.NoError(t, err)
 	require.NotNil(t, ot)
 	assert.Equal(t, pt.ID, ot.GetID())

--- a/core/go/internal/sequencer/sequencer.go
+++ b/core/go/internal/sequencer/sequencer.go
@@ -59,8 +59,6 @@ type sequencerManager struct {
 	blockHeightMutex            sync.RWMutex
 	heartbeatInterval           time.Duration
 	targetActiveSequencersLimit int // Max number of sequencers this node aims to retain in memory concurrently. Hitting this limit will cause an attempt to remove the lowest priority sequencer from memory, and hence require it to be recreated from persisted state if it is needed in the future
-	blockNotifyMu               sync.Mutex
-	blockNotifyCancel           context.CancelFunc
 }
 
 // Init implements Engine.
@@ -535,39 +533,6 @@ func (sMgr *sequencerManager) OnNewBlockHeight(ctx context.Context, blockHeight 
 	sMgr.blockHeightMutex.Lock()
 	sMgr.blockHeight = blockHeight
 	sMgr.blockHeightMutex.Unlock()
-
-	go sMgr.notifySequencersNewBlock(ctx, blockHeight)
-}
-
-func (sMgr *sequencerManager) notifySequencersNewBlock(ctx context.Context, blockHeight int64) {
-	// Cancel any in-progress delivery of an older block, then take ownership.
-	sMgr.blockNotifyMu.Lock()
-	if sMgr.blockNotifyCancel != nil {
-		sMgr.blockNotifyCancel()
-	}
-	notifyCtx, cancel := context.WithCancel(ctx)
-	sMgr.blockNotifyCancel = cancel
-	sMgr.blockNotifyMu.Unlock()
-
-	// Hold the lock only long enough to snapshot the sequencer list — no blocking
-	// calls may be made while the lock is held.
-	sMgr.sequencersLock.RLock()
-	seqs := make([]*sequencer, 0, len(sMgr.sequencers))
-	for _, seq := range sMgr.sequencers {
-		seqs = append(seqs, seq)
-	}
-	sMgr.sequencersLock.RUnlock()
-
-	event := &common.NewBlockEvent{
-		BaseEvent: common.BaseEvent{
-			EventTime: time.Now(),
-		},
-		BlockHeight: uint64(blockHeight),
-	}
-	for _, seq := range seqs {
-		seq.coordinator.QueueEvent(notifyCtx, event)
-		seq.originator.QueueEvent(notifyCtx, event)
-	}
 }
 
 func (sMgr *sequencerManager) GetBlockHeight() int64 {

--- a/core/go/internal/sequencer/sequencer_lifecycle_test.go
+++ b/core/go/internal/sequencer/sequencer_lifecycle_test.go
@@ -1733,142 +1733,20 @@ func TestOnNewBlockHeight_NoSequencers_NoEvents(t *testing.T) {
 	// Any unexpected call would cause testify to fail the test immediately.
 	sm.OnNewBlockHeight(context.Background(), 100)
 
-	// Give the goroutine time to run and confirm it exits without calling any mock.
-	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, int64(100), sm.GetBlockHeight())
 }
 
-func TestOnNewBlockHeight_DispatchesNewBlockToAllSequencers(t *testing.T) {
+func TestOnNewBlockHeight_StoresAndReturnsHeight_WithSequencers(t *testing.T) {
 	ctx := context.Background()
-
-	addr1 := pldtypes.RandAddress()
-	addr2 := pldtypes.RandAddress()
-
-	mocks := newSequencerLifecycleTestMocks(t)
-	sm := newSequencerManagerForTesting(t, mocks)
-
-	// Create separate mock coordinator and originator for the second sequencer.
-	coord2 := coordinatormocks.NewCoordinator(t)
-	orig2 := originatormocks.NewOriginator(t)
-
-	const expectedHeight = int64(999)
-
-	coordReceived := make(chan struct{}, 2)
-	origReceived := make(chan struct{}, 2)
-
-	mocks.coordinator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == uint64(expectedHeight)
-	})).Run(func(_ context.Context, _ common.Event) {
-		coordReceived <- struct{}{}
-	}).Return().Once()
-
-	mocks.originator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == uint64(expectedHeight)
-	})).Run(func(_ context.Context, _ common.Event) {
-		origReceived <- struct{}{}
-	}).Return().Once()
-
-	coord2.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == uint64(expectedHeight)
-	})).Run(func(_ context.Context, _ common.Event) {
-		coordReceived <- struct{}{}
-	}).Return().Once()
-
-	orig2.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == uint64(expectedHeight)
-	})).Run(func(_ context.Context, _ common.Event) {
-		origReceived <- struct{}{}
-	}).Return().Once()
-
-	sm.sequencers[addr1.String()] = &sequencer{
-		contractAddress: addr1.String(),
-		coordinator:     mocks.coordinator,
-		originator:      mocks.originator,
-		cancelCtx:       func() {},
-	}
-	sm.sequencers[addr2.String()] = &sequencer{
-		contractAddress: addr2.String(),
-		coordinator:     coord2,
-		originator:      orig2,
-		cancelCtx:       func() {},
-	}
-
-	sm.OnNewBlockHeight(ctx, expectedHeight)
-
-	// Wait for all four QueueEvent calls to arrive.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-coordReceived:
-		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for coordinator NewBlockEvent dispatch")
-		}
-	}
-	for i := 0; i < 2; i++ {
-		select {
-		case <-origReceived:
-		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for originator NewBlockEvent dispatch")
-		}
-	}
-
-	assert.Equal(t, expectedHeight, sm.GetBlockHeight())
-}
-
-func TestNotifySequencersNewBlock_NewBlockCancelsPrevious(t *testing.T) {
-	ctx := context.Background()
-	mocks := newSequencerLifecycleTestMocks(t)
-	sm := newSequencerManagerForTesting(t, mocks)
 	addr := pldtypes.RandAddress()
-
-	block1CoordCalled := make(chan struct{})
-	block2CoordDone := make(chan struct{})
-	block2OrigDone := make(chan struct{})
-
-	// Block 1 coordinator: block inside Run until context is cancelled, simulating a full event channel.
-	mocks.coordinator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == 1
-	})).Run(func(ctx context.Context, _ common.Event) {
-		close(block1CoordCalled)
-		<-ctx.Done()
-	}).Return().Once()
-
-	// Block 1 originator: may be called with an already-cancelled context after coordinator unblocks.
-	mocks.originator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == 1
-	})).Return().Maybe()
-
-	// Block 2: both coordinator and originator must receive the event.
-	mocks.coordinator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == 2
-	})).Run(func(_ context.Context, _ common.Event) {
-		close(block2CoordDone)
-	}).Return().Once()
-
-	mocks.originator.EXPECT().QueueEvent(mock.Anything, mock.MatchedBy(func(e interface{}) bool {
-		ev, ok := e.(*common.NewBlockEvent)
-		return ok && ev.BlockHeight == 2
-	})).Run(func(_ context.Context, _ common.Event) {
-		close(block2OrigDone)
-	}).Return().Once()
+	mocks := newSequencerLifecycleTestMocks(t)
+	sm := newSequencerManagerForTesting(t, mocks)
 
 	sm.sequencers[addr.String()] = newSequencerForTesting(addr, mocks)
 
-	sm.OnNewBlockHeight(ctx, 1)
+	// With pull-based block height, OnNewBlockHeight only stores the value.
+	// Coordinators and originators query it on-demand via engineIntegration.GetBlockHeight.
+	sm.OnNewBlockHeight(ctx, 999)
 
-	// Wait until block 1's goroutine is blocking inside coordinator.QueueEvent.
-	<-block1CoordCalled
-
-	// Arrival of block 2 must cancel block 1's context and then deliver itself.
-	sm.OnNewBlockHeight(ctx, 2)
-
-	<-block2CoordDone
-	<-block2OrigDone
-	assert.Equal(t, int64(2), sm.GetBlockHeight())
+	assert.Equal(t, int64(999), sm.GetBlockHeight())
 }

--- a/core/go/noderuntests/coordinationtest/coordination_test.go
+++ b/core/go/noderuntests/coordinationtest/coordination_test.go
@@ -1864,7 +1864,7 @@ func TestCoordinatorFailover(t *testing.T) {
 	endorserPool := seqcommon.DedupeSortedCoordinatorEndorserNodes(
 		[]string{alice.GetName(), bob.GetName()},
 	)
-	priorityList := seqcommon.ComputeCoordinatorPriorityList(ctx, endorserPool, 0, math.MaxUint64)
+	priorityList := seqcommon.ComputeCoordinatorPriorityList(ctx, endorserPool, 0)
 	// Bob should always be the preferred coordinator for this block range - it's permissable for this to change if we
 	// move to a different priority selection algorithm, but in that case the test needs to be updated.
 	require.Equal(t, bob.GetName(), priorityList[0])


### PR DESCRIPTION
Moves block height updates back to a pull rather than a push model. This ensures we always have an up to date block height when needed, without driving work when its not needed, and without the need for the sequencer manager to queue events for every single coordinator and originator.
