### PR TITLE
Calculate inactive grace period based on full heartbeat interval periods

### DIFF
--- a/core/go/internal/sequencer/coordinator/inactive_test.go
+++ b/core/go/internal/sequencer/coordinator/inactive_test.go
@@ -84,10 +84,18 @@ func Test_guard_InactiveGracePeriodExceeded_NotExceeded(t *testing.T) {
 	assert.False(t, guard_InactiveGracePeriodExceeded(ctx, c))
 }
 
-func Test_guard_InactiveGracePeriodExceeded_ExactlyMet(t *testing.T) {
+func Test_guard_InactiveGracePeriodExceeded_AtThreshold_DoesNotFire(t *testing.T) {
 	ctx := context.Background()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Observing).
 		InactiveGracePeriod(10).HeartbeatIntervalsSinceLastReceive(10).Build()
+
+	assert.False(t, guard_InactiveGracePeriodExceeded(ctx, c))
+}
+
+func Test_guard_InactiveGracePeriodExceeded_MinimumExceeded(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Observing).
+		InactiveGracePeriod(10).HeartbeatIntervalsSinceLastReceive(11).Build()
 
 	assert.True(t, guard_InactiveGracePeriodExceeded(ctx, c))
 }

--- a/core/go/internal/sequencer/coordinator/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/snapshot.go
@@ -99,7 +99,9 @@ func (c *coordinator) updateOriginatorActivity(ctx context.Context) {
 	}
 
 	for node, count := range c.originatorActivity {
-		if count >= c.inactiveGracePeriod {
+		// measure number of complete heartbeat interval periods - e.g. count of 2 means
+		// 1 full heartbeat interval has elapsed, hence use of > not >=
+		if count > c.inactiveGracePeriod {
 			log.L(ctx).Debugf("pruning originator %s from activity map after %d heartbeat intervals of inactivity", node, count)
 			delete(c.originatorActivity, node)
 		}

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -297,10 +297,10 @@ func TestCoordinator_WhenObserving_TransitionsToIdle_OnHeartbeatIntervalInactive
 	ctx := t.Context()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Observing).
 		InactiveGracePeriod(3).
-		HeartbeatIntervalsSinceLastReceive(2).
+		HeartbeatIntervalsSinceLastReceive(3).
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
-	// action_IncrementHeartbeatIntervalCounts bumps counter to 3; guard_InactiveGracePeriodExceeded = true
+	// action_IncrementHeartbeatIntervalCounts bumps counter to 4; guard_InactiveGracePeriodExceeded = (4 > 3) = true
 	assert.Equal(t, State_Idle, c.GetCurrentState())
 	assert.Equal(t, 3, c.heartbeatIntervalsSinceLastReceive, "counter must be at grace-period threshold after increment")
 }
@@ -312,7 +312,7 @@ func TestCoordinator_WhenObserving_HeartbeatInterval_WithinGrace_IncrementsCount
 		InactiveGracePeriod(3).
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
-	// Counter bumps to 2; guard_InactiveGracePeriodExceeded = (2 >= 3) = false → stays Observing.
+	// Counter bumps to 2; guard_InactiveGracePeriodExceeded = (2 > 3) = false → stays Observing.
 	assert.Equal(t, State_Observing, c.GetCurrentState())
 	assert.Equal(t, 2, c.heartbeatIntervalsSinceLastReceive, "counter must be incremented")
 }
@@ -1010,8 +1010,8 @@ func TestCoordinator_WhenPrepared_HeartbeatInterval_GraceExceeded_TransitionsToA
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Prepared).
 		NodeName("node1").
 		CurrentActiveCoordinator("node2").
-		HeartbeatIntervalsSinceLastReceive(2).
-		InactiveGracePeriod(3). // after increment: 3 >= 3 → Active
+		HeartbeatIntervalsSinceLastReceive(3).
+		InactiveGracePeriod(3). // after increment: 4 > 3 → Active
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
 	// guard_InactiveGracePeriodExceeded = true → transitions to Active
