### PR TITLE
Cancel inflight assembly if new request is received

### DIFF
--- a/core/go/internal/sequencer/originator/transaction/assembling.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling.go
@@ -74,6 +74,9 @@ func action_AssembleError(ctx context.Context, t *originatorTransaction, event c
 // transaction event loop unblocked while allowing the potentially slow AssembleAndSign
 // call to run concurrently.
 //
+// If a previous assembly goroutine is still in flight (from a superseded request), its
+// context is cancelled before the new goroutine is started.
+//
 // handleAssembleAndSign does not modify the private transaction or the latest assembly
 // request, making it safe to call in a separate goroutine. This is enforced via unit tests
 // in the engine integration component.
@@ -84,15 +87,22 @@ func action_AssembleAndSign(ctx context.Context, txn *originatorTransaction, _ c
 		return i18n.NewError(ctx, msgs.MsgSequencerInternalError, "No assemble request found")
 	}
 
+	// Cancel any previously in-flight assembly goroutine for a superseded request
+	if txn.cancelCurrentAssembly != nil {
+		txn.cancelCurrentAssembly()
+	}
+
 	req := *txn.latestAssembleRequest
 	preAssembly := txn.pt.PreAssembly
 	txID := txn.pt.ID
 
-	assembleCtx := ctx
-	cancel := func() {}
+	// Always create a cancellable context so a superseding request can abort this goroutine
+	assembleCtx, cancel := context.WithCancel(ctx)
 	if !req.expiry.IsZero() {
-		assembleCtx, cancel = context.WithDeadline(ctx, req.expiry)
+		assembleCtx, cancel = context.WithDeadline(assembleCtx, req.expiry)
 	}
+	txn.cancelCurrentAssembly = cancel
+
 	go func() {
 		defer cancel()
 		txn.handleAssembleAndSign(assembleCtx, txID, req, preAssembly)
@@ -225,6 +235,14 @@ func action_SendAssembleBlockHeightRejection(ctx context.Context, t *originatorT
 		e.CoordinatorBlockHeight,
 		receiverBlockHeight,
 	)
+}
+
+func validator_AssembleAndSignSuccessMatchesCurrentRequest(_ context.Context, t *originatorTransaction, event common.Event) (bool, error) {
+	e := event.(*AssembleAndSignSuccessEvent)
+	if t.latestAssembleRequest == nil {
+		return false, nil
+	}
+	return t.latestAssembleRequest.requestID == e.RequestID, nil
 }
 
 // action_SendAssembleRejectionNotCurrentDelegate sends an AssembleRejection indicating the

--- a/core/go/internal/sequencer/originator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling_test.go
@@ -527,6 +527,148 @@ func Test_validator_IsPrivateStateDataPendingForAssembly_Error_Propagates(t *tes
 	assert.ErrorIs(t, err, dbErr)
 }
 
+func Test_action_AssembleAndSign_NilCancelIsNoOp(t *testing.T) {
+	// Calling action_AssembleAndSign when cancelCurrentAssembly is nil (first call) must not
+	// panic and must start the goroutine normally.
+	ctx := t.Context()
+
+	done := make(chan struct{})
+	builder := NewTransactionBuilderForTesting(t, State_Assembling).
+		QueueEventsTo(func(_ context.Context, _ common.Event) { close(done) })
+	txn := builder.Build()
+
+	txn.cancelCurrentAssembly = nil // explicit nil to document intent
+
+	builder.fakeEngineIntegration.On(
+		"AssembleAndSign",
+		mock.Anything, txn.pt.ID, mock.Anything, mock.Anything, mock.Anything,
+	).Return(&components.TransactionPostAssembly{
+		AssemblyResult: prototk.AssembleTransactionResponse_OK,
+	}, nil)
+
+	err := action_AssembleAndSign(ctx, txn, nil)
+	require.NoError(t, err)
+
+	// cancelCurrentAssembly must be populated after the call
+	assert.NotNil(t, txn.cancelCurrentAssembly)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for assemble goroutine")
+	}
+}
+
+func Test_action_AssembleAndSign_CancelsPreviousGoroutine(t *testing.T) {
+	// A second call to action_AssembleAndSign must cancel the first goroutine's context so
+	// that the stale goroutine exits without queuing an event. Only the second goroutine's
+	// success event should appear.
+	ctx := t.Context()
+
+	eventCh := make(chan common.Event, 2) // buffer 2 so a spurious second event is detectable
+	builder := NewTransactionBuilderForTesting(t, State_Assembling).
+		QueueEventsTo(func(_ context.Context, e common.Event) { eventCh <- e })
+	txn := builder.Build()
+
+	firstReqID := txn.latestAssembleRequest.requestID
+
+	// firstGoroutineDone is closed once the first goroutine's AssembleAndSign observes
+	// context cancellation and the mock call returns.
+	firstGoroutineDone := make(chan struct{})
+	blocked := make(chan struct{})
+
+	builder.fakeEngineIntegration.On(
+		"AssembleAndSign",
+		mock.Anything, txn.pt.ID, mock.Anything, mock.Anything, mock.Anything,
+	).Once().Run(func(args mock.Arguments) {
+		assembleCtx := args.Get(0).(context.Context)
+		close(blocked)
+		<-assembleCtx.Done() // block until action_AssembleAndSign cancels us
+		close(firstGoroutineDone)
+	}).Return(nil, context.Canceled)
+
+	secondReqID := uuid.New()
+
+	builder.fakeEngineIntegration.On(
+		"AssembleAndSign",
+		mock.Anything, txn.pt.ID, mock.Anything, mock.Anything, mock.Anything,
+	).Once().Return(&components.TransactionPostAssembly{
+		AssemblyResult: prototk.AssembleTransactionResponse_OK,
+	}, nil)
+
+	err := action_AssembleAndSign(ctx, txn, nil)
+	require.NoError(t, err)
+
+	// Wait until the first goroutine is actually blocked inside AssembleAndSign
+	<-blocked
+
+	// Spawn second goroutine with a new request ID — this must cancel the first
+	txn.latestAssembleRequest = &assembleRequestFromCoordinator{requestID: secondReqID}
+	err = action_AssembleAndSign(ctx, txn, nil)
+	require.NoError(t, err)
+
+	// Wait for first goroutine to observe cancellation (AssembleAndSign returned)
+	<-firstGoroutineDone
+
+	// The only event in the channel must be from the second goroutine
+	event := <-eventCh
+	successEvent, ok := event.(*AssembleAndSignSuccessEvent)
+	require.True(t, ok, "expected AssembleAndSignSuccessEvent from second goroutine, got %T", event)
+	assert.Equal(t, secondReqID, successEvent.RequestID)
+	assert.NotEqual(t, firstReqID, successEvent.RequestID, "event must not be from the cancelled first goroutine")
+
+	// No second event should have been queued
+	select {
+	case e := <-eventCh:
+		t.Fatalf("unexpected second event queued: %T", e)
+	default:
+	}
+}
+
+func Test_validator_AssembleAndSignSuccessMatchesCurrentRequest_Match(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Assembling)
+	txn, _ := builder.BuildWithMocks()
+
+	requestID := txn.latestAssembleRequest.requestID
+	event := &AssembleAndSignSuccessEvent{
+		BaseEvent: BaseEvent{TransactionID: txn.pt.ID},
+		RequestID: requestID,
+	}
+	ok, err := validator_AssembleAndSignSuccessMatchesCurrentRequest(ctx, txn, event)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func Test_validator_AssembleAndSignSuccessMatchesCurrentRequest_Mismatch(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Assembling)
+	txn, _ := builder.BuildWithMocks()
+
+	event := &AssembleAndSignSuccessEvent{
+		BaseEvent: BaseEvent{TransactionID: txn.pt.ID},
+		RequestID: uuid.New(), // different ID
+	}
+	ok, err := validator_AssembleAndSignSuccessMatchesCurrentRequest(ctx, txn, event)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func Test_validator_AssembleAndSignSuccessMatchesCurrentRequest_NilRequest(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Assembling)
+	txn, _ := builder.BuildWithMocks()
+
+	txn.latestAssembleRequest = nil
+	event := &AssembleAndSignSuccessEvent{
+		BaseEvent: BaseEvent{TransactionID: txn.pt.ID},
+		RequestID: uuid.New(),
+	}
+	ok, err := validator_AssembleAndSignSuccessMatchesCurrentRequest(ctx, txn, event)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
 func Test_action_RejectAssemblyPrivateStateDataPending_SendsRejection(t *testing.T) {
 	ctx := context.Background()
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Delegated).BuildWithMocks()

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -217,7 +217,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_AssembleAndSignSuccess: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_AssembleAndSignSuccess}},
+					Validator: validator_AssembleAndSignSuccessMatchesCurrentRequest,
+					Actions:   []ActionRule{{Action: action_AssembleAndSignSuccess}},
 					Transitions: []Transition{
 						{
 							To:      State_Endorsement_Gathering,

--- a/core/go/internal/sequencer/originator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine_test.go
@@ -374,6 +374,7 @@ func TestOriginatorTransaction_Assembling_ToEndorsement_Gathering_OnAssembleAndS
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
+		RequestID: builder.GetAssembleRequestID(),
 		PostAssembly: &components.TransactionPostAssembly{
 			AssemblyResult: prototk.AssembleTransactionResponse_OK,
 			//TODO use a builder to create a more realistically populated PostAssembly
@@ -383,6 +384,30 @@ func TestOriginatorTransaction_Assembling_ToEndorsement_Gathering_OnAssembleAndS
 
 	assert.True(t, mocks.SentMessageRecorder.HasSentAssembleSuccessResponse(), "assemble success response was not sent back to coordinator")
 	assert.Equal(t, State_Endorsement_Gathering, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
+}
+
+func TestOriginatorTransaction_Assembling_StaysInAssembling_OnAssembleAndSignSuccess_StaleRequestID(t *testing.T) {
+	// When an AssembleAndSignSuccessEvent arrives with a request ID that does not match the
+	// current outstanding assemble request, the validator must reject it so the state machine
+	// stays in State_Assembling and no assemble response is sent to the coordinator.
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Assembling)
+	txn, mocks := builder.BuildWithMocks()
+
+	staleRequestID := uuid.New() // different from builder.GetAssembleRequestID()
+	assert.NotEqual(t, builder.GetAssembleRequestID(), staleRequestID)
+
+	err := txn.HandleEvent(ctx, &AssembleAndSignSuccessEvent{
+		BaseEvent: BaseEvent{TransactionID: txn.GetID()},
+		RequestID: staleRequestID,
+		PostAssembly: &components.TransactionPostAssembly{
+			AssemblyResult: prototk.AssembleTransactionResponse_OK,
+		},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, State_Assembling, txn.GetCurrentState(), "stale success event must not advance state; current state is %s", txn.GetCurrentState().String())
+	assert.False(t, mocks.SentMessageRecorder.HasSentAssembleSuccessResponse(), "assemble success response must not be sent for a stale request ID")
 }
 
 func TestOriginatorTransaction_Assembling_ToReverted_OnAssembleRevert(t *testing.T) {
@@ -492,6 +517,45 @@ func TestOriginatorTransaction_Assembling_StaysInState_OnAssembleRequestReceived
 	})
 	assert.NoError(t, err)
 	assert.True(t, mocks.SentMessageRecorder.HasSentAssembleRejection(), "assemble rejection was not sent to coordinator")
+	assert.Equal(t, State_Assembling, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
+}
+
+func TestOriginatorTransaction_Assembling_StaysInAssembling_OnAssembleRequestReceived_NewRequest_CancelsPreviousGoroutine(t *testing.T) {
+	// When a new AssembleRequestReceived arrives while already in State_Assembling, the state
+	// machine must call the previously stored cancel function (to abort the stale goroutine)
+	// and store a new cancel function for the freshly spawned goroutine.
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Assembling)
+	txn, mocks := builder.BuildWithMocks()
+
+	// Install a cancel function that signals us when it is called
+	previousCancelCalled := make(chan struct{})
+	txn.cancelCurrentAssembly = func() { close(previousCancelCalled) }
+
+	// The new goroutine spawned by action_AssembleAndSign will call AssembleAndSign.
+	// Allow any number of calls (goroutine is async) and return quickly.
+	mocks.EngineIntegration.On(
+		"AssembleAndSign",
+		mock.Anything, txn.GetID(), mock.Anything, mock.Anything, mock.Anything,
+	).Maybe().Return(nil, context.Canceled)
+
+	newRequestID := uuid.New()
+	err := txn.HandleEvent(ctx, &AssembleRequestReceivedEvent{
+		BaseEvent:              BaseEvent{TransactionID: txn.GetID()},
+		RequestID:              newRequestID,
+		Coordinator:            txn.currentDelegate,
+		CoordinatorBlockHeight: 0,
+		BlockHeightTolerance:   0,
+	})
+	assert.NoError(t, err)
+
+	// action_AssembleAndSign is synchronous within HandleEvent, so the old cancel was called
+	// before HandleEvent returned — this receive completes immediately.
+	<-previousCancelCalled
+
+	// A new cancel for the fresh goroutine must be stored
+	assert.NotNil(t, txn.cancelCurrentAssembly)
+	// No state transition — we remain assembling (just with a new request)
 	assert.Equal(t, State_Assembling, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -70,6 +70,7 @@ type originatorTransaction struct {
 	lastReceivedWillRetry            bool
 	refreshBlockHeight               func(context.Context)
 	getBlockHeight                   func() int64
+	cancelCurrentAssembly            context.CancelFunc
 }
 
 func NewTransaction(

--- a/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_builder_test.go
@@ -90,6 +90,10 @@ func (b *TransactionBuilderForTesting) GetCoordinator() string {
 	return b.currentDelegate
 }
 
+func (b *TransactionBuilderForTesting) GetAssembleRequestID() uuid.UUID {
+	return b.assembleRequestID
+}
+
 func (b *TransactionBuilderForTesting) GetLatestFulfilledAssembleRequestID() uuid.UUID {
 	return b.latestFulfilledAssembleRequestID
 }


### PR DESCRIPTION
An originator is not told if a coordinator cancels the assembly it is currently actioning. Continuing with the assembly does not block the arrival of new assembly requests, but its successful completion will cause the originator transaction state machine to transition out of assembling state, which means it does not handle the assemble result of a second assembly, so does not send a response to the coordinator. The coordinator will time the assembly out at the state timeout, and the transaction will be repooled. This manifests as excessive latency from submit through to confirm of the transaction.

This PR ensures that
* An originator cancels an inflight assembly request if a new one is received
* Does not move out of assembling state if an assembly result is not for the most recently received request.


There a further possible enhancement here to send a notification when assembly is cancelled, rather than letting the only signal be that a new assembly has been request. In the case that there is a large pool of transactions, the new assembly request may be some time later, in which case the originator has wastefully continued on an assembly which isn't needed.