### PR TITLE
Always check whether we can select a new transaction for assembly in active flush

### DIFF
--- a/core/go/internal/sequencer/coordinator/coordinating_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinating_test.go
@@ -60,7 +60,6 @@ func Test_addToDelegatedTransactions_NewTransactionError_ReturnsError(t *testing
 	assert.Equal(t, 0, len(c.transactionsByID), "transaction should not be added when NewTransaction fails")
 }
 
-
 func Test_addToDelegatedTransactions_AddsTransactionInPreDispatchFlowState(t *testing.T) {
 	ctx := t.Context()
 	originator := "sender@senderNode"

--- a/core/go/internal/sequencer/coordinator/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/state_machine.go
@@ -782,10 +782,6 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_TransactionStateTransitionTo(transaction.State_Pooled),
 					Actions:   []ActionRule{{Action: action_PoolTransaction}},
 				}, {
-					// TODO: could we trigger this instead when we see a transaction transition from assembling
-					// It's slightly different semantics - if we've cancelled the currently assembling transaction above
-					// we would do this selection on handling the queued transition event from the cancelling transaction
-					// rather than as part of handling this event
 					Actions: []ActionRule{{If: statemachine.GuardNot(guard_HasTransactionAssembling), Action: action_SelectTransaction}},
 				}, {
 					Validator: validator_TransactionStateTransitionTo(transaction.State_Ready_For_Dispatch),
@@ -973,8 +969,7 @@ var stateDefinitionsMap = StateDefinitions{
 					Validator: validator_TransactionStateTransitionTo(transaction.State_Pooled),
 					Actions:   []ActionRule{{Action: action_PoolTransaction}},
 				}, {
-					Validator: validator_TransactionStateTransitionFrom(transaction.State_Assembling),
-					Actions:   []ActionRule{{Action: action_SelectTransaction}},
+					Actions: []ActionRule{{If: statemachine.GuardNot(guard_HasTransactionAssembling), Action: action_SelectTransaction}},
 				}, {
 					Validator: validator_TransactionStateTransitionTo(transaction.State_Ready_For_Dispatch),
 					Actions:   []ActionRule{{Action: action_QueueTransactionForDispatch}},

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -70,7 +70,7 @@ type originator struct {
 	currentBlockHeight                 int64
 	endorserCandidates                 []string // COORDINATOR_ENDORSER mode: deduped+sorted candidate pool; updated when EndorserNodesDiscoveredEvent arrives
 	coordinatorPriorityList            []string // COORDINATOR_ENDORSER mode: priority-ordered list computed independently from endorserCandidates + effectiveBlockHeight + blockRangeSize
-	failoverIndex                      int      // COORDINATOR_ENDORSER mode:t he next position in coordinatorPriorityList to try when the current active coordinator exceeds the inactive grace period
+	failoverIndex                      int      // COORDINATOR_ENDORSER mode: the next position in coordinatorPriorityList to try when the current active coordinator exceeds the inactive grace period
 
 	/* Config */
 	nodeName            string


### PR DESCRIPTION
Updates the active flush event handlers for transaction state transitions to always check if we have an assembling transaction, and select one if we don't.

The previous handler attempted to be more selective, only selecting when there was a transition out of assembly. This missed the case though where we had stopped assembling, as there were no transactions in the pool, but then a new transaction got created.

I could have added in this additional selective handler; however, on reflection I think the more general approach of always check that active state has is more appropriate. It results in the shortest amount of time between transaction assemblies, especially in the case of dependency chain unwinding. 