@@ -2722,13 +2722,13 @@ func TestCoordinator_WhenClosingGraceExpires_WithNewActiveHeartbeatSeen_Transiti
 	ctx := t.Context()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
 		ClosingGracePeriod(1).
-		HeartbeatIntervalsSinceStateChange(0).
+		HeartbeatIntervalsSinceStateChange(1).
 		HeartbeatIntervalsSinceLastReceive(0). // recent heartbeat seen
 		InactiveGracePeriod(5).
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
-	// heartbeatIntervalsSinceStateChange → 1; closingGracePeriodExpired = 1>=1 true
-	// heartbeatIntervalsSinceLastReceive = 0; inactiveGracePeriodExceeded = 0>=5 false
+	// heartbeatIntervalsSinceStateChange → 2; closingGracePeriodExpired = 2>1 true
+	// heartbeatIntervalsSinceLastReceive = 0; inactiveGracePeriodExceeded = 0>5 false
 	assert.Equal(t, State_Observing, c.GetCurrentState())
 }
 
@@ -2736,13 +2736,13 @@ func TestCoordinator_WhenClosingGraceExpires_WithoutNewActiveHeartbeat_Transitio
 	ctx := t.Context()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
 		ClosingGracePeriod(1).
-		HeartbeatIntervalsSinceStateChange(0).
-		HeartbeatIntervalsSinceLastReceive(5). // no heartbeat seen; counter already at grace
+		HeartbeatIntervalsSinceStateChange(1).
+		HeartbeatIntervalsSinceLastReceive(6). // no heartbeat seen; counter already past grace
 		InactiveGracePeriod(5).
 		Build()
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
-	// heartbeatIntervalsSinceStateChange → 1; closingGracePeriodExpired = 1>=1 true
-	// heartbeatIntervalsSinceLastReceive = 5 (not incremented by this action); inactiveGracePeriodExceeded = 5>=5 true
+	// heartbeatIntervalsSinceStateChange → 2; closingGracePeriodExpired = 2>1 true
+	// heartbeatIntervalsSinceLastReceive = 6 (not incremented by this action); inactiveGracePeriodExceeded = 6>5 true
 	assert.Equal(t, State_Idle, c.GetCurrentState())
 }
 
@@ -2814,8 +2814,8 @@ func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoord
 		NodeName("node3").
 		CurrentActiveCoordinator("node1").
 		CoordinatorPriorityList("node1", "node2", "node3").
-		HeartbeatIntervalsSinceLastReceive(5).
-		InactiveGracePeriod(5). // 5 >= 5 → exceeded
+		HeartbeatIntervalsSinceLastReceive(6).
+		InactiveGracePeriod(5). // 6 > 5 → exceeded
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -302,7 +302,7 @@ func TestCoordinator_WhenObserving_TransitionsToIdle_OnHeartbeatIntervalInactive
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
 	// action_IncrementHeartbeatIntervalCounts bumps counter to 4; guard_InactiveGracePeriodExceeded = (4 > 3) = true
 	assert.Equal(t, State_Idle, c.GetCurrentState())
