### PR TITLE
fix(transportmgr): surface post-commit ACK/NACK dispatch failures

### DIFF
--- a/core/go/internal/transportmgr/reliable_msg_handler.go
+++ b/core/go/internal/transportmgr/reliable_msg_handler.go
@@ -99,10 +99,18 @@ func (tm *transportManager) handleReliableMsgBatch(ctx context.Context, dbTX per
 	dbTX.AddPostCommit(func(ctx context.Context) {
 		// We've committed the database work ok - send the acks/nacks to the other side
 		for _, a := range acksToSend {
+			ackType := RMHMessageTypeAck
 			if a.Error != "" {
+				ackType = RMHMessageTypeNack
 				log.L(ctx).Errorf("Sending nack to node '%s' for message %s: %s", a.node, a.id, a.Error)
 			}
-			_ = tm.queueFireAndForget(ctx, a.node, buildAck(a.id, a.Error), nil)
+			node, msgID := a.node, a.id
+			logSendErr := func(ctx context.Context, err error) {
+				log.L(ctx).Errorf("Failed to send %s to node '%s' for message %s: %s", ackType, node, msgID, err)
+			}
+			if err := tm.queueFireAndForget(ctx, a.node, buildAck(a.id, a.Error), logSendErr); err != nil {
+				logSendErr(ctx, err)
+			}
 		}
 	})
 

--- a/core/go/internal/transportmgr/reliable_msg_handler_test.go
+++ b/core/go/internal/transportmgr/reliable_msg_handler_test.go
@@ -16,10 +16,13 @@
 package transportmgr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/LFDT-Paladin/paladin/config/pkg/confutil"
@@ -31,6 +34,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -61,6 +65,81 @@ func setupAckOrNackCheck(t *testing.T, tp *testPlugin, msgID uuid.UUID, expected
 		}
 
 	}
+}
+
+func captureTransportLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	logger := logrus.StandardLogger()
+	prevOut := logger.Out
+	logger.SetOutput(buf)
+	t.Cleanup(func() {
+		logger.SetOutput(prevOut)
+	})
+	return buf
+}
+
+func TestHandleReliableMsgBatchLogsAckNackSendFailures(t *testing.T) {
+	t.Run("queue failure", func(t *testing.T) {
+		ctx, tm, _, done := newTestTransport(t, false,
+			mockEmptyReliableMsgs,
+			func(mc *mockComponents, conf *pldconf.TransportManagerInlineConfig) {
+				mc.db.Mock.ExpectBegin()
+				mc.db.Mock.ExpectCommit()
+			})
+		defer done()
+
+		logBuf := captureTransportLogs(t)
+		msg := testReceivedReliableMsg("unsupported_message_type", nil)
+		p := &peer{PeerInfo: pldapi.PeerInfo{Name: tm.localNodeName}}
+
+		err := tm.persistence.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) error {
+			_, err := tm.handleReliableMsgBatch(ctx, dbTX, []*reliableMsgOp{{p: p, msg: msg}})
+			return err
+		})
+		require.NoError(t, err)
+		require.Contains(t, logBuf.String(), fmt.Sprintf("Failed to send nack to node '%s' for message %s", p.Name, msg.MessageID))
+	})
+
+	t.Run("send failure", func(t *testing.T) {
+		ctx, tm, tp, done := newTestTransport(t, false,
+			mockGoodTransport,
+			mockEmptyReliableMsgs,
+			func(mc *mockComponents, conf *pldconf.TransportManagerInlineConfig) {
+				mc.db.Mock.ExpectBegin()
+				mc.db.Mock.ExpectCommit()
+			})
+		defer done()
+
+		logBuf := captureTransportLogs(t)
+		sendAttempted := make(chan struct{}, 1)
+		mockActivateDeactivateOk(tp)
+		tp.Functions.SendMessage = func(ctx context.Context, req *prototk.SendMessageRequest) (*prototk.SendMessageResponse, error) {
+			select {
+			case sendAttempted <- struct{}{}:
+			default:
+			}
+			return nil, fmt.Errorf("pop")
+		}
+
+		msg := testReceivedReliableMsg("unsupported_message_type", nil)
+		p := &peer{PeerInfo: pldapi.PeerInfo{Name: "node2"}}
+
+		err := tm.persistence.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) error {
+			_, err := tm.handleReliableMsgBatch(ctx, dbTX, []*reliableMsgOp{{p: p, msg: msg}})
+			return err
+		})
+		require.NoError(t, err)
+
+		select {
+		case <-sendAttempted:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for ack/nack send attempt")
+		}
+		require.Eventually(t, func() bool {
+			return strings.Contains(logBuf.String(), fmt.Sprintf("Failed to send nack to node '%s' for message %s: pop", p.Name, msg.MessageID))
+		}, 5*time.Second, 50*time.Millisecond)
+	})
 }
 
 func TestReceiveMessageStateWithNullifierSendAckRealDB(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes #1207 , making post-commit ACK/NACK dispatch failures observable in the reliable message handler instead of silently dropping them.

## Approach

`queueFireAndForget(...)` is a best-effort, at-most-once send path. Failures can happen either before the message is queued or later in the peer sender loop.

This PR keeps the existing post-commit structure and surfaces both failure points:

* log immediate `queueFireAndForget(...)` errors
* pass an error handler to log async sender-loop failures
* keep the existing NACK diagnostic log

## Scope

This does not make ACK/NACK delivery reliable. The ACK/NACK path still runs after the DB commit and must not change the outcome of an already committed transaction.

The goal is only to make dispatch failures visible within the existing transport semantics.

## Tests

Added focused coverage through the real `handleReliableMsgBatch()` post-commit path:

* synchronous queue failure is logged
* async peer send failure is logged through the error handler

```bash
go test ./core/go/internal/transportmgr -run 'TestHandleReliableMsgBatchLogsAckNackSendFailures' -count=1
go test ./core/go/internal/transportmgr/... -count=1
```
result:
<img width="992" height="87" alt="image" src="https://github.com/user-attachments/assets/123a6754-d5ca-4ecc-a69c-e1fbe314cb85" />
