### PR TITLE
Fix reliable message post commit race

### DIFF
--- a/common/go/pkg/pldmsgs/en_descriptions.go
+++ b/common/go/pkg/pldmsgs/en_descriptions.go
@@ -311,7 +311,6 @@ var (
 	PeerStatsLastSend            = pdm("PeerStats.lastSend", "Timestamp of the last send to this peer")
 	PeerStatsLastReceive         = pdm("PeerStats.lastReceive", "Timestamp of the last receive from this peer")
 	PeerStatsReliableHighestSent = pdm("PeerStats.reliableHighestSent", "Outbound reliable messages are assigned a sequence. This is the highest sequence sent to the peer since activation")
-	PeerStatsReliableAckBase     = pdm("PeerStats.reliableAckBase", "Outbound reliable messages are assigned a sequence. This is the lowest sequence that has not received an acknowledgement from the peer")
 
 	ReliableMessageSequence    = pdm("ReliableMessage.sequence", "Sequence number for the position of this message in the local database")
 	ReliableMessageID          = pdm("ReliableMessage.id", "UUID for this message. A separate message, with a separate ID, is allocated for each participant that will receive the message")

--- a/core/go/internal/transportmgr/manager.go
+++ b/core/go/internal/transportmgr/manager.go
@@ -316,6 +316,9 @@ func (tm *transportManager) queueFireAndForget(ctx context.Context, nodeName str
 		return nil
 	case <-ctx.Done():
 		return i18n.NewError(ctx, msgs.MsgContextCanceled)
+	case <-p.senderDone:
+		log.L(ctx).Warnf("peer %s sender stopped before message %s/%s could be queued (discarding)", p.Name, msg.MessageType, msg.MessageId)
+		return nil
 	}
 }
 
@@ -355,9 +358,20 @@ func (tm *transportManager) SendReliable(ctx context.Context, dbTX persistence.D
 		return err
 	}
 