-	assert.Equal(t, 3, c.heartbeatIntervalsSinceLastReceive, "counter must be at grace-period threshold after increment")
+	assert.Equal(t, 4, c.heartbeatIntervalsSinceLastReceive, "counter must be past the grace-period threshold after increment")
 }
 
 func TestCoordinator_WhenObserving_HeartbeatInterval_WithinGrace_IncrementsCounterAndStaysObserving(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/state_transition_guards.go
+++ b/core/go/internal/sequencer/coordinator/state_transition_guards.go
@@ -39,7 +39,9 @@ func guard_HasTransactionsInflight(_ context.Context, c *coordinator) bool {
 }
 
 func guard_ClosingGracePeriodExpired(_ context.Context, c *coordinator) bool {
-	return c.heartbeatIntervalsSinceStateChange >= c.closingGracePeriod
+	// measure number of complete heartbeat interval periods - e.g. count of 2 means
+	// 1 full heartbeat interval has elapsed, hence use of > not >=
+	return c.heartbeatIntervalsSinceStateChange > c.closingGracePeriod
 }
 
 func guard_HasTransactionAssembling(ctx context.Context, c *coordinator) bool {
@@ -54,7 +56,9 @@ func guard_HasTransactionAssembling(ctx context.Context, c *coordinator) bool {
 // guard_InactiveGracePeriodExceeded returns true when no heartbeat has been received for at least
 // inactiveGracePeriod heartbeat intervals.
 func guard_InactiveGracePeriodExceeded(_ context.Context, c *coordinator) bool {
-	return c.heartbeatIntervalsSinceLastReceive >= c.inactiveGracePeriod
+	// measure number of complete heartbeat interval periods - e.g. count of 2 means
+	// 1 full heartbeat interval has elapsed, hence use of > not >=
+	return c.heartbeatIntervalsSinceLastReceive > c.inactiveGracePeriod
 }
 
 // guard_IsHigherPriorityThanCurrentActive returns true when this node has a strictly higher

--- a/core/go/internal/sequencer/coordinator/state_transition_guards_test.go
+++ b/core/go/internal/sequencer/coordinator/state_transition_guards_test.go
@@ -256,3 +256,48 @@ func TestGuard_HasTransactionAssembling_MixOfAssemblingAndOtherStates(t *testing
 	result := guard_HasTransactionAssembling(ctx, c)
 	assert.True(t, result, "mix with Assembling should return true")
 }
+
+func TestGuard_ClosingGracePeriodExpired_FalseWhenLessThan(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+		ClosingGracePeriod(5).
+		HeartbeatIntervalsSinceStateChange(3).
+		Build()
+	assert.False(t, guard_ClosingGracePeriodExpired(ctx, c))
+}
+
+func TestGuard_ClosingGracePeriodExpired_FalseWhenEqual(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+		ClosingGracePeriod(5).
+		HeartbeatIntervalsSinceStateChange(5).
+		Build()
+	assert.False(t, guard_ClosingGracePeriodExpired(ctx, c))
+}
+
+func TestGuard_ClosingGracePeriodExpired_TrueWhenGreaterThan(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+		ClosingGracePeriod(5).
+		HeartbeatIntervalsSinceStateChange(7).
+		Build()
+	assert.True(t, guard_ClosingGracePeriodExpired(ctx, c))
+}
+
+func TestGuard_ClosingGracePeriodExpired_MinimumGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+		ClosingGracePeriod(1).
+		HeartbeatIntervalsSinceStateChange(2).
+		Build()
+	assert.True(t, guard_ClosingGracePeriodExpired(ctx, c))
+}
+
+func TestGuard_ClosingGracePeriodExpired_ZeroHeartbeatIntervals(t *testing.T) {
+	ctx := context.Background()
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Closing).
+		ClosingGracePeriod(5).
+		HeartbeatIntervalsSinceStateChange(0).
+		Build()
+	assert.False(t, guard_ClosingGracePeriodExpired(ctx, c))
+}

--- a/core/go/internal/sequencer/coordinator/transaction/finalizing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/finalizing.go
@@ -24,7 +24,9 @@ import (
 func guard_HasFinalizingGracePeriodPassedSinceStateChange(ctx context.Context, txn *coordinatorTransaction) bool {
 	// Has this transaction been in the same state for longer than the finalizing grace period?
 	// most useful to know this once we have reached one of the terminal states - Reverted or Committed
-	return txn.heartbeatIntervalsSinceStateChange >= txn.finalizingGracePeriod
+	// measure number of complete heartbeat interval periods - e.g. count of 2 means
+	// 1 full heartbeat interval has elapsed, hence use of > not >=
+	return txn.heartbeatIntervalsSinceStateChange > txn.finalizingGracePeriod
 }
 
 // action_FinalizeAsUnknownByOriginator is called when the originator reports that it doesn't recognize

--- a/core/go/internal/sequencer/coordinator/transaction/finalizing_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/finalizing_test.go
@@ -32,15 +32,14 @@ func Test_guard_HasFinalizingGracePeriodPassedSinceStateChange_FalseWhenLessThan
 	assert.False(t, guard_HasFinalizingGracePeriodPassedSinceStateChange(ctx, txn))
 }
 
-func Test_guard_HasFinalizingGracePeriodPassedSinceStateChange_TrueWhenEqual(t *testing.T) {
+func Test_guard_HasFinalizingGracePeriodPassedSinceStateChange_FalseWhenEqual(t *testing.T) {
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
 		FinalizingGracePeriod(5).
 		HeartbeatIntervalsSinceStateChange(5).
 		Build()
 
-	// Should return true when heartbeat intervals equals grace period
-	assert.True(t, guard_HasFinalizingGracePeriodPassedSinceStateChange(ctx, txn))
+	assert.False(t, guard_HasFinalizingGracePeriodPassedSinceStateChange(ctx, txn))
 }
 
 func Test_guard_HasFinalizingGracePeriodPassedSinceStateChange_TrueWhenGreaterThan(t *testing.T) {
@@ -58,10 +57,9 @@ func Test_guard_HasFinalizingGracePeriodPassedSinceStateChange_ZeroGracePeriod(t
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
 		FinalizingGracePeriod(0).
-		HeartbeatIntervalsSinceStateChange(0).
+		HeartbeatIntervalsSinceStateChange(1).
 		Build()
 
-	// Should return true when both are zero (0 >= 0)
 	assert.True(t, guard_HasFinalizingGracePeriodPassedSinceStateChange(ctx, txn))
 }
 
@@ -90,4 +88,3 @@ func Test_action_FinalizeAsUnknownByOriginator_CancelsRequestStateTimeoutSchedul
 	// Verify the cancel function was called
 	assert.True(t, cancelCalled, "assemble request timeout cancel should have been called")
 }
-

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
@@ -77,6 +77,10 @@ func Test_StateConfirmed_TransitionsToFinalBasedOnFinalizingGracePeriod(t *testi
 
 	err = txn.HandleEvent(ctx, &common.HeartbeatIntervalEvent{})
 	require.NoError(t, err)
+	assert.Equal(t, State_Confirmed, txn.stateMachine.GetCurrentState())
+
+	err = txn.HandleEvent(ctx, &common.HeartbeatIntervalEvent{})
+	require.NoError(t, err)
 	assert.Equal(t, State_Final, txn.stateMachine.GetCurrentState())
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/dependencytracker"
-	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/core/mocks/graphermocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
@@ -819,10 +819,10 @@ func TestCoordinatorTransaction_Endorsement_Gathering_StaysInState_OnEndorseReve
 	}
 
 	event := &EndorseRevertEvent{
-		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.pt.ID},
-		Party:                party1,
+		BaseCoordinatorEvent:   BaseCoordinatorEvent{TransactionID: txn.pt.ID},
+		Party:                  party1,
 		AttestationRequestName: "endorse-multisig",
-		RevertReason:         "assembly state is stale",
+		RevertReason:           "assembly state is stale",
 	}
 	err := txn.HandleEvent(ctx, event)
 	require.NoError(t, err)
@@ -1406,8 +1406,10 @@ func TestCoordinatorTransaction_Dispatched_ToPreAssemblyBlocked_OnConfirmedRever
 
 func TestCoordinatorTransaction_Reverted_ToFinal_OnHeartbeat_WhenFinalizingGracePeriodPassed(t *testing.T) {
 	ctx := context.Background()
+	// Start at count 1 so that after the heartbeat increments to 2, the guard 2 > 1 fires.
 	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).
 		FinalizingGracePeriod(1).
+		HeartbeatIntervalsSinceStateChange(1).
 		Build()
 
 	err := txn.HandleEvent(ctx, &common.HeartbeatIntervalEvent{})
@@ -1418,7 +1420,7 @@ func TestCoordinatorTransaction_Reverted_ToFinal_OnHeartbeat_WhenFinalizingGrace
 func TestCoordinatorTransaction_Confirmed_ToFinal_OnHeartbeatInterval_IfHasBeenIncludedInEnoughHeartbeats(t *testing.T) {
 	ctx := context.Background()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
-		HeartbeatIntervalsSinceStateChange(4).
+		HeartbeatIntervalsSinceStateChange(5).
 		Build()
 
 	err := txn.HandleEvent(ctx, &common.HeartbeatIntervalEvent{})

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -140,7 +140,7 @@ func Test_validator_HasDroppedTransactions_FalseWhenNoInFlightTransactions(t *te
 func Test_guard_InactiveGracePeriodExceeded_WhileObserving_TrueWhenCounterExceedsThreshold(t *testing.T) {
 	ctx := context.Background()
 	o, _ := NewOriginatorBuilderForTesting(t, State_Observing).
-		HeartbeatIntervalsSinceLastReceive(10).
+		HeartbeatIntervalsSinceLastReceive(11).
 		InactiveGracePeriod(10).
 		Build()
 	assert.True(t, guard_InactiveGracePeriodExceeded(ctx, o))

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -747,7 +747,7 @@ func Test_ProcessEvent_HeartbeatReceived_InactiveFallback_RedirectsAndProcessesH
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		CurrentActiveCoordinator("node1").
 		CoordinatorPriorityList("node1", "node2", "node3").
-		HeartbeatIntervalsSinceLastReceive(10).
+		HeartbeatIntervalsSinceLastReceive(11).
 		InactiveGracePeriod(10).
 		Build()
 

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -187,7 +187,9 @@ func action_ResetToTopPriorityCoordinator(ctx context.Context, o *originator, _ 
 }
 
 func guard_InactiveGracePeriodExceeded(_ context.Context, o *originator) bool {
-	return o.heartbeatIntervalsSinceLastReceive >= o.inactiveGracePeriod
+	// measure number of complete heartbeat interval periods - e.g. count of 2 means
+	// 1 full heartbeat interval has elapsed, hence use of > not >=
+	return o.heartbeatIntervalsSinceLastReceive > o.inactiveGracePeriod
 }
 
 // validator_IsFromCurrentCoordinator returns true when the heartbeat sender is the currently

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -378,7 +378,7 @@ func Test_validator_OriginatorTransactionStateTransitionToReverted(t *testing.T)
 func Test_guard_InactiveGracePeriodExceeded_WhileSending_TrueWhenCounterExceedsThreshold(t *testing.T) {
 	ctx := context.Background()
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		HeartbeatIntervalsSinceLastReceive(2).
+		HeartbeatIntervalsSinceLastReceive(3).
 		InactiveGracePeriod(2).
 		Build()
 	assert.True(t, guard_InactiveGracePeriodExceeded(ctx, o))

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -438,14 +438,14 @@ func TestStateMachine_Observing_HeartbeatInterval_WithinGrace_StaysObserving(t *
 func TestStateMachine_Observing_HeartbeatInterval_GraceExceeded_TransitionsToIdle(t *testing.T) {
 	ctx := context.Background()
 	o, _ := NewOriginatorBuilderForTesting(t, State_Observing).
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		Build()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
 
 	assert.Equal(t, State_Idle, o.GetCurrentState())
-	assert.Equal(t, 2, o.heartbeatIntervalsSinceLastReceive, "counter must be incremented before transition check")
+	assert.Equal(t, 3, o.heartbeatIntervalsSinceLastReceive, "counter must be incremented before transition check")
 }
 
 // EndorserNodesDiscovered in Observing updates endorserCandidates and recomputes the priority list.
@@ -696,7 +696,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_NoEndorserMode_Red
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	builder := NewOriginatorBuilderForTesting(t, State_Sending).
 		CurrentActiveCoordinator("coordinator@node1").
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		WithMockTransportWriter(t).
 		Transactions(mockTxn)
@@ -711,7 +711,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_NoEndorserMode_Red
 
 	assert.Equal(t, State_Sending, o.GetCurrentState())
 	// Counter is incremented by action_IncrementHeartbeatIntervalCounts but NOT reset (no priority list).
-	assert.Equal(t, 2, o.heartbeatIntervalsSinceLastReceive)
+	assert.Equal(t, 3, o.heartbeatIntervalsSinceLastReceive)
 }
 
 // HeartbeatInterval in Sending exceeding grace → ENDORSER mode: failover to next-priority
@@ -727,7 +727,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_Failo
 		CurrentActiveCoordinator("A").
 		CoordinatorPriorityList("A", "B", "C").
 		FailoverIndex(1). // A is at index 0 → next failover target is index 1 = "B"
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		WithMockTransportWriter(t).
 		Transactions(mockTxn)
@@ -759,7 +759,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_WrapA
 		CurrentActiveCoordinator("B").
 		CoordinatorPriorityList("A", "B", "C").
 		FailoverIndex(2). // pointing to last slot "C"
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		WithMockTransportWriter(t).
 		Transactions(mockTxn)
@@ -971,8 +971,8 @@ func TestStateMachine_Sending_HeartbeatReceived_Step3_GraceExceeded_SwitchesCoor
 		CurrentActiveCoordinator("node1").
 		CoordinatorPriorityList("node1", "node2", "node3").
 		FailoverIndex(1). // will be recalibrated to 0 after switch to node3 (index 2, not top)
-		HeartbeatIntervalsSinceLastReceive(2).
-		InactiveGracePeriod(2). // 2 >= 2 → exceeded
+		HeartbeatIntervalsSinceLastReceive(3).
+		InactiveGracePeriod(2). // 3 > 2 → exceeded
 		WithMockTransportWriter(t).
 		Transactions(mockTxn)
 	o, mocks := builder.Build()

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -54,7 +54,7 @@ func TestStateMachine_Idle_OnTransitionTo_EndorserMode_ResetsToTopPriorityAndSet
 	o, _ := NewOriginatorBuilderForTesting(t, State_Observing).
 		CurrentActiveCoordinator("C").
 		CoordinatorPriorityList("A", "B", "C").
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		Build()
 
@@ -72,7 +72,7 @@ func TestStateMachine_Idle_OnTransitionTo_NoEndorserMode_NoChange(t *testing.T) 
 	ctx := context.Background()
 	o, _ := NewOriginatorBuilderForTesting(t, State_Observing).
 		CurrentActiveCoordinator("coordinator@node1").
-		HeartbeatIntervalsSinceLastReceive(1).
+		HeartbeatIntervalsSinceLastReceive(2).
 		InactiveGracePeriod(2).
 		FailoverIndex(3).
 		Build()


### PR DESCRIPTION
We have been calculating the inactive grace period based on number of heartbeat interval events received since something last occurred. I'm proposing that we change this to being full heartbeat interval periods instead. These are almost equivalent, you just need to see one more event when calculating based on full periods, but it gives a neater experience around specifying minimums.

We currently have a minimum of `1` but this is broken in the current model. Even in a well functioning system we are guaranteed to get an interval event in between heartbeats, meaning an originator would always consider a coordinator inactive at that point and constantly redelegate.

With our default of `2`, there are still some problematic edge cases. If we see, for example, with a 10s heartbeat interval
- T - heartbeat arrives
- T + 1ms - heartbeat interval event fires
- T + 10,0001 ms - heartbeat interval event fires
- T + 10,0002 ms - heartbeat arrives

We're going to consider the coordinator inactive - yet given heartbeats are processed on what might be a busy event loop, and sent over the network, so it is expected that we might see some variation above and below the 10s in when we get heartbeats.

By counting full interval periods we can keep our minimum at 1 (probably not desirable but fine if you want very low tolerance for latency in a system that is not overloaded), and our default at 2. Whereas it feels harder to explain a minimum of 2 if we don't change how we do the counting.

