### PR TITLE
Add missing originator notifications for chained dependency failure

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/confirming.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming.go
@@ -126,6 +126,15 @@ func action_NotifyOriginatorOfNonRetryableRevert(ctx context.Context, t *coordin
 	)
 }
 
+func action_NotifyOriginatorOfChainedDependencyFailure(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
+	e := event.(*ChainedDependencyFailedEvent)
+	failureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, e.FailedTxID).Error()
+	return t.transportWriter.SendTransactionConfirmed(
+		ctx, t.pt.ID, t.originatorNode, &t.pt.Address, nil,
+		engine.TransactionConfirmed_OUTCOME_REVERTED, nil, failureMessage, false,
+	)
+}
+
 func action_FinalizeNonRetryableRevert(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
 	failureMessage := t.decodedRevertReason
 	log.L(ctx).Infof("finalizing transaction %s as reverted (revertCount=%d): %s", t.pt.ID.String(), t.revertCount, failureMessage)
@@ -212,7 +221,6 @@ func action_FinalizeOnChainedDependencyFailure(ctx context.Context, t *coordinat
 	)
 	return nil
 }
-
 
 func action_RevertTransactionInGrapher(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
 	log.L(ctx).Debugf("releasing transaction locks for %s (revert/failure path)", t.pt.ID.String())

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
@@ -104,6 +104,86 @@ func Test_action_NotifyOriginatorOfNonRetryableRevert(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_action_NotifyOriginatorOfChainedDependencyFailure(t *testing.T) {
+	ctx := t.Context()
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Dispatched).
+		UseMockTransportWriter().
+		Build()
+
+	depID := uuid.New()
+	event := &ChainedDependencyFailedEvent{
+		BaseCoordinatorEvent: BaseCoordinatorEvent{
+			TransactionID: txn.pt.ID,
+		},
+		FailedTxID: depID,
+	}
+
+	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
+	mocks.TransportWriter.EXPECT().
+		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
+			(*pldtypes.HexUint64)(nil),
+			engine.TransactionConfirmed_OUTCOME_REVERTED,
+			pldtypes.HexBytes(nil),
+			expectedFailureMessage,
+			false,
+		).
+		Return(nil)
+
+	err := action_NotifyOriginatorOfChainedDependencyFailure(ctx, txn, event)
+	require.NoError(t, err)
+}
+
+func Test_action_NotifyOriginatorOfChainedDependencyFailureAtCreation(t *testing.T) {
+	ctx := t.Context()
+	grapher, depTracker := newTestGrapher()
+
+	depTx, _ := NewTransactionBuilderForTesting(t, State_Reverted).
+		Grapher(grapher).DependencyTracker(depTracker).
+		Build()
+
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Initial).
+		Grapher(grapher).DependencyTracker(depTracker).
+		CoordinatorTransactions(map[uuid.UUID]CoordinatorTransaction{depTx.pt.ID: depTx}).
+		UseMockTransportWriter().
+		Build()
+
+	depTracker.GetChainedDeps().AddPrerequisites(ctx, txn.pt.ID, depTx.pt.ID)
+
+	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depTx.pt.ID).Error()
+	mocks.TransportWriter.EXPECT().
+		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
+			(*pldtypes.HexUint64)(nil),
+			engine.TransactionConfirmed_OUTCOME_REVERTED,
+			pldtypes.HexBytes(nil),
+			expectedFailureMessage,
+			false,
+		).
+		Return(nil)
+
+	err := action_NotifyOriginatorOfChainedDependencyFailureAtCreation(ctx, txn, nil)
+	require.NoError(t, err)
+}
+
+func Test_action_NotifyOriginatorOfChainedDependencyFailureAtCreation_NoRevertedDependency(t *testing.T) {
+	ctx := t.Context()
+	grapher, depTracker := newTestGrapher()
+
+	depTx, _ := NewTransactionBuilderForTesting(t, State_Dispatched).
+		Grapher(grapher).DependencyTracker(depTracker).
+		Build()
+
+	txn, _ := NewTransactionBuilderForTesting(t, State_Initial).
+		Grapher(grapher).DependencyTracker(depTracker).
+		CoordinatorTransactions(map[uuid.UUID]CoordinatorTransaction{depTx.pt.ID: depTx}).
+		Build()
+
+	depTracker.GetChainedDeps().AddPrerequisites(ctx, txn.pt.ID, depTx.pt.ID)
+
+	// No SendTransactionConfirmed call expected — mock would fail if called unexpectedly.
+	err := action_NotifyOriginatorOfChainedDependencyFailureAtCreation(ctx, txn, nil)
+	require.NoError(t, err)
+}
+
 func Test_action_RecordConfirmationRevert_SetsRevertReason(t *testing.T) {
 	ctx := t.Context()
 	hash := pldtypes.RandBytes32()

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -22,6 +22,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/syncpoints"
+	"github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
 )
 