+	// After Create, each message has its DB-assigned Sequence populated. Compute the minimum
+	// sequence per peer so the post-commit notification can correctly seed the scan floor
+	minSeqPerPeer := make(map[string]uint64, len(peers))
+	for _, msg := range msgs {
+		if prev, ok := minSeqPerPeer[msg.Node]; !ok || msg.Sequence < prev {
+			minSeqPerPeer[msg.Node] = msg.Sequence
+		}
+	}
+
 	dbTX.AddPostCommit(func(ctx context.Context) {
-		for _, p := range peers {
-			p.notifyPersistedMsgAvailable()
+		for nodeName, minSeq := range minSeqPerPeer {
+			if p := peers[nodeName]; p != nil {
+				p.notifyPersistedMsgAvailableFromSeq(minSeq)
+			}
 		}
 	})
 	return nil

--- a/core/go/internal/transportmgr/peer.go
+++ b/core/go/internal/transportmgr/peer.go
@@ -19,6 +19,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"math"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -54,9 +55,10 @@ type peer struct {
 
 	// Send loop state (no lock as only used on the loop)
 	lastFullScan          time.Time
-	lastDrainHWM          *uint64
-	persistentMsgsDrained bool
 	consecutiveSendErrors int
+
+	lowestPendingSeqLock sync.Mutex
+	lowestPendingSeq     uint64
 
 	senderStarted atomic.Bool
 	senderDone    chan struct{}
@@ -195,6 +197,8 @@ func (tm *transportManager) connectPeer(ctx context.Context, nodeName string, se
 			sendQueue:              make(chan *msgWithErrChan, tm.senderBufferLen),
 			senderDone:             make(chan struct{}),
 		}
+		// imitialise high - the first pending reliable message sequencer must be lower than the start value
+		p.lowestPendingSeq = math.MaxUint64
 		p.ctx, p.cancelCtx = context.WithCancel(
 			log.WithLogField(tm.bgCtx /* go-routine need bg context*/, "peer", nodeName))
 	}
@@ -261,7 +265,16 @@ func (p *peer) startSender() (string, error) {
 	return p.transport.name, nil
 }
 
-func (p *peer) notifyPersistedMsgAvailable() {
+// notifyPersistedMsgAvailableFromSeq records the minimum sequence number of newly committed
+// reliable messages and signals the sender loop to wake up. If the channel already has a
+// pending notification, the sequence floor is still updated so the next scan starts from
+// the correct position.
+func (p *peer) notifyPersistedMsgAvailableFromSeq(minSeq uint64) {
+	p.lowestPendingSeqLock.Lock()
+	if minSeq < p.lowestPendingSeq {
+		p.lowestPendingSeq = minSeq
+	}
+	p.lowestPendingSeqLock.Unlock()
 	select {
 	case p.persistedMsgsAvailable <- struct{}{}:
 	default:
@@ -287,9 +300,6 @@ func (p *peer) send(msg *prototk.PaladinMsg, reliableSeq *uint64) error {
 	if reliableSeq != nil && *reliableSeq > p.Stats.ReliableHighestSent {
 		p.Stats.ReliableHighestSent = *reliableSeq
 	}
-	if p.lastDrainHWM != nil {
-		p.Stats.ReliableAckBase = *p.lastDrainHWM
-	}
 	return nil
 }
 
@@ -310,17 +320,19 @@ func (p *peer) updateReceivedStats(msg *prototk.PaladinMsg) {
 
 func (p *peer) reliableMessageScan(checkNew bool) error {
 
-	fullScan := p.lastDrainHWM == nil || time.Since(p.lastFullScan) >= p.tm.reliableMessageResend
+	// A full scan queries all unacked messages and applies an age gate before resending.
+	// A triggered scan (checkNew) queries only newly committed messages (from lowestPendingSeq)
+	// and sends them immediately with no age gate.
+	fullScan := !checkNew && (p.lastFullScan.IsZero() || time.Since(p.lastFullScan) >= p.tm.reliableMessageResend)
 	if !fullScan && !checkNew {
 		return nil // Nothing to do
 	}
 	log.L(p.ctx).Debugf(
-		"reliableMessageScan starting node=%s checkNew=%t fullScan=%t pageSize=%d lastDrainHWM=%v",
+		"reliableMessageScan starting node=%s checkNew=%t fullScan=%t pageSize=%d",
 		p.Name,
 		checkNew,
 		fullScan,
 		p.tm.reliableMessagePageSize,
-		p.lastDrainHWM,
 	)
 
 	pageSize := p.tm.reliableMessagePageSize
@@ -328,12 +340,11 @@ func (p *peer) reliableMessageScan(checkNew bool) error {
 	var lastPageEnd *uint64
 	for {
 		log.L(p.ctx).Tracef(
-			"reliableMessageScan querying DB node=%s pageSize=%d fullScan=%t lastPageEnd=%v lastDrainHWM=%v",
+			"reliableMessageScan querying DB node=%s pageSize=%d fullScan=%t lastPageEnd=%v",
 			p.Name,
 			pageSize,
 			fullScan,
 			lastPageEnd,
-			p.lastDrainHWM,
 		)
 		query := p.tm.persistence.DB().
 			WithContext(p.ctx).
@@ -345,7 +356,21 @@ func (p *peer) reliableMessageScan(checkNew bool) error {
 		if lastPageEnd != nil {
 			query = query.Where("sequence > ?", *lastPageEnd)
 		} else if !fullScan {
-			query = query.Where("sequence > ?", *p.lastDrainHWM)
+			// Triggered by a post-commit notification. Consume lowestPendingSeq as the scan
+			// floor so all messages from the triggering (and any concurrent) DB transactions
+			// are found, including those that committed out-of-order relative to each other.
+			p.lowestPendingSeqLock.Lock()
+			startSeq := p.lowestPendingSeq
+			p.lowestPendingSeq = math.MaxUint64
+			p.lowestPendingSeqLock.Unlock()
+			if startSeq == math.MaxUint64 {
+				// Stale notification: a concurrent scan already consumed and reset lowestPendingSeq,
+				// covering the messages from this notification's batch. Nothing left to scan.
+				log.L(p.ctx).Debugf("reliableMessageScan triggered scan on node=%s skipped - stale notification (lowestPendingSeq already consumed)", p.Name)
+				break
+			}
+			log.L(p.ctx).Tracef("reliableMessageScan triggered scan from sequence %d", startSeq)
+			query = query.Where("sequence >= ?", startSeq)
 		}
 
 		var page []*pldapi.ReliableMessage
@@ -366,14 +391,13 @@ func (p *peer) reliableMessageScan(checkNew bool) error {
 		}
 
 		// Process the page - building and sending the proto messages
-		if err = p.processReliableMsgPage(p.tm.persistence.NOTX(), page); err != nil {
+		if err = p.processReliableMsgPage(p.tm.persistence.NOTX(), page, checkNew); err != nil {
 			// Errors returned are retryable - for data errors the function
 			// must record those as acks with an error.
 			return err
 		}
 
 		if len(page) > 0 {
-			p.persistentMsgsDrained = false // we know there's some messages
 			total += len(page)
 			lastPageEnd = &page[len(page)-1].Sequence
 		}
@@ -387,24 +411,15 @@ func (p *peer) reliableMessageScan(checkNew bool) error {
 
 	log.L(p.ctx).Debugf("reliableMessageScan fullScan=%t total=%d lastPageEnd=%v", fullScan, total, lastPageEnd)
 
-	// If we found anything, then mark that as our high water mark for
-	// future scans. If an empty full scan - then we store nil
-	if lastPageEnd != nil || fullScan {
-		p.lastDrainHWM = lastPageEnd
-	}
-
 	// Record the last full scan
 	if fullScan {
-		// We only know we're empty when we do a full re-scan, and that comes back empty
-		p.persistentMsgsDrained = (total == 0)
-
 		p.lastFullScan = time.Now()
 	}
 
 	return nil
 }
 
-func (p *peer) processReliableMsgPage(dbTX persistence.DBTX, page []*pldapi.ReliableMessage) (err error) {
+func (p *peer) processReliableMsgPage(dbTX persistence.DBTX, page []*pldapi.ReliableMessage, isTriggeredScan bool) (err error) {
 
 	type paladinMsgWithSeq struct {
 		*prototk.PaladinMsg
@@ -416,10 +431,11 @@ func (p *peer) processReliableMsgPage(dbTX persistence.DBTX, page []*pldapi.Reli
 	var errorAcks []*pldapi.ReliableMessageAck
 	for _, rm := range page {
 
-		// Check it's either after our HWM, or eligible for re-send
-		afterHWM := p.lastDrainHWM == nil || *p.lastDrainHWM < rm.Sequence
-		if !afterHWM && time.Since(rm.Created.Time()) < p.tm.reliableMessageResend {
-			log.L(p.ctx).Infof("Unacknowledged message %s not yet eligible for re-send", rm.ID)
+		// Triggered scans deliver freshly committed messages — send immediately.
+		// Periodic full scans may re-encounter messages already sent; skip them until
+		// enough time has passed that a resend is warranted.
+		if !isTriggeredScan && time.Since(rm.Created.Time()) < p.tm.reliableMessageResend {
+			log.L(p.ctx).Debugf("Unacknowledged message %s not yet eligible for re-send", rm.ID)
 			continue
 		}
 		log.L(p.ctx).Debugf(

--- a/core/go/internal/transportmgr/peer_test.go
+++ b/core/go/internal/transportmgr/peer_test.go
@@ -488,7 +488,6 @@ func TestGetReliableMessageScanNoAction(t *testing.T) {
 
 	p := &peer{
 		tm:           tm,
-		lastDrainHWM: confutil.P(uint64(100)),
 		lastFullScan: time.Now(),
 	}
 
@@ -496,24 +495,24 @@ func TestGetReliableMessageScanNoAction(t *testing.T) {
 
 }
 
-func TestProcessReliableMsgPageIgnoreBeforeHWM(t *testing.T) {
+func TestProcessReliableMsgPageFullScanIgnoreRecent(t *testing.T) {
 
 	ctx, tm, _, done := newTestTransport(t, false)
 	defer done()
 
 	p := &peer{
-		ctx:          ctx,
-		tm:           tm,
-		lastDrainHWM: confutil.P(uint64(100)),
+		ctx: ctx,
+		tm:  tm,
 	}
 
+	// A full scan (isTriggeredScan=false) should skip messages created less than reliableMessageResend ago.
 	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{
 		{
 			ID:       uuid.New(),
 			Sequence: 50,
 			Created:  pldtypes.TimestampNow(),
 		},
-	})
+	}, false)
 	require.NoError(t, err)
 
 }
@@ -537,7 +536,7 @@ func TestProcessReliableMsgPageIgnoreUnsupported(t *testing.T) {
 			Created:     pldtypes.TimestampNow(),
 			MessageType: pldtypes.Enum[pldapi.ReliableMessageType]("wrong"),
 		},
-	})
+	}, true)
 	require.Regexp(t, "pop", err)
 
 }
@@ -573,7 +572,7 @@ func TestProcessReliableMsgPageInsertFail(t *testing.T) {
 		Created:     pldtypes.TimestampNow(),
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.Regexp(t, "PD020302", err)
 
 }
@@ -622,7 +621,7 @@ func TestProcessReliableMsgPagePrivacyGroup(t *testing.T) {
 		return nil, nil
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.NoError(t, err)
 
 	sentMsg := <-sentMessages
@@ -688,7 +687,7 @@ func TestProcessReliableMsgPagePrivacyGroupMessage(t *testing.T) {
 		return nil, nil
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.NoError(t, err)
 
 	sentMsg := <-sentMessages
@@ -740,7 +739,7 @@ func TestProcessReliableMsgPageReceipt(t *testing.T) {
 		return nil, nil
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.NoError(t, err)
 
 	sentMsg := <-sentMessages
@@ -965,7 +964,7 @@ func TestProcessReliableMsgPagePublicTransactionSubmission(t *testing.T) {
 		return nil, nil
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.NoError(t, err)
 
 	sentMsg := <-sentMessages
@@ -1025,7 +1024,7 @@ func TestProcessReliableMsgPageSequencingActivity(t *testing.T) {
 		return nil, nil
 	}
 
-	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm})
+	err := p.processReliableMsgPage(tm.persistence.NOTX(), []*pldapi.ReliableMessage{rm}, true)
 	require.NoError(t, err)
 
 	sentMsg := <-sentMessages

--- a/core/go/internal/transportmgr/transport_test.go
+++ b/core/go/internal/transportmgr/transport_test.go
@@ -507,6 +507,28 @@ func TestSendContextClosed(t *testing.T) {
 
 }
 
+func TestSendSenderStopped(t *testing.T) {
+	ctx, tm, tp, done := newTestTransport(t, false)
+	defer done()
+
+	senderDone := make(chan struct{})
+	close(senderDone)
+
+	p := &peer{
+		transport:  tp.t,
+		sendQueue:  make(chan *msgWithErrChan), // no readers, so the send case never fires
+		senderDone: senderDone,
+	}
+	tm.peers = map[string]*peer{
+		"node2": p,
+	}
+	p.senderStarted.Store(true)
+	defer delete(tm.peers, "node2") // remove before done() runs to avoid Stop() trying to reap this bare peer
+
+	err := tm.Send(ctx, testMessage())
+	assert.NoError(t, err)
+}
+
 func TestSendReliableOk(t *testing.T) {
 	ctx, tm, tp, done := newTestTransport(t, false,
 		mockGoodTransport,

--- a/doc-site/docs/reference/types/peerinfo.md
+++ b/doc-site/docs/reference/types/peerinfo.md
@@ -16,8 +16,7 @@ title: PeerInfo
         "receivedBytes": 0,
         "lastSend": null,
         "lastReceive": null,
-        "reliableHighestSent": 0,
-        "reliableAckBase": 0
+        "reliableHighestSent": 0
     },
     "activated": 0
 }
@@ -46,6 +45,5 @@ title: PeerInfo
 | `lastSend` | Timestamp of the last send to this peer | [`Timestamp`](simpletypes.md#timestamp) |
 | `lastReceive` | Timestamp of the last receive from this peer | [`Timestamp`](simpletypes.md#timestamp) |
 | `reliableHighestSent` | Outbound reliable messages are assigned a sequence. This is the highest sequence sent to the peer since activation | `uint64` |
-| `reliableAckBase` | Outbound reliable messages are assigned a sequence. This is the lowest sequence that has not received an acknowledgement from the peer | `uint64` |
 
 

--- a/sdk/go/pkg/pldapi/peerinfo.go
+++ b/sdk/go/pkg/pldapi/peerinfo.go
@@ -36,5 +36,4 @@ type PeerStats struct {
 	LastSend            *pldtypes.Timestamp `docstruct:"PeerStats" json:"lastSend"`
 	LastReceive         *pldtypes.Timestamp `docstruct:"PeerStats" json:"lastReceive"`
 	ReliableHighestSent uint64              `docstruct:"PeerStats" json:"reliableHighestSent"`
-	ReliableAckBase     uint64              `docstruct:"PeerStats" json:"reliableAckBase"`
 }

--- a/sdk/typescript/src/interfaces/transport.ts
+++ b/sdk/typescript/src/interfaces/transport.ts
@@ -15,7 +15,6 @@ export interface IPeerStats {
   lastSend?: string;
   lastReceive?: string;
   reliableHighestSent: number;
-  reliableAckBase: number;
 }
 
 export interface IReliableMessage {

--- a/ui/client/src/components/TransportPeer.tsx
+++ b/ui/client/src/components/TransportPeer.tsx
@@ -70,11 +70,6 @@ export const TransportPeer: React.FC<Props> = ({ transportPeer }) => {
             <Typography align="center" variant="h6" color="textPrimary">{transportPeer.stats.reliableHighestSent.toLocaleString()}</Typography>
             <Typography align="center" variant="body2" color="textSecondary">{t('reliableHighestSent')}</Typography>
           </Grid2>
-
-          <Grid2>
-            <Typography align="center" variant="h6" color="textPrimary">{transportPeer.stats.reliableAckBase.toLocaleString()}</Typography>
-            <Typography align="center" variant="body2" color="textSecondary">{t('reliableHighestAck')}</Typography>
-          </Grid2>
         </Grid2>
       </Box>
       <Box sx={{ padding: '10px' }}>


### PR DESCRIPTION
Addresses two bugs found in transport manager

---
When multiple reliable messages are being inserted, there is no guarantee that their commits will complete in the same order as their assigned sequence numbers. The post commit notifies the peer that there are messages to send, and if it gets notified before This could result in the `lastDrainHWM` being advanced past a message sequence that is not yet committed. This message will not be sent until the full scan runs, as the sequence is below the `lastDrainHWM`.

This PR replaces `lastDrainHWM` with a `lowestPendingSeq`. This is reset between each triggered scan, so it can always be lowered for the lowest possible sequencer the triggered scan may need to send. In the case where we've had out of order commits, this will likely result in the message with the later sequencer/earlier commit being immediately resent (where we usually enforce the resend interval before a retry), but this is a) tolerated by at least once delivery and b) isn't going to be the sort of endless spamming of unacked messages that the age gate is supposed to prevent.

---
If there is a problem in draining the fire and forget send queue (likely because of a bug somewhere else in the system), a peer can be reaped while there are still messages on its queue to send. This is not a problem, since the semantics are at most once delivery. What is a problem is that if a sender is waiting in a select on the buffered channel, once the peer is reaped, there is no way out of that select. This PR adds an additional `senderDone` check into the select to prevent this blocking behaviour.