### PR TITLE
Include all transactions in delegation message

### DIFF
--- a/core/go/internal/sequencer/transport/transport_writer.go
+++ b/core/go/internal/sequencer/transport/transport_writer.go
@@ -102,32 +102,34 @@ func (tw *transportWriter) SendDelegationRequest(
 	transactions []*components.PrivateTransaction,
 	blockHeight uint64,
 ) error {
+	allTxBytes := make([][]byte, 0, len(transactions))
 	for _, transaction := range transactions {
 		transactionBytes, err := json.Marshal(transaction)
-
 		if err != nil {
-			log.L(ctx).Errorf("error marshalling transaction message: %s", err)
+			log.L(ctx).Errorf("error marshalling transaction for delegation request: %v", err)
+			return err
 		}
+		allTxBytes = append(allTxBytes, transactionBytes)
+	}
 
-		delegationRequest := &engineProto.DelegationRequest{
-			TransactionId:         transaction.ID.String(),
-			DelegateNodeId:        coordinatorNode,
-			PrivateTransaction:    transactionBytes,
-			OriginatorBlockHeight: int64(blockHeight),
-		}
-		delegationRequestBytes, err := proto.Marshal(delegationRequest)
-		if err != nil {
-			log.L(ctx).Errorf("error marshalling delegationRequest  message: %s", err)
-		}
+	delegationRequest := &engineProto.DelegationRequest{
+		DelegateNodeId:        coordinatorNode,
+		OriginatorBlockHeight: int64(blockHeight),
+		PrivateTransactions:   allTxBytes,
+	}
+	delegationRequestBytes, err := proto.Marshal(delegationRequest)
+	if err != nil {
+		log.L(ctx).Errorf("error marshalling delegationRequest message: %s", err)
+		return err
+	}
 
-		if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-			MessageType: MessageType_DelegationRequest,
-			Payload:     delegationRequestBytes,
-			Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-			Node:        coordinatorNode,
-		}); err != nil {
-			log.L(ctx).Warnf("error sending delegationRequest message: %s", err)
-		}
+	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
+		MessageType: MessageType_DelegationRequest,
+		Payload:     delegationRequestBytes,
+		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
+		Node:        coordinatorNode,
+	}); err != nil {
+		log.L(ctx).Warnf("error sending delegationRequest message: %s", err)
 	}
 	return nil
 }

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -264,9 +264,8 @@ func TestSendDelegationRequest_Success(t *testing.T) {
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTransportManager.On("LocalNodeName").Return("local-node").Maybe()
 
-	callCount := 0
+	var capturedRequest engineProto.DelegationRequest
 	mockTransportManager.On("Send", ctx, mock.MatchedBy(func(msg *components.FireAndForgetMessageSend) bool {
-		callCount++
 		if msg.MessageType != MessageType_DelegationRequest {
 			return false
 		}
@@ -276,25 +275,8 @@ func TestSendDelegationRequest_Success(t *testing.T) {
 		if msg.Component.String() != "TRANSACTION_ENGINE" {
 			return false
 		}
-		var delegationRequest engineProto.DelegationRequest
-		err := proto.Unmarshal(msg.Payload, &delegationRequest)
-		if err != nil {
-			return false
-		}
-		if callCount == 1 && delegationRequest.TransactionId != tx1ID.String() {
-			return false
-		}
-		if callCount == 2 && delegationRequest.TransactionId != tx2ID.String() {
-			return false
-		}
-		if delegationRequest.DelegateNodeId != coordinatorNode {
-			return false
-		}
-		if delegationRequest.OriginatorBlockHeight != int64(blockHeight) {
-			return false
-		}
-		return true
-	})).Return(nil).Times(2)
+		return proto.Unmarshal(msg.Payload, &capturedRequest) == nil
+	})).Return(nil).Times(1)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -306,6 +288,18 @@ func TestSendDelegationRequest_Success(t *testing.T) {
 
 	err := tw.SendDelegationRequest(ctx, coordinatorNode, transactions, blockHeight)
 	require.NoError(t, err)
+
+	assert.Equal(t, coordinatorNode, capturedRequest.DelegateNodeId)
+	assert.Equal(t, int64(blockHeight), capturedRequest.OriginatorBlockHeight)
+	require.Len(t, capturedRequest.PrivateTransactions, 2)
+
+	var tx1 components.PrivateTransaction
+	require.NoError(t, json.Unmarshal(capturedRequest.PrivateTransactions[0], &tx1))
+	assert.Equal(t, tx1ID, tx1.ID)
+
+	var tx2 components.PrivateTransaction
+	require.NoError(t, json.Unmarshal(capturedRequest.PrivateTransactions[1], &tx2))
+	assert.Equal(t, tx2ID, tx2.ID)
 }
 
 func TestSendDelegationRequest_EmptyTransactions(t *testing.T) {
@@ -316,6 +310,13 @@ func TestSendDelegationRequest_EmptyTransactions(t *testing.T) {
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
+	mockTransportManager.On("LocalNodeName").Return("local-node").Maybe()
+
+	var capturedRequest engineProto.DelegationRequest
+	mockTransportManager.On("Send", ctx, mock.MatchedBy(func(msg *components.FireAndForgetMessageSend) bool {
+		return msg.MessageType == MessageType_DelegationRequest &&
+			proto.Unmarshal(msg.Payload, &capturedRequest) == nil
+	})).Return(nil).Times(1)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -327,7 +328,7 @@ func TestSendDelegationRequest_EmptyTransactions(t *testing.T) {
 
 	err := tw.SendDelegationRequest(ctx, coordinatorNode, []*components.PrivateTransaction{}, blockHeight)
 	require.NoError(t, err)
-	mockTransportManager.AssertNotCalled(t, "Send")
+	assert.Empty(t, capturedRequest.PrivateTransactions)
 }
 
 // ===== SendDelegationResponse Tests =====

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -422,15 +422,33 @@ func (sMgr *sequencerManager) handleDelegationRequest(ctx context.Context, messa
 		return
 	}
 
-	privateTransaction := &components.PrivateTransaction{}
-	err = json.Unmarshal(delegationRequest.PrivateTransaction, privateTransaction)
-	if err != nil {
-		sMgr.logPaladinMessageJsonUnmarshalError(ctx, "PrivateTransaction", message, err)
-		return
+	transactionDelegatedEvent := &coordinator.TransactionsDelegatedEvent{}
+	transactionDelegatedEvent.FromNode = message.FromNode
+	transactionDelegatedEvent.OriginatorsBlockHeight = uint64(delegationRequest.OriginatorBlockHeight)
+	transactionDelegatedEvent.DelegationID = delegationRequest.DelegationId
+	transactionDelegatedEvent.EventTime = time.Now()
+
+	var contractAddress *pldtypes.EthAddress
+	for _, txBytes := range delegationRequest.PrivateTransactions {
+		privateTransaction := &components.PrivateTransaction{}
+		if err = json.Unmarshal(txBytes, privateTransaction); err != nil {
+			sMgr.logPaladinMessageJsonUnmarshalError(ctx, "PrivateTransaction", message, err)
+			return
+		}
+		if contractAddress == nil {
+			contractAddress = sMgr.parseContractAddressString(ctx, privateTransaction.PreAssembly.TransactionSpecification.ContractInfo.ContractAddress, message)
+			if contractAddress == nil {
+				return
+			}
+		}
+		if transactionDelegatedEvent.Originator == "" {
+			transactionDelegatedEvent.Originator = privateTransaction.PreAssembly.TransactionSpecification.From
+		}
+		transactionDelegatedEvent.Transactions = append(transactionDelegatedEvent.Transactions, privateTransaction)
 	}
 
-	contractAddress := sMgr.parseContractAddressString(ctx, privateTransaction.PreAssembly.TransactionSpecification.ContractInfo.ContractAddress, message)
 	if contractAddress == nil {
+		log.L(ctx).Warnf("delegation request from %s contained no transactions", message.FromNode)
 		return
 	}
 
@@ -439,14 +457,6 @@ func (sMgr *sequencerManager) handleDelegationRequest(ctx context.Context, messa
 		log.L(ctx).Errorf("failed to obtain sequencer to handle delegation request event %v:", err)
 		return
 	}
-
-	transactionDelegatedEvent := &coordinator.TransactionsDelegatedEvent{}
-	transactionDelegatedEvent.FromNode = message.FromNode
-	transactionDelegatedEvent.Originator = privateTransaction.PreAssembly.TransactionSpecification.From
-	transactionDelegatedEvent.Transactions = append(transactionDelegatedEvent.Transactions, privateTransaction)
-	transactionDelegatedEvent.OriginatorsBlockHeight = uint64(delegationRequest.OriginatorBlockHeight)
-	transactionDelegatedEvent.DelegationID = delegationRequest.DelegationId
-	transactionDelegatedEvent.EventTime = time.Now()
 
 	seq.GetCoordinator().QueueEvent(ctx, transactionDelegatedEvent)
 }

--- a/core/go/internal/sequencer/transport_client_test.go
+++ b/core/go/internal/sequencer/transport_client_test.go
@@ -176,11 +176,11 @@ func TestHandleAssembleRequest_Success(t *testing.T) {
 	preAssemblyJSON, _ := json.Marshal(preAssembly)
 
 	assembleRequest := &engineProto.AssembleRequest{
-		TransactionId:     txID.String(),
-		AssembleRequestId: requestID.String(),
-		ContractAddress:   contractAddr.String(),
-		PreAssembly:       preAssemblyJSON,
-		StateLocks:        []byte("{}"),
+		TransactionId:          txID.String(),
+		AssembleRequestId:      requestID.String(),
+		ContractAddress:        contractAddr.String(),
+		PreAssembly:            preAssemblyJSON,
+		StateLocks:             []byte("{}"),
 		CoordinatorBlockHeight: 100,
 	}
 	payload, _ := proto.Marshal(assembleRequest)
@@ -234,11 +234,11 @@ func TestHandleAssembleRequest_InvalidContractAddress(t *testing.T) {
 	preAssemblyJSON, _ := json.Marshal(preAssembly)
 
 	assembleRequest := &engineProto.AssembleRequest{
-		TransactionId:     txID.String(),
-		AssembleRequestId: requestID.String(),
-		ContractAddress:   "invalid-address",
-		PreAssembly:       preAssemblyJSON,
-		StateLocks:        []byte("{}"),
+		TransactionId:          txID.String(),
+		AssembleRequestId:      requestID.String(),
+		ContractAddress:        "invalid-address",
+		PreAssembly:            preAssemblyJSON,
+		StateLocks:             []byte("{}"),
 		CoordinatorBlockHeight: 100,
 	}
 	payload, _ := proto.Marshal(assembleRequest)
@@ -266,11 +266,11 @@ func TestHandleAssembleRequest_SequencerNotLoaded(t *testing.T) {
 	preAssemblyJSON, _ := json.Marshal(preAssembly)
 
 	assembleRequest := &engineProto.AssembleRequest{
-		TransactionId:     txID.String(),
-		AssembleRequestId: requestID.String(),
-		ContractAddress:   contractAddr.String(),
-		PreAssembly:       preAssemblyJSON,
-		StateLocks:        []byte("{}"),
+		TransactionId:          txID.String(),
+		AssembleRequestId:      requestID.String(),
+		ContractAddress:        contractAddr.String(),
+		PreAssembly:            preAssemblyJSON,
+		StateLocks:             []byte("{}"),
 		CoordinatorBlockHeight: 100,
 	}
 	payload, _ := proto.Marshal(assembleRequest)
@@ -413,15 +413,28 @@ func TestHandleAssembleError_Success(t *testing.T) {
 	mocks.coordinator.AssertExpectations(t)
 }
 
-func TestHandleDelegationRequest_Success(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	contractAddr := pldtypes.RandAddress()
+func newDelegationRequestMessage(fromNode string, contractAddr *pldtypes.EthAddress, blockHeight int64, txs ...*components.PrivateTransaction) *components.ReceivedMessage {
+	allTxBytes := make([][]byte, 0, len(txs))
+	for _, tx := range txs {
+		b, _ := json.Marshal(tx)
+		allTxBytes = append(allTxBytes, b)
+	}
+	delegationRequest := &engineProto.DelegationRequest{
+		PrivateTransactions:   allTxBytes,
+		OriginatorBlockHeight: blockHeight,
+	}
+	payload, _ := proto.Marshal(delegationRequest)
+	return &components.ReceivedMessage{
+		FromNode:    fromNode,
+		MessageID:   uuid.New(),
+		MessageType: transport.MessageType_DelegationRequest,
+		Payload:     payload,
+	}
+}
 
-	txID := uuid.New()
-	privateTx := &components.PrivateTransaction{
-		ID: txID,
+func newTestPrivateTx(contractAddr *pldtypes.EthAddress) *components.PrivateTransaction {
+	return &components.PrivateTransaction{
+		ID: uuid.New(),
 		PreAssembly: &components.TransactionPreAssembly{
 			TransactionSpecification: &prototk.TransactionSpecification{
 				ContractInfo: &prototk.ContractInfo{
@@ -431,22 +444,17 @@ func TestHandleDelegationRequest_Success(t *testing.T) {
 			},
 		},
 	}
-	privateTxJSON, _ := json.Marshal(privateTx)
+}
 
-	delegationRequest := &engineProto.DelegationRequest{
-		PrivateTransaction: privateTxJSON,
-		OriginatorBlockHeight:   100,
-	}
-	payload, _ := proto.Marshal(delegationRequest)
+func TestHandleDelegationRequest_Success(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
 
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationRequest,
-		Payload:     payload,
-	}
+	privateTx := newTestPrivateTx(contractAddr)
+	message := newDelegationRequestMessage("test-node", contractAddr, 100, privateTx)
 
-	// Setup mocks - LoadSequencer will be called
 	setupDefaultMocks(ctx, mocks, contractAddr)
 	mocks.components.EXPECT().Persistence().Return(mocks.persistence).Maybe()
 	mocks.persistence.EXPECT().NOTX().Return(nil).Maybe()
@@ -457,12 +465,68 @@ func TestHandleDelegationRequest_Success(t *testing.T) {
 
 	mocks.coordinator.EXPECT().QueueEvent(ctx, mock.MatchedBy(func(e interface{}) bool {
 		event, ok := e.(*coordinator.TransactionsDelegatedEvent)
-		return ok && len(event.Transactions) == 1 && event.Transactions[0].ID == txID
+		return ok &&
+			len(event.Transactions) == 1 &&
+			event.Transactions[0].ID == privateTx.ID &&
+			event.FromNode == "test-node" &&
+			event.Originator == "originator@node1" &&
+			event.OriginatorsBlockHeight == 100
 	})).Once()
 
 	sm.handleDelegationRequest(ctx, message)
 
 	mocks.coordinator.AssertExpectations(t)
+}
+
+func TestHandleDelegationRequest_MultipleTxBatch(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
+
+	tx1 := newTestPrivateTx(contractAddr)
+	tx2 := newTestPrivateTx(contractAddr)
+	tx3 := newTestPrivateTx(contractAddr)
+	message := newDelegationRequestMessage("originator-node", contractAddr, 42, tx1, tx2, tx3)
+
+	setupDefaultMocks(ctx, mocks, contractAddr)
+	mocks.components.EXPECT().Persistence().Return(mocks.persistence).Maybe()
+	mocks.persistence.EXPECT().NOTX().Return(nil).Maybe()
+	mocks.domainManager.EXPECT().GetSmartContractByAddress(ctx, mock.Anything, *contractAddr).Return(nil, nil).Maybe()
+
+	seq := newSequencerForTransportClientTesting(contractAddr, mocks)
+	sm.sequencers[contractAddr.String()] = seq
+
+	mocks.coordinator.EXPECT().QueueEvent(ctx, mock.MatchedBy(func(e interface{}) bool {
+		event, ok := e.(*coordinator.TransactionsDelegatedEvent)
+		if !ok || len(event.Transactions) != 3 {
+			return false
+		}
+		return event.Transactions[0].ID == tx1.ID &&
+			event.Transactions[1].ID == tx2.ID &&
+			event.Transactions[2].ID == tx3.ID &&
+			event.FromNode == "originator-node" &&
+			event.OriginatorsBlockHeight == 42
+	})).Once()
+
+	sm.handleDelegationRequest(ctx, message)
+
+	mocks.coordinator.AssertExpectations(t)
+}
+
+func TestHandleDelegationRequest_EmptyTransactions(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
+
+	// A delegation request with no transactions — coordinator must not be called
+	message := newDelegationRequestMessage("originator-node", contractAddr, 100)
+
+	sm.handleDelegationRequest(ctx, message)
+
+	// No QueueEvent call expected — mocks.coordinator has no registered expectations,
+	// and NewCoordinator(t) will fail the test if QueueEvent is called unexpectedly.
 }
 
 func TestHandleNonceAssigned_Success(t *testing.T) {
@@ -1019,7 +1083,7 @@ func TestHandleEndorsementRequest_Success_Sign(t *testing.T) {
 		TransactionId: txID, IdempotencyKey: idempotencyKey,
 		ContractAddress: contractAddr.String(), Party: party,
 		TransactionSpecification: txSpec,
-		Verifiers: []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
+		Verifiers:                []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
 		InputStates: []*prototk.EndorsableState{state}, ReadStates: []*prototk.EndorsableState{state},
 		OutputStates: []*prototk.EndorsableState{state}, InfoStates: []*prototk.EndorsableState{state},
 		AttestationRequest: attestationRequest,
@@ -1071,7 +1135,7 @@ func TestHandleEndorsementRequest_Success_Revert(t *testing.T) {
 		TransactionId: txID, IdempotencyKey: idempotencyKey,
 		ContractAddress: contractAddr.String(), Party: party,
 		TransactionSpecification: txSpec,
-		Verifiers: []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
+		Verifiers:                []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
 		InputStates: []*prototk.EndorsableState{state}, ReadStates: []*prototk.EndorsableState{state},
 		OutputStates: []*prototk.EndorsableState{state}, InfoStates: []*prototk.EndorsableState{state},
 		AttestationRequest: attestationRequest,
@@ -1123,7 +1187,7 @@ func TestHandleEndorsementRequest_Success_EndorserSubmit(t *testing.T) {
 		TransactionId: txID, IdempotencyKey: idempotencyKey,
 		ContractAddress: contractAddr.String(), Party: party,
 		TransactionSpecification: txSpec,
-		Verifiers: []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
+		Verifiers:                []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
 		InputStates: []*prototk.EndorsableState{state}, ReadStates: []*prototk.EndorsableState{state},
 		OutputStates: []*prototk.EndorsableState{state}, InfoStates: []*prototk.EndorsableState{state},
 		AttestationRequest: attestationRequest,
@@ -1218,7 +1282,7 @@ func TestHandleEndorsementRequest_QueuesEventWithDecodedFields(t *testing.T) {
 		TransactionId: txID, IdempotencyKey: idempotencyKey,
 		ContractAddress: contractAddr.String(), Party: party,
 		TransactionSpecification: txSpec,
-		Verifiers: []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
+		Verifiers:                []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
 		InputStates: []*prototk.EndorsableState{state}, ReadStates: []*prototk.EndorsableState{state},
 		OutputStates: []*prototk.EndorsableState{state}, InfoStates: []*prototk.EndorsableState{state},
 		AttestationRequest: attestationRequest,
@@ -1278,7 +1342,7 @@ func TestHandleEndorsementRequest_LoadSequencerError(t *testing.T) {
 	endorsementRequest := &engineProto.EndorsementRequest{
 		TransactionId: txID, ContractAddress: contractAddr.String(), Party: party,
 		TransactionSpecification: txSpec,
-		Verifiers: []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
+		Verifiers:                []*prototk.ResolvedVerifier{verifier}, Signatures: []*prototk.AttestationResult{signature},
 		InputStates: []*prototk.EndorsableState{state}, ReadStates: []*prototk.EndorsableState{state},
 		OutputStates: []*prototk.EndorsableState{state}, InfoStates: []*prototk.EndorsableState{state},
 		AttestationRequest: attestationRequest,

--- a/core/go/pkg/proto/engine.proto
+++ b/core/go/pkg/proto/engine.proto
@@ -105,11 +105,10 @@ message EndorsementRejection {
 }
 
 message DelegationRequest {
-    string transaction_id = 1;
-    string delegate_node_id = 2;
-    string delegation_id = 3; //this is used to correlate the acknowledgement back to the delegation. unlike the transport message id / correlation id, this is not unique across retries
-    bytes private_transaction = 4; //json serialized copy of the in-memory private transaction object
-    int64 originator_block_height = 5; // the originator's block height upon which this delegation was calculated
+    string delegate_node_id = 1;
+    string delegation_id = 2; //this is used to correlate the acknowledgement back to the delegation. unlike the transport message id / correlation id, this is not unique across retries
+    int64 originator_block_height = 3; // the originator's block height upon which this delegation was calculated
+    repeated bytes private_transactions = 4; // json serialized copies of all in-memory private transaction objects, batched into a single message
 }
 
 message DelegationResponse {


### PR DESCRIPTION
This must have been omitted earlier on. The transport writer interface and transactions delegated event in the coordinator accept multiple transactions, but then at the point of sending each transaction was being put into its own message severing the FIFO ordering between them.