@@ -178,6 +179,20 @@ func action_FinalizeOnRevertedChainedDependencyAtCreation(ctx context.Context, t
 				},
 			)
 			return nil
+		}
+	}
+	return nil
+}
+
+func action_NotifyOriginatorOfChainedDependencyFailureAtCreation(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
+	for _, depID := range t.dependencyTracker.GetChainedDeps().GetPrerequisites(ctx, t.pt.ID) {
+		state, ok := t.getCoordinatorTransactionState(ctx, depID)
+		if ok && state == State_Reverted {
+			failureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
+			return t.transportWriter.SendTransactionConfirmed(
+				ctx, t.pt.ID, t.originatorNode, &t.pt.Address, nil,
+				engine.TransactionConfirmed_OUTCOME_REVERTED, nil, failureMessage, false,
+			)
 		}
 	}
 	return nil

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -107,11 +107,14 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{
-						{
-							To:      State_Reverted,
-							If:      guard_HasRevertedChainedDependency,
-							Actions: []ActionRule{{Action: action_FinalizeOnRevertedChainedDependencyAtCreation}},
+					{
+						To:  State_Reverted,
+						If:  guard_HasRevertedChainedDependency,
+						Actions: []ActionRule{
+							{Action: action_FinalizeOnRevertedChainedDependencyAtCreation},
+							{Action: action_NotifyOriginatorOfChainedDependencyFailureAtCreation},
 						},
+					},
 						{
 							To: State_Evicted,
 							If: guard_HasEvictedChainedDependency,
@@ -175,7 +178,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -242,7 +248,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -411,7 +420,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -575,7 +587,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -643,7 +658,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -765,7 +783,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -836,7 +857,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},
@@ -950,7 +974,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ChainedDependencyFailed: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions:     []ActionRule{{Action: action_FinalizeOnChainedDependencyFailure}},
+					Actions: []ActionRule{
+						{Action: action_FinalizeOnChainedDependencyFailure},
+						{Action: action_NotifyOriginatorOfChainedDependencyFailure},
+					},
 					Transitions: []Transition{{To: State_Reverted}},
 				}},
 			},

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/dependencytracker"
 	"github.com/LFDT-Paladin/paladin/core/mocks/graphermocks"
@@ -101,11 +103,23 @@ func Test_ChainedDependencyFailed_AllStates_TransitionToReverted(t *testing.T) {
 
 	for _, fromState := range states {
 		t.Run(fromState.String(), func(t *testing.T) {
-			txn, mocks := NewTransactionBuilderForTesting(t, fromState).Build()
+			txn, mocks := NewTransactionBuilderForTesting(t, fromState).
+				UseMockTransportWriter().
+				Build()
 
 			mocks.SyncPoints.On("QueueTransactionFinalize",
 				mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			).Return()
+
+			expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
+			mocks.TransportWriter.EXPECT().
+				SendTransactionConfirmed(mock.Anything, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
+					(*pldtypes.HexUint64)(nil),
+					engineProto.TransactionConfirmed_OUTCOME_REVERTED,
+					pldtypes.HexBytes(nil),
+					expectedFailureMessage,
+					false,
+				).Return(nil)
 
 			err := txn.HandleEvent(ctx, &ChainedDependencyFailedEvent{
 				BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.pt.ID},
@@ -279,10 +293,21 @@ func TestCoordinatorTransaction_Initial_ToReverted_OnDelegated_IfHasRevertedChai
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Initial).
 		ChainedDependencies(depID).
 		CoordinatorTransactions(map[uuid.UUID]CoordinatorTransaction{depID: depTx}).
+		UseMockTransportWriter().
 		Build()
 	mocks.SyncPoints.On("QueueTransactionFinalize",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return()
+
+	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
+	mocks.TransportWriter.EXPECT().
+		SendTransactionConfirmed(mock.Anything, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
+			(*pldtypes.HexUint64)(nil),
+			engineProto.TransactionConfirmed_OUTCOME_REVERTED,
+			pldtypes.HexBytes(nil),
+			expectedFailureMessage,
+			false,
+		).Return(nil)
 
 	err := txn.HandleEvent(ctx, &DelegatedEvent{
 		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.GetID()},


### PR DESCRIPTION
A missing notification for when a transaction had finalized as reverted because of a chained dependency failure resulted in the originator repeatedly redelegating the transaction.