### PR TITLE
Sequencer protos

### DIFF
--- a/core/go/internal/sequencer/common/events.go
+++ b/core/go/internal/sequencer/common/events.go
@@ -25,10 +25,10 @@ import (
 type EventType int
 
 const (
-	Event_HeartbeatInterval         EventType = iota // emitted on a regular basis, interval defined by the sequencer config
-	Event_TransactionStateTransition                 // transaction state machine transition; originator/coordinator handle cleanup and side effects
-	Event_HeartbeatReceived                          // a heartbeat notification was received from the active coordinator
-	Event_EndorserNodesDiscovered                    // pushed by the coordinator to its co-located originator when new endorser nodes are discovered
+	Event_HeartbeatInterval          EventType = iota // emitted on a regular basis, interval defined by the sequencer config
+	Event_TransactionStateTransition                  // transaction state machine transition; originator/coordinator handle cleanup and side effects
+	Event_HeartbeatReceived                           // a heartbeat notification was received from the active coordinator
+	Event_EndorserNodesDiscovered                     // pushed by the coordinator to its co-located originator when new endorser nodes are discovered
 )
 
 type BaseEvent struct {

--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -27,6 +27,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/statemachine"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
@@ -58,7 +59,10 @@ func action_NudgeHandoverRequest(ctx context.Context, c *coordinator, _ common.E
 func (c *coordinator) sendHandoverRequest(ctx context.Context) error {
 	if c.pendingHandoverRequest == nil {
 		c.pendingHandoverRequest = common.NewIdempotentRequest(ctx, c.clock, c.requestTimeout, func(ctx context.Context, _ uuid.UUID) error {
-			return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, c.contractAddress)
+			return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, &engineProto.CoordinatorHandoverRequest{
+				FromNode:        c.nodeName,
+				ContractAddress: c.contractAddress.HexString(),
+			})
 		})
 		c.scheduleRequestTimeout(ctx)
 	}
@@ -390,7 +394,13 @@ func (c *coordinator) addToDelegatedTransactions(
 	}
 
 	// Acknowledge the delegate request. Optionally errors can be returned which the originator may use to base re-delegate decisions on
-	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementErrors, uint64(c.currentBlockHeight))
+	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, &engineProto.DelegationResponse{
+		DelegationId:    delegationID,
+		TransactionIds:  delegateAcknowledgementIDs,
+		DelegateNodeId:  originatorNode,
+		ContractAddress: c.contractAddress.HexString(),
+		Errors:          delegateAcknowledgementErrors,
+	})
 	if err != nil {
 		return err
 	}

--- a/core/go/internal/sequencer/coordinator/coordinating_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinating_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/testutil"
 	"github.com/LFDT-Paladin/paladin/core/mocks/coordinatortransactionmocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -554,7 +555,7 @@ func Test_addToDelegatedTransactions_SendDelegationResponseError_ReturnsError(t 
 	mocks.DomainAPI.On("ContractConfig").Return(&prototk.ContractConfig{
 		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
 	})
-	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("send ack failed"))
+	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("send ack failed"))
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
@@ -728,10 +729,10 @@ func Test_addToDelegatedTransactions_SubsequentTransactionGetsPreviousTransactio
 
 	var capturedErrors []int64
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(errors []int64) bool {
-		capturedErrors = errors
+	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
+		capturedErrors = msg.Errors
 		return true
-	}), mock.Anything).Return(nil)
+	})).Return(nil)
 
 	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
@@ -754,7 +755,7 @@ func Test_addToDelegatedTransactions_ErrorStopsSubsequentTransactionsBeingAccept
 
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Delegate 10 transactions. TX 5 fails at HandleEvent time. 5-10 should not be in the TX list for the coordinator
 	txns := make([]*components.PrivateTransaction, 10)
@@ -811,7 +812,7 @@ func Test_addToDelegatedTransactions_FifthFailsThenFullRetry_PreservesFirstFourA
 	fifthErr := fmt.Errorf("fifth transaction HandleEvent failed")
 
 	c, mocks := builder.WithMockTransportWriter().Build()
-	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
 
 	txns := make([]*components.PrivateTransaction, 10)
 	for i := range txns {
@@ -1349,7 +1350,10 @@ func Test_nudgeHandoverRequest_WithPendingRequest_CallsNudge(t *testing.T) {
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil).Once()
 	// A freshly created IdempotentRequest (requestTime == nil) always sends on first Nudge.
 	c.pendingHandoverRequest = common.NewIdempotentRequest(ctx, c.clock, c.requestTimeout, func(ctx context.Context, _ uuid.UUID) error {
-		return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, c.contractAddress)
+		return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, &engineProto.CoordinatorHandoverRequest{
+			FromNode:        c.nodeName,
+			ContractAddress: c.contractAddress.HexString(),
+		})
 	})
 
 	err := c.nudgeHandoverRequest(ctx)

--- a/core/go/internal/sequencer/coordinator/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/endorsing.go
@@ -40,19 +40,17 @@ func action_RejectEndorsementPrivateStateDataPending(ctx context.Context, c *coo
 	e := event.(*EndorsementRequestReceivedEvent)
 	log.L(ctx).Warnf("rejecting endorsement request from %s due to pending private state data (coordinator=%d, endorser=%d, tolerance=%d)",
 		e.FromNode, e.CoordinatorBlockHeight, c.currentBlockHeight, e.BlockHeightTolerance)
-	return c.transportWriter.SendEndorsementRejection(
-		ctx,
-		e.TransactionId,
-		e.IdempotencyKey,
-		c.contractAddress.String(),
-		e.AttestationRequest.Name,
-		e.Party,
-		e.FromNode,
-		engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		e.CoordinatorBlockHeight,
-		int64(c.currentBlockHeight),
-		e.BlockHeightTolerance,
-	)
+	return c.transportWriter.SendEndorsementRejection(ctx, e.FromNode, &engineProto.EndorsementRejection{
+		TransactionId:          e.TransactionId,
+		IdempotencyKey:         e.IdempotencyKey,
+		ContractAddress:        c.contractAddress.HexString(),
+		AttestationRequestName: e.AttestationRequest.Name,
+		Party:                  e.Party,
+		RejectionReason:        engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
+		CoordinatorBlockHeight: e.CoordinatorBlockHeight,
+		EndorserBlockHeight:    int64(c.currentBlockHeight),
+		BlockHeightTolerance:   e.BlockHeightTolerance,
+	})
 }
 
 // validator_IsEndorsementBlockHeightToleranceExceeded returns true when the absolute difference
@@ -72,19 +70,17 @@ func validator_IsEndorsementBlockHeightToleranceExceeded(_ context.Context, c *c
 func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*EndorsementRequestReceivedEvent)
 	log.L(ctx).Warnf("rejecting endorsement request from %s due to block height tolerance (coordinator=%d, endorser=%d, tolerance=%d)", e.FromNode, e.CoordinatorBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
-	return c.transportWriter.SendEndorsementRejection(
-		ctx,
-		e.TransactionId,
-		e.IdempotencyKey,
-		c.contractAddress.String(),
-		e.AttestationRequest.Name,
-		e.Party,
-		e.FromNode,
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		e.CoordinatorBlockHeight,
-		c.currentBlockHeight,
-		int64(c.blockHeightTolerance),
-	)
+	return c.transportWriter.SendEndorsementRejection(ctx, e.FromNode, &engineProto.EndorsementRejection{
+		TransactionId:          e.TransactionId,
+		IdempotencyKey:         e.IdempotencyKey,
+		ContractAddress:        c.contractAddress.HexString(),
+		AttestationRequestName: e.AttestationRequest.Name,
+		Party:                  e.Party,
+		RejectionReason:        engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		CoordinatorBlockHeight: e.CoordinatorBlockHeight,
+		EndorserBlockHeight:    c.currentBlockHeight,
+		BlockHeightTolerance:   int64(c.blockHeightTolerance),
+	})
 }
 
 // action_RejectEndorsementEndorserIsActiveCoordinator sends an EndorsementRejection to the
@@ -94,17 +90,14 @@ func action_RejectEndorsementBlockHeight(ctx context.Context, c *coordinator, ev
 func action_RejectEndorsementEndorserIsActiveCoordinator(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*EndorsementRequestReceivedEvent)
 	log.L(ctx).Warnf("rejecting endorsement request from %s: this node is the active coordinator", e.FromNode)
-	return c.transportWriter.SendEndorsementRejection(
-		ctx,
-		e.TransactionId,
-		e.IdempotencyKey,
-		c.contractAddress.String(),
-		e.AttestationRequest.Name,
-		e.Party,
-		e.FromNode,
-		engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
-		0, 0, 0,
-	)
+	return c.transportWriter.SendEndorsementRejection(ctx, e.FromNode, &engineProto.EndorsementRejection{
+		TransactionId:          e.TransactionId,
+		IdempotencyKey:         e.IdempotencyKey,
+		ContractAddress:        c.contractAddress.HexString(),
+		AttestationRequestName: e.AttestationRequest.Name,
+		Party:                  e.Party,
+		RejectionReason:        engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
+	})
 }
 
 // validator_IsEndorsementRequestFromHigherPriorityCoordinator returns true when the node
@@ -168,7 +161,14 @@ func action_HandleEndorsementRequest(ctx context.Context, c *coordinator, event 
 func (c *coordinator) handleEndorsementRequest(ctx context.Context, e *EndorsementRequestReceivedEvent) {
 	sendErr := func(errMsg string) {
 		log.L(ctx).Errorf("handleEndorsementRequest error for tx %s: %s", e.TransactionId, errMsg)
-		if err := c.transportWriter.SendEndorsementError(ctx, e.TransactionId, e.IdempotencyKey, c.contractAddress.String(), errMsg, e.Party, e.AttestationRequest.Name, e.FromNode); err != nil {
+		if err := c.transportWriter.SendEndorsementError(ctx, e.FromNode, &engineProto.EndorsementError{
+			TransactionId:          e.TransactionId,
+			IdempotencyKey:         e.IdempotencyKey,
+			ContractAddress:        c.contractAddress.HexString(),
+			ErrorMessage:           errMsg,
+			Party:                  e.Party,
+			AttestationRequestName: e.AttestationRequest.Name,
+		}); err != nil {
 			log.L(ctx).Errorf("handleEndorsementRequest failed to send endorsement error: %s", err)
 		}
 	}
@@ -244,19 +244,18 @@ func (c *coordinator) handleEndorsementRequest(ctx context.Context, e *Endorseme
 	}
 
 	c.metrics.IncEndorsedTransactions()
-	err = c.transportWriter.SendEndorsementResponse(
-		ctx,
-		e.TransactionId,
-		e.IdempotencyKey,
-		c.contractAddress.String(),
-		attResult,
-		endorsementResult,
-		revertReason,
-		e.AttestationRequest.Name,
-		e.Party,
-		e.FromNode,
-	)
-	if err != nil {
+	msg := &engineProto.EndorsementResponse{
+		Endorsement:            attResult,
+		TransactionId:          e.TransactionId,
+		IdempotencyKey:         e.IdempotencyKey,
+		AttestationRequestName: e.AttestationRequest.Name,
+		Party:                  e.Party,
+		ContractAddress:        c.contractAddress.HexString(),
+	}
+	if revertReason != "" {
+		msg.RevertReason = &revertReason
+	}
+	if err = c.transportWriter.SendEndorsementResponse(ctx, e.FromNode, msg); err != nil {
 		log.L(ctx).Errorf("handleEndorsementRequest failed to send endorsement response: %s", err)
 	}
 }

--- a/core/go/internal/sequencer/coordinator/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/endorsing_test.go
@@ -35,6 +35,41 @@ import (
 // partyKeyVerifier is the resolved verifier string used for party key resolution in tests.
 const partyKeyVerifier = "party-verifier"
 
+// matchEndorsementErrorMsg returns a mock.MatchedBy matcher that inspects the EndorsementError
+// proto struct to verify the transaction ID and idempotency key.
+func matchEndorsementErrorMsg(txID, ik string) interface{} {
+	return mock.MatchedBy(func(msg *engineProto.EndorsementError) bool {
+		return msg.TransactionId == txID && msg.IdempotencyKey == ik
+	})
+}
+
+// matchEndorsementRejectionMsg returns a mock.MatchedBy matcher that inspects the
+// EndorsementRejection proto struct, verifying the rejection reason and optional block heights.
+func matchEndorsementRejectionMsg(txID, ik string, reason engineProto.RejectionReason, coordBH, endorserBH, tolerance int64) interface{} {
+	return mock.MatchedBy(func(msg *engineProto.EndorsementRejection) bool {
+		return msg.TransactionId == txID &&
+			msg.IdempotencyKey == ik &&
+			msg.RejectionReason == reason &&
+			msg.CoordinatorBlockHeight == coordBH &&
+			msg.EndorserBlockHeight == endorserBH &&
+			msg.BlockHeightTolerance == tolerance
+	})
+}
+
+// matchEndorsementResponseMsg returns a mock.MatchedBy matcher that inspects the
+// EndorsementResponse proto struct, verifying the key fields that were previously individual args.
+func matchEndorsementResponseMsg(txID, ik, party, attName string, revertReason *string) interface{} {
+	return mock.MatchedBy(func(msg *engineProto.EndorsementResponse) bool {
+		if msg.TransactionId != txID || msg.IdempotencyKey != ik || msg.Party != party || msg.AttestationRequestName != attName {
+			return false
+		}
+		if revertReason != nil {
+			return msg.RevertReason != nil && *msg.RevertReason == *revertReason
+		}
+		return true
+	})
+}
+
 // buildEndorsementEvent creates a minimal EndorsementRequestReceivedEvent for tests.
 func buildEndorsementEvent(fromNode string) *EndorsementRequestReceivedEvent {
 	return &EndorsementRequestReceivedEvent{
@@ -137,9 +172,8 @@ func Test_action_RejectEndorsementPrivateStateDataPending_SendsRejection(t *test
 		Build()
 
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, "node2", matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -222,7 +256,6 @@ func Test_validator_IsEndorsementRequestFromSelf_DifferentNode_ReturnsFalse(t *t
 	assert.False(t, result, "request from a different node should not match")
 }
 
-
 func Test_handleEndorsementRequest_SendEndorsementErrorFails_LogsAndContinues(t *testing.T) {
 	ctx := t.Context()
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Observing).
@@ -231,7 +264,7 @@ func Test_handleEndorsementRequest_SendEndorsementErrorFails_LogsAndContinues(t 
 
 	// Trigger sendErr via a party identity error (empty identity), and have SendEndorsementError itself fail.
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(fmt.Errorf("transport failure"))
 
 	event := buildEndorsementEvent("node2")
@@ -273,8 +306,8 @@ func Test_action_HandleEndorsementRequest_SpawnsGoroutineThatCompletesEndorsemen
 
 	done := make(chan struct{})
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Run(func(_ context.Context, _, _, _ string, _ *prototk.AttestationResult, _ *components.EndorsementResult, _, _, _, _ string) {
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, msg *engineProto.EndorsementResponse) {
 			close(done)
 		}).
 		Return(nil)
@@ -303,8 +336,8 @@ func Test_action_HandleEndorsementRequest_SendsEndorsementError_WhenExpiryAlread
 
 	errorSent := make(chan struct{})
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
-		Run(func(_ context.Context, _, _, _, _, _, _, _ string) { close(errorSent) }).
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
+		Run(func(_ context.Context, _ string, _ *engineProto.EndorsementError) { close(errorSent) }).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -335,7 +368,7 @@ func Test_handleEndorsementRequest_Revert_SendsResponseWithRevertReason(t *testi
 	}
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, endorsementResult, revertMsg, "att1", "party1@node2", "node2").
+		SendEndorsementResponse(mock.Anything, "node2", matchEndorsementResponseMsg("tx-1", "ik-1", "party1@node2", "att1", &revertMsg)).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -357,8 +390,9 @@ func Test_handleEndorsementRequest_Revert_NoRevertReason_UsesDefaultMessage(t *t
 		Endorser:     &prototk.ResolvedVerifier{Lookup: "party1@node2"},
 	}
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
+	defaultMsg := "(no revert reason)"
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, endorsementResult, "(no revert reason)", "att1", "party1@node2", "node2").
+		SendEndorsementResponse(mock.Anything, "node2", matchEndorsementResponseMsg("tx-1", "ik-1", "party1@node2", "att1", &defaultMsg)).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -372,7 +406,7 @@ func Test_handleEndorsementRequest_PartyIdentityError_SendsEndorsementError(t *t
 		Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	// Party "@node2" has an empty identity part, causing PrivateIdentityLocator.Identity to fail.
@@ -393,7 +427,7 @@ func Test_handleEndorsementRequest_PartyKeyResolveError_SendsEndorsementError(t 
 	mocks.AllComponents.On("KeyManager").Return(mockKeyManager).Maybe()
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -412,7 +446,7 @@ func Test_handleEndorsementRequest_EndorseTransactionError_SendsEndorsementError
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("domain error"))
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -436,9 +470,9 @@ func Test_handleEndorsementRequest_EndorserSubmit_SendsResponseWithConstraint(t 
 
 	var capturedAttResult *prototk.AttestationResult
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Run(func(_ context.Context, _, _, _ string, attResult *prototk.AttestationResult, _ *components.EndorsementResult, _, _, _, _ string) {
-			capturedAttResult = attResult
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, msg *engineProto.EndorsementResponse) {
+			capturedAttResult = msg.Endorsement
 		}).
 		Return(nil)
 
@@ -475,9 +509,9 @@ func Test_handleEndorsementRequest_Sign_ThisNode_SignsAndSendsResponse(t *testin
 
 	var capturedAttResult *prototk.AttestationResult
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Run(func(_ context.Context, _, _, _ string, attResult *prototk.AttestationResult, _ *components.EndorsementResult, _, _, _, _ string) {
-			capturedAttResult = attResult
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, msg *engineProto.EndorsementResponse) {
+			capturedAttResult = msg.Endorsement
 		}).
 		Return(nil)
 
@@ -513,7 +547,7 @@ func Test_handleEndorsementRequest_Sign_ResolveKeyError_SendsEndorsementError(t 
 	km.EXPECT().ResolveKeyNewDatabaseTX(mock.Anything, "signer", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("key error"))
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -545,7 +579,7 @@ func Test_handleEndorsementRequest_Sign_SignError_SendsEndorsementError(t *testi
 	km.EXPECT().Sign(mock.Anything, resolvedKey, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("sign error"))
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -572,7 +606,7 @@ func Test_handleEndorsementRequest_Sign_WrongNode_LogsErrorAndSendsResponseUnsig
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
 	// Response is still sent (with empty payload since we didn't sign).
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -594,7 +628,7 @@ func Test_handleEndorsementRequest_SendResponseError_LogsError(t *testing.T) {
 	}
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("transport error"))
 
 	event := buildEndorsementEvent("node2")
@@ -655,7 +689,9 @@ func Test_handleEndorsementRequest_UsesContractAddressFromCoordinator(t *testing
 
 	// Verify the contract address from c.contractAddress is used (not from the event).
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, contractAddr.String(), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.MatchedBy(func(msg *engineProto.EndorsementResponse) bool {
+			return msg.ContractAddress == contractAddr.HexString()
+		})).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -678,7 +714,7 @@ func Test_handleEndorsementRequest_IncEndorsedTransactionsOnSuccess(t *testing.T
 	}
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		SendEndorsementResponse(mock.Anything, mock.Anything, mock.Anything).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")
@@ -706,7 +742,7 @@ func Test_handleEndorsementRequest_Sign_ValidateEndorserError_SendsEndorsementEr
 	mocks.DomainAPI.EXPECT().EndorseTransaction(mock.Anything, mock.Anything, mock.Anything).Return(endorsementResult, nil)
 
 	mocks.TransportWriter.EXPECT().
-		SendEndorsementError(mock.Anything, "tx-1", "ik-1", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "node2").
+		SendEndorsementError(mock.Anything, "node2", matchEndorsementErrorMsg("tx-1", "ik-1")).
 		Return(nil)
 
 	event := buildEndorsementEvent("node2")

--- a/core/go/internal/sequencer/coordinator/inactive.go
+++ b/core/go/internal/sequencer/coordinator/inactive.go
@@ -59,31 +59,29 @@ func action_RejectDelegationRequestBlockHeight(ctx context.Context, c *coordinat
 	c.recordOriginatorActivity(e.FromNode)
 	log.L(ctx).Warnf("rejecting delegation from %s due to block height tolerance (originator=%d, coordinator=%d, tolerance=%d)",
 		e.FromNode, e.OriginatorsBlockHeight, c.currentBlockHeight, c.blockHeightTolerance)
-	return c.transportWriter.SendDelegationRejection(
-		ctx,
-		e.FromNode,
-		e.DelegationID,
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", // no active coordinator redirect for block height rejections
-		int64(e.OriginatorsBlockHeight),
-		c.currentBlockHeight,
-		int64(c.blockHeightTolerance),
-	)
+	return c.transportWriter.SendDelegationRejection(ctx, e.FromNode, &engineProto.DelegationRejection{
+		DelegationId:           e.DelegationID,
+		DelegateNodeId:         e.FromNode,
+		ContractAddress:        c.contractAddress.HexString(),
+		RejectionReason:        engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		OriginatorBlockHeight:  int64(e.OriginatorsBlockHeight),
+		CoordinatorBlockHeight: c.currentBlockHeight,
+		BlockHeightTolerance:   int64(c.blockHeightTolerance),
+	})
 }
 
 func action_RejectDelegationRequest(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*TransactionsDelegatedEvent)
 	c.recordOriginatorActivity(e.FromNode)
-	return c.transportWriter.SendDelegationRejection(
-		ctx,
-		e.FromNode,
-		e.DelegationID,
-		engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
-		c.currentActiveCoordinator,
-		int64(e.OriginatorsBlockHeight),
-		c.currentBlockHeight,
-		0, // tolerance not relevant for non-block-height rejections
-	)
+	return c.transportWriter.SendDelegationRejection(ctx, e.FromNode, &engineProto.DelegationRejection{
+		DelegationId:           e.DelegationID,
+		DelegateNodeId:         e.FromNode,
+		ContractAddress:        c.contractAddress.HexString(),
+		ActiveCoordinator:      c.currentActiveCoordinator,
+		RejectionReason:        engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
+		OriginatorBlockHeight:  int64(e.OriginatorsBlockHeight),
+		CoordinatorBlockHeight: c.currentBlockHeight,
+	})
 }
 
 func action_SetSelfAsActiveCoordinator(_ context.Context, c *coordinator, _ common.Event) error {

--- a/core/go/internal/sequencer/coordinator/inactive_test.go
+++ b/core/go/internal/sequencer/coordinator/inactive_test.go
@@ -24,6 +24,7 @@ import (
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,10 +120,13 @@ func Test_action_RejectDelegationRequestBlockHeight_Success(t *testing.T) {
 
 	fromNode := "remoteNode"
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		ctx, fromNode, "del-789",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"",
-		int64(100), int64(200), int64(10),
+		mock.Anything, fromNode, mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-789" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(100) &&
+				msg.CoordinatorBlockHeight == int64(200) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	event := &TransactionsDelegatedEvent{
@@ -141,7 +145,11 @@ func Test_action_RejectDelegationRequest_Success(t *testing.T) {
 
 	delegationID := "del-123"
 	fromNode := "remoteNode"
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, fromNode, mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == delegationID && msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		}),
+	).Return(nil)
 
 	event := &TransactionsDelegatedEvent{
 		FromNode:     fromNode,
@@ -158,7 +166,11 @@ func Test_action_RejectDelegationRequest_PropagatesError(t *testing.T) {
 	delegationID := "del-456"
 	fromNode := "remoteNode"
 	expectedErr := fmt.Errorf("transport error")
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(ctx, fromNode, delegationID, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, c.currentActiveCoordinator, int64(0), int64(0), int64(0)).Return(expectedErr)
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(
+		mock.Anything, fromNode, mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == delegationID && msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		}),
+	).Return(expectedErr)
 
 	event := &TransactionsDelegatedEvent{
 		FromNode:     fromNode,

--- a/core/go/internal/sequencer/coordinator/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/snapshot.go
@@ -17,11 +17,16 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 )
+
+// jsonMarshalFn is a package-level variable so tests can inject errors.
+var jsonMarshalFn = json.Marshal
 
 func action_SendHeartbeat(ctx context.Context, c *coordinator, _ common.Event) error {
 	return c.sendHeartbeat(ctx, false)
@@ -73,7 +78,18 @@ func (c *coordinator) sendHeartbeat(ctx context.Context, includeLocks bool) erro
 				OutputStates:           statesAndLocks.OutputState,
 			}
 		}
-		if sendErr := c.transportWriter.SendHeartbeat(ctx, node, c.contractAddress, snapshot); sendErr != nil {
+		snapshotBytes, jsonErr := jsonMarshalFn(snapshot)
+		if jsonErr != nil {
+			log.L(ctx).Errorf("error marshalling heartbeat snapshot for node %s: %v", node, jsonErr)
+			err = jsonErr
+			continue
+		}
+		heartbeatMsg := &engineProto.CoordinatorHeartbeatNotification{
+			From:                c.nodeName,
+			ContractAddress:     c.contractAddress.HexString(),
+			CoordinatorSnapshot: snapshotBytes,
+		}
+		if sendErr := c.transportWriter.SendHeartbeat(ctx, node, heartbeatMsg); sendErr != nil {
 			log.L(ctx).Errorf("error sending heartbeat to %s: %v", node, sendErr)
 			err = sendErr
 		}

--- a/core/go/internal/sequencer/coordinator/snapshot_test.go
+++ b/core/go/internal/sequencer/coordinator/snapshot_test.go
@@ -125,9 +125,9 @@ func TestSendHeartbeat_HandlesError(t *testing.T) {
 		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
 		WithMockTransportWriter().
 		Build()
-	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node1", mock.Anything, mock.Anything).
+	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node1", mock.Anything).
 		Return(nil)
-	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node2", mock.Anything, mock.Anything).
+	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node2", mock.Anything).
 		Return(fmt.Errorf("transport error"))
 
 	err := c.sendHeartbeat(ctx, false)
@@ -225,4 +225,23 @@ func TestSendHeartbeat_ExportStatesAndLocksError_ReturnsError(t *testing.T) {
 	err := c.sendHeartbeat(ctx, true)
 	assert.Error(t, err)
 	assert.Equal(t, "export error", err.Error())
+}
+
+func TestSendHeartbeat_JSONMarshalError_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
+		EndorserCandidates("node1").
+		CoordinatorSelectionMode(prototk.ContractConfig_COORDINATOR_ENDORSER).
+		Build()
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, fmt.Errorf("json marshal error")
+	}
+
+	err := c.sendHeartbeat(ctx, false)
+	require.Error(t, err)
+	assert.Equal(t, "json marshal error", err.Error())
 }

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -195,9 +195,13 @@ func TestCoordinator_WhenIdle_TransactionsDelegated_BlockHeightToleranceExceeded
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	// diff = |100 - 0| = 100 > 10 → block height rejection.
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "node2", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "node2", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("node2")))
@@ -233,8 +237,8 @@ func TestCoordinator_WhenIdle_EndorsementRequestReceived_BlockHeightToleranceExc
 	// Block height difference (100 - 0 = 100) exceeds tolerance (10) → rejection.
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node2", mocks)
@@ -272,9 +276,8 @@ func TestCoordinator_WhenIdle_EndorsementRequestReceived_PrivateStateDataPending
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -327,7 +330,9 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_HigherPriority_Transiti
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_ProcessDelegatedTransactions sends an acknowledgment.
-	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
+		return msg.DelegationId == "del-1"
+	})).Return(nil)
 	// OnTransitionTo Elect fires action_SendHandoverRequest.
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil)
 
@@ -350,7 +355,9 @@ func TestCoordinator_WhenObserving_DelegatedTransactions_LowerPriority_RejectsAn
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_RejectDelegationRequest sends a rejection naming the current active coordinator.
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-1", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+		return msg.DelegationId == "del-1" && msg.ActiveCoordinator == "node1" && msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+	})).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
@@ -374,9 +381,13 @@ func TestCoordinator_WhenObserving_TransactionsDelegated_BlockHeightToleranceExc
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -413,8 +424,8 @@ func TestCoordinator_WhenObserving_EndorsementRequestReceived_BlockHeightToleran
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node1", mocks)
@@ -452,9 +463,8 @@ func TestCoordinator_WhenObserving_EndorsementRequestReceived_PrivateStateDataPe
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -506,7 +516,10 @@ func TestCoordinator_WhenElectRequestTimeoutFires_NudgesHandoverRequest(t *testi
 	// IdempotentRequest has requestTime == nil, so its first Nudge() always sends immediately.
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil).Once()
 	c.pendingHandoverRequest = common.NewIdempotentRequest(ctx, c.clock, c.requestTimeout, func(ctx context.Context, _ uuid.UUID) error {
-		return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, c.contractAddress)
+		return c.transportWriter.SendHandoverRequest(ctx, c.currentActiveCoordinator, &engineProto.CoordinatorHandoverRequest{
+			FromNode:        c.nodeName,
+			ContractAddress: c.contractAddress.HexString(),
+		})
 	})
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &RequestTimeoutIntervalEvent{}))
@@ -782,9 +795,13 @@ func TestCoordinator_WhenElect_TransactionsDelegated_BlockHeightToleranceExceede
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -900,9 +917,8 @@ func TestCoordinator_WhenElect_EndorsementRequestReceived_LowerPriority_RejectsA
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
-		int64(0), int64(0), int64(0),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-lp-test", "ik-lp-test",
+			engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR, int64(0), int64(0), int64(0)),
 	).Return(nil)
 
 	event := newLowerPriorityEndorsementEvent(t, "node3", mocks, true) // node3 < node1 in priority
@@ -927,8 +943,8 @@ func TestCoordinator_WhenElect_EndorsementRequestReceived_BlockHeightToleranceEx
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node1", mocks) // node1 is higher priority
@@ -968,9 +984,8 @@ func TestCoordinator_WhenElect_EndorsementRequestReceived_PrivateStateDataPendin
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -1265,9 +1280,13 @@ func TestCoordinator_WhenPrepared_TransactionsDelegated_BlockHeightToleranceExce
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -1405,9 +1424,8 @@ func TestCoordinator_WhenPrepared_EndorsementRequestReceived_LowerPriority_Rejec
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
-		int64(0), int64(0), int64(0),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-lp-test", "ik-lp-test",
+			engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR, int64(0), int64(0), int64(0)),
 	).Return(nil)
 
 	event := newLowerPriorityEndorsementEvent(t, "node3", mocks, true)
@@ -1430,8 +1448,8 @@ func TestCoordinator_WhenPrepared_EndorsementRequestReceived_BlockHeightToleranc
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node1", mocks) // higher priority — rejected before priority check
@@ -1470,9 +1488,8 @@ func TestCoordinator_WhenPrepared_EndorsementRequestReceived_PrivateStateDataPen
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -1662,9 +1679,13 @@ func TestCoordinator_WhenActive_TransactionsDelegated_BlockHeightToleranceExceed
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -1928,14 +1949,13 @@ func TestCoordinator_WhenActive_EndorsementRequestReceived_LowerPriority_Rejects
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
-		int64(0), int64(0), int64(0),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-lp-test", "ik-lp-test",
+			engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR, int64(0), int64(0), int64(0)),
 	).Return(nil)
 	// After rejecting a lower-priority sender, Active reasserts its coordinator status to all candidates.
-	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node1", mock.Anything, mock.Anything).Return(nil)
-	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node2", mock.Anything, mock.Anything).Return(nil)
-	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node3", mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node1", mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node2", mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendHeartbeat(mock.Anything, "node3", mock.Anything).Return(nil)
 
 	event := newLowerPriorityEndorsementEvent(t, "node3", mocks, true)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, event))
@@ -1957,8 +1977,8 @@ func TestCoordinator_WhenActive_EndorsementRequestReceived_BlockHeightToleranceE
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node2", mocks)
@@ -1995,9 +2015,8 @@ func TestCoordinator_WhenActive_EndorsementRequestReceived_PrivateStateDataPendi
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -2113,9 +2132,13 @@ func TestCoordinator_WhenActiveFLush_TransactionsDelegated_BlockHeightToleranceE
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -2271,9 +2294,8 @@ func TestCoordinator_WhenActiveFlush_EndorsementRequestReceived_LowerPriority_Re
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR,
-		int64(0), int64(0), int64(0),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-lp-test", "ik-lp-test",
+			engineProto.RejectionReason_ENDORSER_IS_ACTIVE_COORDINATOR, int64(0), int64(0), int64(0)),
 	).Return(nil)
 
 	event := newLowerPriorityEndorsementEvent(t, "node2", mocks, true)
@@ -2296,8 +2318,8 @@ func TestCoordinator_WhenActiveFLush_EndorsementRequestReceived_BlockHeightToler
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node2", mocks)
@@ -2334,9 +2356,8 @@ func TestCoordinator_WhenActiveFlush_EndorsementRequestReceived_PrivateStateData
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -2427,7 +2448,9 @@ func TestCoordinator_WhenClosingFlush_DelegatedTransactions_HigherPriority_Trans
 		Transactions(txDispatched).
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
-	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
+		return msg.DelegationId == "del-1"
+	})).Return(nil)
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
@@ -2448,7 +2471,9 @@ func TestCoordinator_WhenClosingFlush_DelegatedTransactions_LowerPriority_Reject
 		Transactions(txDispatched).
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-2", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+		return msg.DelegationId == "del-2" && msg.ActiveCoordinator == "node1" && msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+	})).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -2470,9 +2495,13 @@ func TestCoordinator_WhenClosingFlush_TransactionsDelegated_BlockHeightTolerance
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -2590,8 +2619,8 @@ func TestCoordinator_WhenClosingFlush_EndorsementRequestReceived_BlockHeightTole
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node1", mocks)
@@ -2629,9 +2658,8 @@ func TestCoordinator_WhenClosingFlush_EndorsementRequestReceived_PrivateStateDat
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{
@@ -2788,7 +2816,9 @@ func TestCoordinator_WhenClosing_DelegationRequest_HigherPriorityThanCurrentActi
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
 	// action_ProcessDelegatedTransactions always sends an acknowledgment (even for empty transaction lists).
-	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", "del-1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationResponse(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
+		return msg.DelegationId == "del-1"
+	})).Return(nil)
 	mocks.TransportWriter.EXPECT().SendHandoverRequest(mock.Anything, "node2", mock.Anything).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
@@ -2812,7 +2842,9 @@ func TestCoordinator_WhenClosing_DelegatedTransactions_LowerPriority_ActiveCoord
 		WithMockTransportWriter().
 		Build()
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0))
-	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", "del-3", mock.Anything, "node1", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.TransportWriter.EXPECT().SendDelegationRejection(mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+		return msg.DelegationId == "del-3" && msg.ActiveCoordinator == "node1" && msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+	})).Return(nil)
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, &TransactionsDelegatedEvent{
 		FromNode:     "originator-node",
 		Originator:   "sender@originator-node",
@@ -2856,9 +2888,13 @@ func TestCoordinator_WhenClosing_TransactionsDelegated_BlockHeightToleranceExcee
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendDelegationRejection(
-		mock.Anything, "originator-node", "del-bh-test",
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		"", int64(0), int64(100), int64(10),
+		mock.Anything, "originator-node", mock.MatchedBy(func(msg *engineProto.DelegationRejection) bool {
+			return msg.DelegationId == "del-bh-test" &&
+				msg.RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE &&
+				msg.OriginatorBlockHeight == int64(0) &&
+				msg.CoordinatorBlockHeight == int64(100) &&
+				msg.BlockHeightTolerance == int64(10)
+		}),
 	).Return(nil)
 
 	require.NoError(t, c.stateMachineEventLoop.ProcessEvent(ctx, newDelegationBlockHeightExceedingEvent("originator-node")))
@@ -2916,8 +2952,8 @@ func TestCoordinator_WhenClosing_EndorsementRequestReceived_BlockHeightTolerance
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(100))
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), mock.Anything,
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-bh-test", "ik-bh-test",
+			engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, int64(0), int64(100), int64(10)),
 	).Return(nil)
 
 	event := newBlockHeightExceedingEndorsementEvent("node1", mocks)
@@ -2955,9 +2991,8 @@ func TestCoordinator_WhenClosing_EndorsementRequestReceived_PrivateStateDataPend
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(0))
 	mocks.EngineIntegration.On("CheckPendingPrivateStateData", mock.Anything, int64(90)).Return(false, nil)
 	mocks.TransportWriter.EXPECT().SendEndorsementRejection(
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		int64(100), int64(0), int64(10),
+		mock.Anything, mock.Anything, matchEndorsementRejectionMsg("tx-1", "ik-1",
+			engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING, int64(100), int64(0), int64(10)),
 	).Return(nil)
 
 	event := &EndorsementRequestReceivedEvent{

--- a/core/go/internal/sequencer/coordinator/transaction/assembling.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling.go
@@ -16,6 +16,7 @@ package transaction
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -28,6 +29,9 @@ import (
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 )
+
+// jsonMarshalFn is a package-level variable so tests can inject errors.
+var jsonMarshalFn = json.Marshal
 
 func (t *coordinatorTransaction) revertTransactionFailedAssembly(ctx context.Context, revertReason string) {
 	var tryFinalize func()
@@ -121,8 +125,27 @@ func (t *coordinatorTransaction) sendAssembleRequest(ctx context.Context) error 
 			log.L(ctx).Errorf("failed to export grapher state locks: %s", err)
 			return err
 		}
-
-		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, t.pt.ID, idempotencyKey, t.pt.PreAssembly, grapherStatesAndLocks, t.getBlockHeight(), t.clock.Now().Add(t.stateTimeout), int64(t.blockHeightTolerance))
+		preAssemblyBytes, err := jsonMarshalFn(t.pt.PreAssembly)
+		if err != nil {
+			log.L(ctx).Errorf("failed to marshal pre-assembly: %s", err)
+			return err
+		}
+		stateLocksBytes, err := jsonMarshalFn(grapherStatesAndLocks)
+		if err != nil {
+			log.L(ctx).Errorf("failed to marshal state locks: %s", err)
+			return err
+		}
+		log.L(ctx).Debugf("assemble request state locks for tx %s: %s", t.pt.ID, string(stateLocksBytes))
+		return t.transportWriter.SendAssembleRequest(ctx, t.originatorNode, &engineProto.AssembleRequest{
+			TransactionId:          t.pt.ID.String(),
+			AssembleRequestId:      idempotencyKey.String(),
+			ContractAddress:        t.pt.Address.HexString(),
+			PreAssembly:            preAssemblyBytes,
+			StateLocks:             stateLocksBytes,
+			CoordinatorBlockHeight: t.getBlockHeight(),
+			ExpiryTimeUnixMs:       t.clock.Now().Add(t.stateTimeout).UnixMilli(),
+			BlockHeightTolerance:   int64(t.blockHeightTolerance),
+		})
 	})
 
 	t.scheduleRequestTimeout(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/assembling_test.go
@@ -17,7 +17,9 @@ package transaction
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +39,28 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// matchSendAssembleRequestMsg returns a mock.MatchedBy matcher that inspects the
+// AssembleRequest proto struct, equivalent to the previous per-argument assertions.
+// Pass a non-nil idempotencyKey only when the idempotency key should be asserted (e.g. nudge calls).
+func matchSendAssembleRequestMsg(txn *coordinatorTransaction, blockHeight int64, idempotencyKey *uuid.UUID) interface{} {
+	return mock.MatchedBy(func(msg *engineProto.AssembleRequest) bool {
+		if msg.TransactionId != txn.pt.ID.String() {
+			return false
+		}
+		if msg.CoordinatorBlockHeight != blockHeight {
+			return false
+		}
+		if idempotencyKey != nil && msg.AssembleRequestId != idempotencyKey.String() {
+			return false
+		}
+		var pa components.TransactionPreAssembly
+		if err := json.Unmarshal(msg.PreAssembly, &pa); err != nil {
+			return false
+		}
+		return reflect.DeepEqual(&pa, txn.pt.PreAssembly)
+	})
+}
 
 func Test_revertTransactionFailedAssembly_Success(t *testing.T) {
 	ctx := t.Context()
@@ -238,9 +262,9 @@ func Test_sendAssembleRequest_Success(t *testing.T) {
 		WithCurrentBlockHeight(100).
 		Build()
 
-	// Mock transport writer - use mock.Anything for idempotency key since it's generated dynamically
+	// Mock transport writer - idempotency key is generated dynamically so only assert proto struct fields
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -262,6 +286,39 @@ func Test_sendAssembleRequest_ExportStatesAndLocksError(t *testing.T) {
 	require.ErrorContains(t, err, "export states and locks failed")
 }
 
+func Test_sendAssembleRequest_PreAssemblyMarshalError(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).Build()
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, errors.New("pre-assembly marshal error")
+	}
+
+	err := txn.sendAssembleRequest(ctx)
+	require.ErrorContains(t, err, "pre-assembly marshal error")
+}
+
+func Test_sendAssembleRequest_StateLocksJSONMarshalError(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).Build()
+
+	callCount := 0
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(v any) ([]byte, error) {
+		callCount++
+		if callCount == 2 {
+			return nil, errors.New("state locks marshal error")
+		}
+		return json.Marshal(v)
+	}
+
+	err := txn.sendAssembleRequest(ctx)
+	require.ErrorContains(t, err, "state locks marshal error")
+}
+
 func Test_sendAssembleRequest_SendAssembleRequestError(t *testing.T) {
 	ctx := t.Context()
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Assembling).
@@ -269,9 +326,9 @@ func Test_sendAssembleRequest_SendAssembleRequestError(t *testing.T) {
 		WithCurrentBlockHeight(100).
 		Build()
 
-	// Mock transport writer to return error - use mock.Anything for idempotency key
+	// Mock transport writer to return error - idempotency key is generated dynamically
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(errors.New("send error"))
 
 	err := txn.sendAssembleRequest(ctx)
@@ -296,15 +353,16 @@ func Test_nudgeAssembleRequest_WithPendingRequest(t *testing.T) {
 
 	// Create a pending request first
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
 	require.NoError(t, err)
 
-	// Now nudge it - should succeed since request exists
+	// Now nudge it - should succeed since request exists; nudge reuses the same idempotency key
+	idempotencyKey := txn.pendingAssembleRequest.IdempotencyKey()
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), &idempotencyKey),
 	).Return(nil)
 
 	err = txn.nudgeAssembleRequest(ctx)
@@ -340,7 +398,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleSuccessEvent_Match(t *
 
 	// Create a pending request
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -365,7 +423,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleSuccessEvent_NoMatch(t
 
 	// Create a pending request
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -402,7 +460,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleRevertEvent_Match(t *t
 
 	// Create a pending request
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -427,7 +485,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleErrorEvent_Match(t *te
 
 	// Create a pending request
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -453,7 +511,7 @@ func Test_validator_MatchesPendingAssembleRequest_AssembleErrorEvent_NoMatch(t *
 
 	// Create a pending request
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
@@ -502,7 +560,7 @@ func Test_action_SendAssembleRequest_Success(t *testing.T) {
 		Build()
 
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := action_SendAssembleRequest(ctx, txn, nil)
@@ -521,15 +579,16 @@ func Test_action_NudgeAssembleRequest_Success(t *testing.T) {
 
 	// Create a pending request first
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)
 	require.NoError(t, err)
 
-	// Now nudge it
+	// Now nudge it - nudge reuses the same idempotency key
+	idempotencyKey := txn.pendingAssembleRequest.IdempotencyKey()
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, txn.pendingAssembleRequest.IdempotencyKey(), txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), &idempotencyKey),
 	).Return(nil)
 
 	err = action_NudgeAssembleRequest(ctx, txn, nil)
@@ -607,7 +666,7 @@ func Test_sendAssembleRequest_schedulesTimer(t *testing.T) {
 	})
 
 	mocks.TransportWriter.EXPECT().SendAssembleRequest(
-		ctx, txn.originatorNode, txn.pt.ID, mock.Anything, txn.pt.PreAssembly, mock.Anything, int64(100), mock.Anything, mock.Anything,
+		mock.Anything, txn.originatorNode, matchSendAssembleRequestMsg(txn, int64(100), nil),
 	).Return(nil)
 
 	err := txn.sendAssembleRequest(ctx)

--- a/core/go/internal/sequencer/coordinator/transaction/confirming.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming.go
@@ -25,6 +25,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/syncpoints"
 	"github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/google/uuid"
 )
 
 func guard_CanRetryRevert(ctx context.Context, txn *coordinatorTransaction) bool {
@@ -108,35 +109,61 @@ func checkConfirmedHash(ctx context.Context, t *coordinatorTransaction, hash pld
 
 func action_NotifyOriginatorOfConfirmation(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*ConfirmedSuccessEvent)
-	return t.transportWriter.SendTransactionConfirmed(
-		ctx, t.pt.ID, t.originatorNode, &t.pt.Address, e.Nonce,
-		engine.TransactionConfirmed_OUTCOME_SUCCESS, nil, "", false,
-	)
+	msg := &engine.TransactionConfirmed{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Outcome:         engine.TransactionConfirmed_OUTCOME_SUCCESS,
+	}
+	if e.Nonce != nil {
+		msg.Nonce = int64(*e.Nonce)
+	}
+	return t.transportWriter.SendTransactionConfirmed(ctx, t.originatorNode, msg)
 }
 
 func action_NotifyOriginatorOfRetryableRevert(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*ConfirmedRevertedEvent)
-	return t.transportWriter.SendTransactionConfirmed(
-		ctx, t.pt.ID, t.originatorNode, &t.pt.Address, e.Nonce,
-		engine.TransactionConfirmed_OUTCOME_REVERTED, t.revertReason, t.decodedRevertReason, true,
-	)
+	msg := &engine.TransactionConfirmed{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Outcome:         engine.TransactionConfirmed_OUTCOME_REVERTED,
+		RevertReason:    t.revertReason,
+		FailureMessage:  t.decodedRevertReason,
+		WillRetry:       true,
+	}
+	if e.Nonce != nil {
+		msg.Nonce = int64(*e.Nonce)
+	}
+	return t.transportWriter.SendTransactionConfirmed(ctx, t.originatorNode, msg)
 }
 
 func action_NotifyOriginatorOfNonRetryableRevert(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*ConfirmedRevertedEvent)
-	return t.transportWriter.SendTransactionConfirmed(
-		ctx, t.pt.ID, t.originatorNode, &t.pt.Address, e.Nonce,
-		engine.TransactionConfirmed_OUTCOME_REVERTED, t.revertReason, t.decodedRevertReason, false,
-	)
+	msg := &engine.TransactionConfirmed{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Outcome:         engine.TransactionConfirmed_OUTCOME_REVERTED,
+		RevertReason:    t.revertReason,
+		FailureMessage:  t.decodedRevertReason,
+	}
+	if e.Nonce != nil {
+		msg.Nonce = int64(*e.Nonce)
+	}
+	return t.transportWriter.SendTransactionConfirmed(ctx, t.originatorNode, msg)
 }
 
 func action_NotifyOriginatorOfChainedDependencyFailure(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*ChainedDependencyFailedEvent)
 	failureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, e.FailedTxID).Error()
-	return t.transportWriter.SendTransactionConfirmed(
-		ctx, t.pt.ID, t.originatorNode, &t.pt.Address, nil,
-		engine.TransactionConfirmed_OUTCOME_REVERTED, nil, failureMessage, false,
-	)
+	return t.transportWriter.SendTransactionConfirmed(ctx, t.originatorNode, &engine.TransactionConfirmed{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Outcome:         engine.TransactionConfirmed_OUTCOME_REVERTED,
+		FailureMessage:  failureMessage,
+	})
 }
 
 func action_FinalizeNonRetryableRevert(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch.go
@@ -42,13 +42,12 @@ func (t *coordinatorTransaction) sendPreDispatchRequest(ctx context.Context) err
 			return err
 		}
 		t.pendingPreDispatchRequest = common.NewIdempotentRequest(ctx, t.clock, t.requestTimeout, func(ctx context.Context, idempotencyKey uuid.UUID) error {
-			return t.transportWriter.SendPreDispatchRequest(
-				ctx,
-				t.originatorNode,
-				idempotencyKey,
-				t.pt.PreAssembly.TransactionSpecification,
-				hash,
-			)
+			return t.transportWriter.SendPreDispatchRequest(ctx, t.originatorNode, &engineProto.PreDispatchRequest{
+				Id:               idempotencyKey.String(),
+				TransactionId:    t.pt.ID.String(),
+				ContractAddress:  t.pt.Address.HexString(),
+				PostAssembleHash: hash.Bytes(),
+			})
 		})
 		t.scheduleRequestTimeout(ctx)
 	}

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/mocks/graphermocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -176,7 +177,9 @@ func Test_sendPreDispatchRequest_RequestTimeoutSchedulesTimer_QueueEventCalled(t
 		Build()
 
 	mocks.TransportWriter.EXPECT().SendPreDispatchRequest(
-		ctx, txn.originatorNode, mock.Anything, txn.pt.PreAssembly.TransactionSpecification, mock.Anything,
+		mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.PreDispatchRequest) bool {
+			return msg.TransactionId == txn.pt.ID.String()
+		}),
 	).Return(nil)
 
 	mocks.Clock.On("Now").Return(time.Now()).Once()

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/dependencytracker"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/syncpoints"
 	"github.com/LFDT-Paladin/paladin/core/mocks/graphermocks"
-	"github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,12 @@ func Test_action_NotifyOriginatorOfConfirmation_Success(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, &nonce, engine.TransactionConfirmed_OUTCOME_SUCCESS, pldtypes.HexBytes(nil), "", false).
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.Nonce == int64(42) &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_SUCCESS &&
+				!msg.WillRetry
+		})).
 		Return(nil)
 
 	err := action_NotifyOriginatorOfConfirmation(ctx, txn, event)
@@ -72,7 +77,12 @@ func Test_action_NotifyOriginatorOfRetryableRevert(t *testing.T) {
 	txn.revertReason = revertReason
 
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, &nonce, engine.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "", true).
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.Nonce == int64(42) &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+				msg.WillRetry
+		})).
 		Return(nil)
 
 	err := action_NotifyOriginatorOfRetryableRevert(ctx, txn, event)
@@ -97,7 +107,12 @@ func Test_action_NotifyOriginatorOfNonRetryableRevert(t *testing.T) {
 	txn.revertReason = revertReason
 
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, &nonce, engine.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "", false).
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.Nonce == int64(42) &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+				!msg.WillRetry
+		})).
 		Return(nil)
 
 	err := action_NotifyOriginatorOfNonRetryableRevert(ctx, txn, event)
@@ -120,13 +135,13 @@ func Test_action_NotifyOriginatorOfChainedDependencyFailure(t *testing.T) {
 
 	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
-			(*pldtypes.HexUint64)(nil),
-			engine.TransactionConfirmed_OUTCOME_REVERTED,
-			pldtypes.HexBytes(nil),
-			expectedFailureMessage,
-			false,
-		).
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.ContractAddress == txn.pt.Address.HexString() &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+				msg.FailureMessage == expectedFailureMessage &&
+				!msg.WillRetry
+		})).
 		Return(nil)
 
 	err := action_NotifyOriginatorOfChainedDependencyFailure(ctx, txn, event)
@@ -151,13 +166,13 @@ func Test_action_NotifyOriginatorOfChainedDependencyFailureAtCreation(t *testing
 
 	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depTx.pt.ID).Error()
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
-			(*pldtypes.HexUint64)(nil),
-			engine.TransactionConfirmed_OUTCOME_REVERTED,
-			pldtypes.HexBytes(nil),
-			expectedFailureMessage,
-			false,
-		).
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.ContractAddress == txn.pt.Address.HexString() &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+				msg.FailureMessage == expectedFailureMessage &&
+				!msg.WillRetry
+		})).
 		Return(nil)
 
 	err := action_NotifyOriginatorOfChainedDependencyFailureAtCreation(ctx, txn, nil)

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched.go
@@ -19,16 +19,18 @@ import (
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
-	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
 )
 
 func action_NotifyDispatched(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
-	var txSpec *prototk.TransactionSpecification
-	if t.pt.PreAssembly != nil {
-		txSpec = t.pt.PreAssembly.TransactionSpecification
+	msg := &engineProto.TransactionDispatched{
+		Id:              uuid.New().String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Signer:          t.originator,
+		TransactionId:   t.pt.ID.String(),
 	}
-	return t.transportWriter.SendDispatched(ctx, t.originator, uuid.New(), txSpec)
+	return t.transportWriter.SendDispatched(ctx, t.originatorNode, msg)
 }
 
 // action_CleanUpAssemblyPayload releases the heavy post-assembly and prepared-dispatch
@@ -50,12 +52,22 @@ func action_NotifyCollected(_ context.Context, t *coordinatorTransaction, event 
 func action_NotifyNonceAllocated(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*NonceAllocatedEvent)
 	t.nonce = &e.Nonce
-	return t.transportWriter.SendNonceAssigned(ctx, t.pt.ID, t.originatorNode, &t.pt.Address, e.Nonce)
+	return t.transportWriter.SendNonceAssigned(ctx, t.originatorNode, &engineProto.NonceAssigned{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Nonce:           int64(e.Nonce),
+	})
 }
 
 func action_NotifySubmitted(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*SubmittedEvent)
 	log.L(ctx).Infof("coordinator transaction applying SubmittedEvent for transaction %s submitted with hash %s", t.pt.ID.String(), e.SubmissionHash.HexString())
 	t.latestSubmissionHash = &e.SubmissionHash
-	return t.transportWriter.SendTransactionSubmitted(ctx, t.pt.ID, t.originatorNode, &t.pt.Address, &e.SubmissionHash)
+	return t.transportWriter.SendTransactionSubmitted(ctx, t.originatorNode, &engineProto.TransactionSubmitted{
+		Id:              uuid.New().String(),
+		TransactionId:   t.pt.ID.String(),
+		ContractAddress: t.pt.Address.HexString(),
+		Hash:            e.SubmissionHash.Bytes(),
+	})
 }

--- a/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatched_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
@@ -61,7 +62,9 @@ func Test_action_NotifyNonceAllocated_SetsNonceAndSends(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendNonceAssigned(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, nonce).
+		SendNonceAssigned(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.NonceAssigned) bool {
+			return msg.TransactionId == txn.pt.ID.String() && msg.Nonce == int64(nonce)
+		})).
 		Return(nil)
 
 	err := action_NotifyNonceAllocated(ctx, txn, event)
@@ -86,7 +89,9 @@ func Test_action_NotifyNonceAllocated_PropagatesSendError(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendNonceAssigned(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, uint64(1)).
+		SendNonceAssigned(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.NonceAssigned) bool {
+			return msg.TransactionId == txn.pt.ID.String() && msg.Nonce == int64(1)
+		})).
 		Return(assert.AnError)
 
 	err := action_NotifyNonceAllocated(ctx, txn, event)
@@ -112,7 +117,9 @@ func Test_action_NotifySubmitted_SetsSubmissionHashAndSends(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendTransactionSubmitted(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, &submissionHash).
+		SendTransactionSubmitted(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionSubmitted) bool {
+			return msg.TransactionId == txn.pt.ID.String()
+		})).
 		Return(nil)
 
 	err := action_NotifySubmitted(ctx, txn, event)
@@ -138,7 +145,9 @@ func Test_action_NotifySubmitted_PropagatesSendError(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendTransactionSubmitted(ctx, txn.pt.ID, txn.originatorNode, &txn.pt.Address, &submissionHash).
+		SendTransactionSubmitted(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionSubmitted) bool {
+			return msg.TransactionId == txn.pt.ID.String()
+		})).
 		Return(assert.AnError)
 
 	err := action_NotifySubmitted(ctx, txn, event)
@@ -202,9 +211,10 @@ func Test_action_NotifyDispatched_UsesTransactionSpec(t *testing.T) {
 		UseMockTransportWriter().
 		Build()
 
-	spec := txn.pt.PreAssembly.TransactionSpecification
 	mocks.TransportWriter.EXPECT().
-		SendDispatched(ctx, txn.originator, mock.Anything, spec).
+		SendDispatched(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionDispatched) bool {
+			return msg.TransactionId == txn.pt.ID.String() && msg.Signer == txn.originator
+		})).
 		Return(nil)
 
 	err := action_NotifyDispatched(ctx, txn, nil)
@@ -219,7 +229,9 @@ func Test_action_NotifyDispatched_AllowsNilTransactionSpec(t *testing.T) {
 	txn.pt.PreAssembly = nil
 
 	mocks.TransportWriter.EXPECT().
-		SendDispatched(ctx, txn.originator, mock.Anything, (*prototk.TransactionSpecification)(nil)).
+		SendDispatched(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionDispatched) bool {
+			return msg.TransactionId == txn.pt.ID.String()
+		})).
 		Return(nil)
 
 	err := action_NotifyDispatched(ctx, txn, nil)
@@ -233,7 +245,9 @@ func Test_action_NotifyDispatched_PropagatesSendError(t *testing.T) {
 		Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendDispatched(ctx, txn.originator, mock.Anything, txn.pt.PreAssembly.TransactionSpecification).
+		SendDispatched(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionDispatched) bool {
+			return msg.TransactionId == txn.pt.ID.String()
+		})).
 		Return(assert.AnError)
 
 	err := action_NotifyDispatched(ctx, txn, nil)

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 )
 
+
 type endorsementRequirement struct {
 	attRequest *prototk.AttestationRequest
 	party      string
@@ -206,23 +207,27 @@ func (t *coordinatorTransaction) resetEndorsementRequests(ctx context.Context) {
 }
 
 func (t *coordinatorTransaction) requestEndorsement(ctx context.Context, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest) error {
-	err := t.transportWriter.SendEndorsementRequest(
-		ctx,
-		t.pt.ID,
-		idempotencyKey,
-		party,
-		attRequest,
-		t.pt.PreAssembly.TransactionSpecification,
-		t.pt.PostAssembly.ResolvedVerifiers,
-		t.pt.PostAssembly.Signatures,
-		toEndorsableList(t.pt.PostAssembly.InputStates),
-		toEndorsableList(t.pt.PostAssembly.ReadStates),
-		toEndorsableList(t.pt.PostAssembly.OutputStates),
-		toEndorsableList(t.pt.PostAssembly.InfoStates),
-		t.clock.Now().Add(t.stateTimeout),
-		t.getBlockHeight(),
-		int64(t.blockHeightTolerance),
-	)
+	partyNode, err := pldtypes.PrivateIdentityLocator(party).Node(ctx, false)
+	if err != nil {
+		return err
+	}
+	err = t.transportWriter.SendEndorsementRequest(ctx, partyNode, &engineProto.EndorsementRequest{
+		IdempotencyKey:           idempotencyKey.String(),
+		ContractAddress:          t.pt.Address.HexString(),
+		TransactionId:            t.pt.ID.String(),
+		AttestationRequest:       attRequest,
+		Party:                    party,
+		TransactionSpecification: t.pt.PreAssembly.TransactionSpecification,
+		Verifiers:                t.pt.PostAssembly.ResolvedVerifiers,
+		Signatures:               t.pt.PostAssembly.Signatures,
+		InputStates:              toEndorsableList(t.pt.PostAssembly.InputStates),
+		ReadStates:               toEndorsableList(t.pt.PostAssembly.ReadStates),
+		OutputStates:             toEndorsableList(t.pt.PostAssembly.OutputStates),
+		InfoStates:               toEndorsableList(t.pt.PostAssembly.InfoStates),
+		ExpiryTimeUnixMs:         t.clock.Now().Add(t.stateTimeout).UnixMilli(),
+		CoordinatorBlockHeight:   t.getBlockHeight(),
+		BlockHeightTolerance:     int64(t.blockHeightTolerance),
+	})
 	if err != nil {
 		log.L(ctx).Errorf("failed to send endorsement request to party %s: %s", party, err)
 	}

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing_test.go
@@ -44,8 +44,13 @@ func Test_action_NudgeEndorsementRequests_CallsSendEndorsementRequests(t *testin
 func Test_action_NudgeEndorsementRequests_WithUnfulfilledRequirements_InitializesPendingRequests(t *testing.T) {
 	ctx := t.Context()
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		PreAssembly(&components.TransactionPreAssembly{
+			TransactionSpecification: &prototk.TransactionSpecification{
+				ContractInfo: &prototk.ContractInfo{},
+			},
+		}).
 		PostAssembly(&components.TransactionPostAssembly{
-			AttestationPlan:   []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1"}}},
+			AttestationPlan:   []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1@node1"}}},
 			Endorsements:      []*prototk.AttestationResult{},
 			ResolvedVerifiers: []*prototk.ResolvedVerifier{{Lookup: "v1"}},
 		}).
@@ -55,9 +60,9 @@ func Test_action_NudgeEndorsementRequests_WithUnfulfilledRequirements_Initialize
 
 	mocks.TransportWriter.EXPECT().
 		SendEndorsementRequest(
-			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
-			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, "node1", mock.MatchedBy(func(msg *engineProto.EndorsementRequest) bool {
+				return msg.TransactionId == txn.pt.ID.String() && msg.Party == "party1@node1"
+			}),
 		).Return(nil)
 
 	err := action_NudgeEndorsementRequests(ctx, txn, nil)
@@ -70,8 +75,13 @@ func Test_sendEndorsementRequests_SendEndorsementRequestReturnsError_LogsAndCont
 	ctx := t.Context()
 	sendErr := errors.New("transport send failed")
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		PreAssembly(&components.TransactionPreAssembly{
+			TransactionSpecification: &prototk.TransactionSpecification{
+				ContractInfo: &prototk.ContractInfo{},
+			},
+		}).
 		PostAssembly(&components.TransactionPostAssembly{
-			AttestationPlan:   []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1"}}},
+			AttestationPlan:   []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1@node1"}}},
 			Endorsements:      []*prototk.AttestationResult{},
 			ResolvedVerifiers: []*prototk.ResolvedVerifier{{Lookup: "v1"}},
 		}).
@@ -81,9 +91,9 @@ func Test_sendEndorsementRequests_SendEndorsementRequestReturnsError_LogsAndCont
 
 	mocks.TransportWriter.EXPECT().
 		SendEndorsementRequest(
-			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
-			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, "node1", mock.MatchedBy(func(msg *engineProto.EndorsementRequest) bool {
+				return msg.TransactionId == txn.pt.ID.String() && msg.Party == "party1@node1"
+			}),
 		).Return(sendErr)
 
 	err := txn.sendEndorsementRequests(ctx)
@@ -97,6 +107,7 @@ func Test_sendEndorsementRequests_WhenPendingNil_SchedulesTimerAndQueueEventOnFi
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
 		UseMockClock().
 		UseMockTransportWriter().
+		NumberOfRequiredEndorsers(0).
 		QueueEventForCoordinator(func(ctx context.Context, event common.Event) {
 			if _, ok := event.(*RequestTimeoutIntervalEvent); ok {
 				timeoutEventReceived = true
@@ -110,7 +121,7 @@ func Test_sendEndorsementRequests_WhenPendingNil_SchedulesTimerAndQueueEventOnFi
 		callback := args.Get(2).(func())
 		callback()
 	})
-	mocks.TransportWriter.EXPECT().SendEndorsementRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mocks.TransportWriter.EXPECT().SendEndorsementRequest(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := txn.sendEndorsementRequests(ctx)
 	require.NoError(t, err)
@@ -121,8 +132,13 @@ func Test_sendEndorsementRequests_WhenPendingNil_SchedulesTimerAndQueueEventOnFi
 func Test_sendEndorsementRequests_TwoAttestationNames_CreatesMapPerName(t *testing.T) {
 	ctx := t.Context()
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
+		PreAssembly(&components.TransactionPreAssembly{
+			TransactionSpecification: &prototk.TransactionSpecification{
+				ContractInfo: &prototk.ContractInfo{},
+			},
+		}).
 		PostAssembly(&components.TransactionPostAssembly{
-			AttestationPlan: []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1"}}, {Name: "att2", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party2"}}},
+			AttestationPlan: []*prototk.AttestationRequest{{Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1@node1"}}, {Name: "att2", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party2@node2"}}},
 			Endorsements:    []*prototk.AttestationResult{},
 		}).
 		UseMockTransportWriter().
@@ -131,15 +147,15 @@ func Test_sendEndorsementRequests_TwoAttestationNames_CreatesMapPerName(t *testi
 
 	mocks.TransportWriter.EXPECT().
 		SendEndorsementRequest(
-			ctx, txn.pt.ID, mock.Anything, "party1", mock.Anything,
-			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, "node1", mock.MatchedBy(func(msg *engineProto.EndorsementRequest) bool {
+				return msg.TransactionId == txn.pt.ID.String() && msg.Party == "party1@node1"
+			}),
 		).Return(nil)
 	mocks.TransportWriter.EXPECT().
 		SendEndorsementRequest(
-			ctx, txn.pt.ID, mock.Anything, "party2", mock.Anything,
-			(*prototk.TransactionSpecification)(nil), mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything, "node2", mock.MatchedBy(func(msg *engineProto.EndorsementRequest) bool {
+				return msg.TransactionId == txn.pt.ID.String() && msg.Party == "party2@node2"
+			}),
 		).Return(nil)
 
 	err := txn.sendEndorsementRequests(ctx)
@@ -156,7 +172,7 @@ func Test_sendEndorsementRequests_PermanentlyFailedParty_IsSkipped(t *testing.T)
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
 		PostAssembly(&components.TransactionPostAssembly{
 			AttestationPlan: []*prototk.AttestationRequest{{
-				Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1"},
+				Name: "att1", AttestationType: prototk.AttestationType_ENDORSE, Parties: []string{"party1@node1"},
 			}},
 			Endorsements: []*prototk.AttestationResult{},
 		}).
@@ -167,7 +183,7 @@ func Test_sendEndorsementRequests_PermanentlyFailedParty_IsSkipped(t *testing.T)
 	// Pre-populate pendingEndorsementRequests so the nil check in the loop is reachable.
 	// The outer map key exists, and the party entry is nil — the permanently-failed sentinel.
 	txn.pendingEndorsementRequests = map[string]map[string]*common.IdempotentRequest{
-		"att1": {"party1": nil},
+		"att1": {"party1@node1": nil},
 	}
 
 	// No SendEndorsementRequest expectation registered: any call to it would fail the test.
@@ -176,7 +192,7 @@ func Test_sendEndorsementRequests_PermanentlyFailedParty_IsSkipped(t *testing.T)
 	err := txn.sendEndorsementRequests(ctx)
 	require.NoError(t, err)
 	// The nil sentinel must be preserved — it was not overwritten.
-	assert.Nil(t, txn.pendingEndorsementRequests["att1"]["party1"])
+	assert.Nil(t, txn.pendingEndorsementRequests["att1"]["party1@node1"])
 }
 
 func Test_action_RecordEndorseFailure_UnknownEventType_WarnsAndReturnsNil(t *testing.T) {
@@ -345,6 +361,30 @@ func Test_extractEndorserNodes_NilPostAssembly_ReturnsEmpty(t *testing.T) {
 	txn.pt.PostAssembly = nil
 	nodes := txn.extractEndorserNodes(ctx)
 	assert.Empty(t, nodes)
+}
+
+func Test_extractEndorserNodes_InvalidPartyLocator_SkipsInvalidEntry(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).Build()
+	txn.pt.PostAssembly = &components.TransactionPostAssembly{
+		AttestationPlan: []*prototk.AttestationRequest{{
+			AttestationType: prototk.AttestationType_ENDORSE,
+			// "a@b@c" has too many @ signs and is an invalid locator; "valid@node1" is valid.
+			Parties: []string{"a@b@c", "valid@node1"},
+		}},
+	}
+	nodes := txn.extractEndorserNodes(ctx)
+	// The invalid locator is skipped; only the valid one is returned.
+	assert.Equal(t, []string{"node1"}, nodes)
+}
+
+func Test_requestEndorsement_InvalidPartyLocator_ReturnsError(t *testing.T) {
+	ctx := t.Context()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).Build()
+
+	// "a@b@c" has too many @ signs and fails locator parsing.
+	err := txn.requestEndorsement(ctx, uuid.New(), "a@b@c", &prototk.AttestationRequest{})
+	require.Error(t, err)
 }
 
 

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -194,10 +194,13 @@ func action_NotifyOriginatorOfChainedDependencyFailureAtCreation(ctx context.Con
 		state, ok := t.getCoordinatorTransactionState(ctx, depID)
 		if ok && state == State_Reverted {
 			failureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
-			return t.transportWriter.SendTransactionConfirmed(
-				ctx, t.pt.ID, t.originatorNode, &t.pt.Address, nil,
-				engine.TransactionConfirmed_OUTCOME_REVERTED, nil, failureMessage, false,
-			)
+			return t.transportWriter.SendTransactionConfirmed(ctx, t.originatorNode, &engine.TransactionConfirmed{
+				Id:              uuid.New().String(),
+				TransactionId:   t.pt.ID.String(),
+				ContractAddress: t.pt.Address.HexString(),
+				Outcome:         engine.TransactionConfirmed_OUTCOME_REVERTED,
+				FailureMessage:  failureMessage,
+			})
 		}
 	}
 	return nil

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
@@ -113,13 +113,13 @@ func Test_ChainedDependencyFailed_AllStates_TransitionToReverted(t *testing.T) {
 
 			expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
 			mocks.TransportWriter.EXPECT().
-				SendTransactionConfirmed(mock.Anything, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
-					(*pldtypes.HexUint64)(nil),
-					engineProto.TransactionConfirmed_OUTCOME_REVERTED,
-					pldtypes.HexBytes(nil),
-					expectedFailureMessage,
-					false,
-				).Return(nil)
+				SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+					return msg.TransactionId == txn.pt.ID.String() &&
+						msg.ContractAddress == txn.pt.Address.HexString() &&
+						msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+						msg.FailureMessage == expectedFailureMessage &&
+						!msg.WillRetry
+				})).Return(nil)
 
 			err := txn.HandleEvent(ctx, &ChainedDependencyFailedEvent{
 				BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.pt.ID},
@@ -303,13 +303,13 @@ func TestCoordinatorTransaction_Initial_ToReverted_OnDelegated_IfHasRevertedChai
 
 	expectedFailureMessage := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error()
 	mocks.TransportWriter.EXPECT().
-		SendTransactionConfirmed(mock.Anything, txn.pt.ID, txn.originatorNode, &txn.pt.Address,
-			(*pldtypes.HexUint64)(nil),
-			engineProto.TransactionConfirmed_OUTCOME_REVERTED,
-			pldtypes.HexBytes(nil),
-			expectedFailureMessage,
-			false,
-		).Return(nil)
+		SendTransactionConfirmed(mock.Anything, txn.originatorNode, mock.MatchedBy(func(msg *engineProto.TransactionConfirmed) bool {
+			return msg.TransactionId == txn.pt.ID.String() &&
+				msg.ContractAddress == txn.pt.Address.HexString() &&
+				msg.Outcome == engineProto.TransactionConfirmed_OUTCOME_REVERTED &&
+				msg.FailureMessage == expectedFailureMessage &&
+				!msg.WillRetry
+		})).Return(nil)
 
 	err := txn.HandleEvent(ctx, &DelegatedEvent{
 		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.GetID()},

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -17,6 +17,7 @@ package originator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"slices"
@@ -30,6 +31,9 @@ import (
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
 )
+
+// jsonMarshalFn is a package-level variable so tests can inject errors.
+var jsonMarshalFn = json.Marshal
 
 func validator_IsDelegationBlockHeightRejection(_ context.Context, _ *originator, event common.Event) (bool, error) {
 	return event.(*DelegationRequestRejectedEvent).RejectionReason == engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, nil
@@ -118,7 +122,19 @@ func sendDelegationRequest(ctx context.Context, o *originator) error {
 
 	log.L(ctx).Debugf("sending delegation request for %d transactions", len(o.transactionsOrdered))
 
-	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, transactionsToDelegate, uint64(o.currentBlockHeight))
+	allTxBytes := make([][]byte, 0, len(transactionsToDelegate))
+	for _, tx := range transactionsToDelegate {
+		txBytes, err := jsonMarshalFn(tx)
+		if err != nil {
+			return fmt.Errorf("error marshalling transaction for delegation request: %w", err)
+		}
+		allTxBytes = append(allTxBytes, txBytes)
+	}
+	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, &engineProto.DelegationRequest{
+		DelegateNodeId:        o.currentActiveCoordinator,
+		OriginatorBlockHeight: int64(o.currentBlockHeight),
+		PrivateTransactions:   allTxBytes,
+	})
 }
 
 func action_SendDelegationRequest(ctx context.Context, o *originator, _ common.Event) error {

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -398,12 +398,35 @@ func Test_sendDelegationRequest_TransportError_ReturnsError(t *testing.T) {
 	o, mocks := builder.Transactions(mockTxn).CurrentActiveCoordinator("coordinator@node1").Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("transport error"))
 
 	err := sendDelegationRequest(ctx, o)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transport error")
+}
+
+func Test_sendDelegationRequest_JSONMarshalError_ReturnsError(t *testing.T) {
+	ctx := t.Context()
+	txn := testutil.NewPrivateTransactionBuilderForTesting().Build()
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txn.ID)
+	mockTxn.On("GetPrivateTransaction").Return(txn)
+	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(mockTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, fmt.Errorf("json marshal error")
+	}
+
+	err := sendDelegationRequest(ctx, o)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json marshal error")
 }
 
 func Test_action_UpdateEndorserCandidates_DoesNotChangeCurrentActiveCoordinator(t *testing.T) {
@@ -613,7 +636,7 @@ func Test_action_FailoverToNextCoordinator_WithPriorityList_AdvancesCoordinatorA
 		Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "B", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "B", mock.Anything).
 		Return(nil).Once()
 
 	err := action_FailoverToNextCoordinator(ctx, o, nil)
@@ -641,7 +664,7 @@ func Test_action_FailoverToNextCoordinator_WrapAround_CyclesBackToStart(t *testi
 		Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "C", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "C", mock.Anything).
 		Return(nil).Once()
 
 	err := action_FailoverToNextCoordinator(ctx, o, nil)
@@ -668,7 +691,7 @@ func Test_action_FailoverToNextCoordinator_EmptyPriorityList_DelegatesWithoutRes
 		Build()
 
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "static-coordinator", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "static-coordinator", mock.Anything).
 		Return(nil).Once()
 
 	err := action_FailoverToNextCoordinator(ctx, o, nil)

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -173,11 +173,19 @@ func (o *originator) propagateEventToTransaction(ctx context.Context, event tran
 
 	switch e := event.(type) {
 	case *transaction.AssembleRequestReceivedEvent:
-		return o.transportWriter.SendAssembleRejection(ctx, e.GetTransactionID(), e.RequestID, e.Coordinator,
-			engineProto.RejectionReason_TRANSACTION_UNKNOWN, 0, 0)
+		return o.transportWriter.SendAssembleRejection(ctx, e.Coordinator, &engineProto.AssembleRejection{
+			TransactionId:     e.GetTransactionID().String(),
+			AssembleRequestId: e.RequestID.String(),
+			ContractAddress:   o.contractAddress.HexString(),
+			RejectionReason:   engineProto.RejectionReason_TRANSACTION_UNKNOWN,
+		})
 	case *transaction.PreDispatchRequestReceivedEvent:
-		return o.transportWriter.SendPreDispatchRejection(ctx, e.GetTransactionID(), e.RequestID, e.Coordinator,
-			engineProto.RejectionReason_TRANSACTION_UNKNOWN)
+		return o.transportWriter.SendPreDispatchRejection(ctx, e.Coordinator, &engineProto.PreDispatchRejection{
+			TransactionId:   e.GetTransactionID().String(),
+			RequestId:       e.RequestID.String(),
+			ContractAddress: o.contractAddress.HexString(),
+			RejectionReason: engineProto.RejectionReason_TRANSACTION_UNKNOWN,
+		})
 	default:
 		// Other events can be safely ignored
 		return nil

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -99,7 +99,7 @@ func TestStateMachine_Idle_TransactionCreated_EpochBoundary_EndorserMode_ResetsT
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(10))
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "A", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "A", mock.Anything).
 		Return(nil).Once()
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator("sender@node1").Build()
@@ -209,7 +209,7 @@ func TestStateMachine_Idle_TransactionCreated_TransitionsToSending_SendsDelegati
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Times(2)
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything).
 		Return(nil).Once()
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator("sender@node1").Build()
@@ -319,7 +319,7 @@ func TestStateMachine_Observing_TransactionCreated_TransitionsToSending_SendsDel
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything).
 		Return(nil).Once()
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator("sender@node1").Build()
@@ -544,7 +544,7 @@ func TestStateMachine_Sending_TransactionCreated_CreatesTxnAndDelegates(t *testi
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything).
 		Return(nil).Once()
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator("sender@node1").Build()
@@ -590,7 +590,7 @@ func TestStateMachine_Sending_HeartbeatReceived_DroppedTransaction_Redelegates(t
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything).
 		Return(nil).Once()
 
 	// Heartbeat with empty snapshot — txID is absent ⇒ dropped.
@@ -654,7 +654,7 @@ func TestStateMachine_Sending_HeartbeatReceived_HigherPriorityActiveNode_Redirec
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "node1", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{
@@ -704,7 +704,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_NoEndorserMode_Red
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "coordinator@node1", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
@@ -735,7 +735,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_Failo
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "B", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "B", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
@@ -767,7 +767,7 @@ func TestStateMachine_Sending_HeartbeatInterval_GraceExceeded_EndorserMode_WrapA
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "C", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "C", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatIntervalEvent{}))
@@ -797,7 +797,7 @@ func TestStateMachine_Sending_DelegationRejected_HigherPriority_RedirectsAndRede
 
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "node1", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "node1", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &DelegationRequestRejectedEvent{
@@ -983,7 +983,7 @@ func TestStateMachine_Sending_HeartbeatReceived_Step3_GraceExceeded_SwitchesCoor
 	// Step 5 fires because empty snapshot means txID is dropped → redelegate.
 	mocks.EngineIntegration.EXPECT().GetBlockHeight(mock.Anything).Return(int64(0)).Once()
 	mocks.TransportWriter.EXPECT().
-		SendDelegationRequest(mock.Anything, "node3", mock.Anything, mock.Anything).
+		SendDelegationRequest(mock.Anything, "node3", mock.Anything).
 		Return(nil).Once()
 
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &common.HeartbeatReceivedEvent{

--- a/core/go/internal/sequencer/originator/transaction/assembling.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling.go
@@ -16,6 +16,7 @@ package transaction
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -26,6 +27,9 @@ import (
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 )
+
+// jsonMarshalFn is a package-level variable so tests can inject errors.
+var jsonMarshalFn = json.Marshal
 
 func action_AssembleRequestReceived(ctx context.Context, t *originatorTransaction, event common.Event) error {
 	e := event.(*AssembleRequestReceivedEvent)
@@ -169,20 +173,54 @@ func (txn *originatorTransaction) handleAssembleAndSign(ctx context.Context, txI
 	}
 }
 
+func buildAssembleResponse(_ context.Context, txn *originatorTransaction) (*engineProto.AssembleResponse, error) {
+	postAssemblyBytes, err := jsonMarshalFn(txn.pt.PostAssembly)
+	if err != nil {
+		return nil, err
+	}
+	preAssemblyBytes, err := jsonMarshalFn(txn.pt.PreAssembly)
+	if err != nil {
+		return nil, err
+	}
+	return &engineProto.AssembleResponse{
+		TransactionId:     txn.pt.ID.String(),
+		AssembleRequestId: txn.latestFulfilledAssembleRequestID.String(),
+		ContractAddress:   txn.pt.Address.HexString(),
+		PostAssembly:      postAssemblyBytes,
+		PreAssembly:       preAssemblyBytes,
+	}, nil
+}
+
 func action_SendAssembleRevertResponse(ctx context.Context, txn *originatorTransaction, _ common.Event) error {
-	return txn.transportWriter.SendAssembleResponse(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.pt.PostAssembly, txn.pt.PreAssembly, txn.currentDelegate)
+	msg, err := buildAssembleResponse(ctx, txn)
+	if err != nil {
+		return err
+	}
+	return txn.transportWriter.SendAssembleResponse(ctx, txn.currentDelegate, msg)
 }
 
 func action_SendAssembleParkResponse(ctx context.Context, txn *originatorTransaction, _ common.Event) error {
-	return txn.transportWriter.SendAssembleResponse(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.pt.PostAssembly, txn.pt.PreAssembly, txn.currentDelegate)
+	msg, err := buildAssembleResponse(ctx, txn)
+	if err != nil {
+		return err
+	}
+	return txn.transportWriter.SendAssembleResponse(ctx, txn.currentDelegate, msg)
 }
 
 func action_SendAssembleSuccessResponse(ctx context.Context, txn *originatorTransaction, _ common.Event) error {
-	return txn.transportWriter.SendAssembleResponse(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.pt.PostAssembly, txn.pt.PreAssembly, txn.currentDelegate)
+	msg, err := buildAssembleResponse(ctx, txn)
+	if err != nil {
+		return err
+	}
+	return txn.transportWriter.SendAssembleResponse(ctx, txn.currentDelegate, msg)
 }
 
 func action_SendAssembleError(ctx context.Context, txn *originatorTransaction, _ common.Event) error {
-	return txn.transportWriter.SendAssembleError(ctx, txn.pt.ID, txn.latestFulfilledAssembleRequestID, txn.currentDelegate)
+	return txn.transportWriter.SendAssembleError(ctx, txn.currentDelegate, &engineProto.AssembleError{
+		TransactionId:     txn.pt.ID.String(),
+		AssembleRequestId: txn.latestFulfilledAssembleRequestID.String(),
+		ContractAddress:   txn.pt.Address.HexString(),
+	})
 }
 
 func action_RefreshBlockHeight(ctx context.Context, t *originatorTransaction, _ common.Event) error {
@@ -206,15 +244,14 @@ func action_RejectAssemblyPrivateStateDataPending(ctx context.Context, t *origin
 	receiverBlockHeight := t.getBlockHeight()
 	log.L(ctx).Warnf("rejecting assemble request from coordinator due to pending private state data (coordinator=%d, assembler=%d, tolerance=%d)",
 		e.CoordinatorBlockHeight, receiverBlockHeight, e.BlockHeightTolerance)
-	return t.transportWriter.SendAssembleRejection(
-		ctx,
-		t.pt.ID,
-		e.RequestID,
-		e.Coordinator,
-		engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
-		e.CoordinatorBlockHeight,
-		receiverBlockHeight,
-	)
+	return t.transportWriter.SendAssembleRejection(ctx, e.Coordinator, &engineProto.AssembleRejection{
+		TransactionId:          t.pt.ID.String(),
+		AssembleRequestId:      e.RequestID.String(),
+		ContractAddress:        t.pt.Address.HexString(),
+		RejectionReason:        engineProto.RejectionReason_PRIVATE_STATE_DATA_PENDING,
+		CoordinatorBlockHeight: e.CoordinatorBlockHeight,
+		AssemblerBlockHeight:   receiverBlockHeight,
+	})
 }
 
 // validator_AssembleBlockHeightToleranceExceeded returns true when the absolute difference between
@@ -235,15 +272,14 @@ func action_SendAssembleBlockHeightRejection(ctx context.Context, t *originatorT
 	receiverBlockHeight := t.getBlockHeight()
 	log.L(ctx).Warnf("rejecting assemble request from coordinator due to block height tolerance (coordinator=%d, assembler=%d, tolerance=%d)",
 		e.CoordinatorBlockHeight, receiverBlockHeight, e.BlockHeightTolerance)
-	return t.transportWriter.SendAssembleRejection(
-		ctx,
-		t.pt.ID,
-		e.RequestID,
-		e.Coordinator,
-		engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
-		e.CoordinatorBlockHeight,
-		receiverBlockHeight,
-	)
+	return t.transportWriter.SendAssembleRejection(ctx, e.Coordinator, &engineProto.AssembleRejection{
+		TransactionId:          t.pt.ID.String(),
+		AssembleRequestId:      e.RequestID.String(),
+		ContractAddress:        t.pt.Address.HexString(),
+		RejectionReason:        engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE,
+		CoordinatorBlockHeight: e.CoordinatorBlockHeight,
+		AssemblerBlockHeight:   receiverBlockHeight,
+	})
 }
 
 func validator_AssembleAndSignSuccessMatchesCurrentRequest(_ context.Context, t *originatorTransaction, event common.Event) (bool, error) {
@@ -267,14 +303,12 @@ func guard_AssembleRequestMatchesInProgressAssembly(_ context.Context, txn *orig
 func action_SendAssembleRejectionNotCurrentDelegate(ctx context.Context, txn *originatorTransaction, event common.Event) error {
 	assembleRequestEvent := event.(*AssembleRequestReceivedEvent)
 	log.L(ctx).Debugf("rejecting assemble request from %s: not current delegate (current=%s)", assembleRequestEvent.Coordinator, txn.currentDelegate)
-	if err := txn.transportWriter.SendAssembleRejection(
-		ctx,
-		txn.pt.ID,
-		assembleRequestEvent.RequestID,
-		assembleRequestEvent.Coordinator,
-		engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
-		0, 0,
-	); err != nil {
+	if err := txn.transportWriter.SendAssembleRejection(ctx, assembleRequestEvent.Coordinator, &engineProto.AssembleRejection{
+		TransactionId:     txn.pt.ID.String(),
+		AssembleRequestId: assembleRequestEvent.RequestID.String(),
+		ContractAddress:   txn.pt.Address.HexString(),
+		RejectionReason:   engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
+	}); err != nil {
 		log.L(ctx).Warnf("failed to send assemble rejection (not-current-delegate) to %s: %s", assembleRequestEvent.Coordinator, err)
 	}
 	return nil

--- a/core/go/internal/sequencer/originator/transaction/assembling_test.go
+++ b/core/go/internal/sequencer/originator/transaction/assembling_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -401,14 +402,83 @@ func Test_action_SendAssembleError_TransportError(t *testing.T) {
 	expectedError := errors.New("transport error")
 	mocks.TransportWriter.EXPECT().SendAssembleError(
 		mock.Anything,
-		txn.GetID(),
-		requestID,
 		coordinator,
+		mock.MatchedBy(func(msg *engineProto.AssembleError) bool {
+			return msg.TransactionId == txn.GetID().String() && msg.AssembleRequestId == requestID.String()
+		}),
 	).Return(expectedError)
 
 	err := action_SendAssembleError(ctx, txn, nil)
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
+}
+
+func Test_action_SendAssembleRevertResponse_JSONMarshalError(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).BuildWithMocks()
+	txn.currentDelegate = "coordinator@node1"
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, errors.New("marshal error")
+	}
+
+	err := action_SendAssembleRevertResponse(ctx, txn, nil)
+	require.Error(t, err)
+	assert.Equal(t, "marshal error", err.Error())
+}
+
+func Test_action_SendAssembleParkResponse_JSONMarshalError(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).BuildWithMocks()
+	txn.currentDelegate = "coordinator@node1"
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, errors.New("marshal error")
+	}
+
+	err := action_SendAssembleParkResponse(ctx, txn, nil)
+	require.Error(t, err)
+	assert.Equal(t, "marshal error", err.Error())
+}
+
+func Test_action_SendAssembleSuccessResponse_JSONMarshalError(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).BuildWithMocks()
+	txn.currentDelegate = "coordinator@node1"
+
+	originalFn := jsonMarshalFn
+	defer func() { jsonMarshalFn = originalFn }()
+	jsonMarshalFn = func(_ any) ([]byte, error) {
+		return nil, errors.New("marshal error")
+	}
+
+	err := action_SendAssembleSuccessResponse(ctx, txn, nil)
+	require.Error(t, err)
+	assert.Equal(t, "marshal error", err.Error())
+}
+
+func Test_buildAssembleResponse_PreAssemblyMarshalError(t *testing.T) {
+	ctx := context.Background()
+	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).BuildWithMocks()
+
+	callCount := 0
+	originalFn := jsonMarshalFn
+	jsonMarshalFn = func(v any) ([]byte, error) {
+		callCount++
+		if callCount == 2 {
+			return nil, errors.New("pre-assembly marshal error")
+		}
+		return originalFn(v)
+	}
+	defer func() { jsonMarshalFn = originalFn }()
+
+	_, err := buildAssembleResponse(ctx, txn)
+	require.Error(t, err)
+	assert.Equal(t, "pre-assembly marshal error", err.Error())
 }
 
 func Test_handleAssembleAndSign_AbandonsSilently_WhenContextExpired(t *testing.T) {

--- a/core/go/internal/sequencer/originator/transaction/delegated.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated.go
@@ -62,9 +62,11 @@ func (t *originatorTransaction) updateLastDelegatedTime() {
 }
 
 func action_SendPreDispatchResponse(ctx context.Context, txn *originatorTransaction, _ common.Event) error {
-	// MRW TODO - sending a dispatch response should be based on some sanity check that we are OK for the coordinator
-	// to proceed to dispatch. Not sure if that belongs here, or somewhere else, but at the moment we always reply OK/proceed.
-	return txn.transportWriter.SendPreDispatchResponse(ctx, txn.currentDelegate, txn.latestPreDispatchRequestID, txn.pt.PreAssembly.TransactionSpecification)
+	return txn.transportWriter.SendPreDispatchResponse(ctx, txn.currentDelegate, &engineProto.PreDispatchResponse{
+		Id:              txn.latestPreDispatchRequestID.String(),
+		TransactionId:   txn.pt.ID.String(),
+		ContractAddress: txn.pt.Address.HexString(),
+	})
 }
 
 func validator_AssembleRequestFromCurrentDelegate(ctx context.Context, txn *originatorTransaction, event common.Event) (bool, error) {
@@ -108,7 +110,12 @@ func validator_PreDispatchRequestFromCurrentDelegate(ctx context.Context, txn *o
 func action_SendPreDispatchRejectionNotCurrentDelegate(ctx context.Context, txn *originatorTransaction, event common.Event) error {
 	e := event.(*PreDispatchRequestReceivedEvent)
 	log.L(ctx).Debugf("rejecting pre-dispatch request from %s: not current delegate (current=%s)", e.Coordinator, txn.currentDelegate)
-	if err := txn.transportWriter.SendPreDispatchRejection(ctx, txn.pt.ID, e.RequestID, e.Coordinator, engineProto.RejectionReason_NOT_CURRENT_DELEGATE); err != nil {
+	if err := txn.transportWriter.SendPreDispatchRejection(ctx, e.Coordinator, &engineProto.PreDispatchRejection{
+		TransactionId:   txn.pt.ID.String(),
+		RequestId:       e.RequestID.String(),
+		ContractAddress: txn.pt.Address.HexString(),
+		RejectionReason: engineProto.RejectionReason_NOT_CURRENT_DELEGATE,
+	}); err != nil {
 		log.L(ctx).Warnf("failed to send pre-dispatch rejection to %s: %s", e.Coordinator, err)
 	}
 	return nil

--- a/core/go/internal/sequencer/originator/transaction/delegated_test.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated_test.go
@@ -116,7 +116,6 @@ func TestAction_SendPreDispatchResponse_TransportError(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
-		mock.Anything,
 	).Return(expectedError)
 
 	// Execute the action
@@ -448,7 +447,11 @@ func TestAction_SendAssembleRejectionNotCurrentDelegate_Success(t *testing.T) {
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendAssembleRejection(mock.Anything, txn.pt.ID, reqID, "other@node2", engineProto.RejectionReason_NOT_CURRENT_DELEGATE, int64(0), int64(0)).
+		SendAssembleRejection(mock.Anything, "other@node2", mock.MatchedBy(func(msg *engineProto.AssembleRejection) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.AssembleRequestId == reqID.String() &&
+				msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		})).
 		Return(nil)
 
 	err := action_SendAssembleRejectionNotCurrentDelegate(ctx, txn, event)
@@ -469,7 +472,11 @@ func TestAction_SendAssembleRejectionNotCurrentDelegate_TransportError_LogsWarnA
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendAssembleRejection(mock.Anything, txn.pt.ID, reqID, "other@node2", engineProto.RejectionReason_NOT_CURRENT_DELEGATE, int64(0), int64(0)).
+		SendAssembleRejection(mock.Anything, "other@node2", mock.MatchedBy(func(msg *engineProto.AssembleRejection) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.AssembleRequestId == reqID.String() &&
+				msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		})).
 		Return(errors.New("transport error"))
 
 	err := action_SendAssembleRejectionNotCurrentDelegate(ctx, txn, event)
@@ -491,7 +498,11 @@ func TestAction_SendPreDispatchRejectionNotCurrentDelegate_Success(t *testing.T)
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendPreDispatchRejection(mock.Anything, txn.pt.ID, reqID, "other@node2", engineProto.RejectionReason_NOT_CURRENT_DELEGATE).
+		SendPreDispatchRejection(mock.Anything, "other@node2", mock.MatchedBy(func(msg *engineProto.PreDispatchRejection) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.RequestId == reqID.String() &&
+				msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		})).
 		Return(nil)
 
 	err := action_SendPreDispatchRejectionNotCurrentDelegate(ctx, txn, event)
@@ -513,7 +524,11 @@ func TestAction_SendPreDispatchRejectionNotCurrentDelegate_TransportError_LogsWa
 	}
 
 	mocks.TransportWriter.EXPECT().
-		SendPreDispatchRejection(mock.Anything, txn.pt.ID, reqID, "other@node2", engineProto.RejectionReason_NOT_CURRENT_DELEGATE).
+		SendPreDispatchRejection(mock.Anything, "other@node2", mock.MatchedBy(func(msg *engineProto.PreDispatchRejection) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.RequestId == reqID.String() &&
+				msg.RejectionReason == engineProto.RejectionReason_NOT_CURRENT_DELEGATE
+		})).
 		Return(errors.New("transport error"))
 
 	err := action_SendPreDispatchRejectionNotCurrentDelegate(ctx, txn, event)

--- a/core/go/internal/sequencer/originator/transaction/endorsing_test.go
+++ b/core/go/internal/sequencer/originator/transaction/endorsing_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -94,11 +95,11 @@ func TestAction_ResendAssembleSuccessResponse_TransportError(t *testing.T) {
 	expectedError := errors.New("transport error")
 	mocks.TransportWriter.EXPECT().SendAssembleResponse(
 		mock.Anything,
-		txn.GetID(),
-		requestID,
-		txn.pt.PostAssembly,
-		txn.pt.PreAssembly,
 		coordinator,
+		mock.MatchedBy(func(msg *engineProto.AssembleResponse) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.AssembleRequestId == requestID.String()
+		}),
 	).Return(expectedError)
 
 	// Execute the action
@@ -173,11 +174,11 @@ func TestAction_ResendAssembleRevertResponse_TransportError(t *testing.T) {
 	expectedError := errors.New("transport error")
 	mocks.TransportWriter.EXPECT().SendAssembleResponse(
 		mock.Anything,
-		txn.GetID(),
-		requestID,
-		txn.pt.PostAssembly,
-		txn.pt.PreAssembly,
 		coordinator,
+		mock.MatchedBy(func(msg *engineProto.AssembleResponse) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.AssembleRequestId == requestID.String()
+		}),
 	).Return(expectedError)
 
 	// Execute the action
@@ -250,11 +251,11 @@ func TestAction_ResendAssembleParkResponse_TransportError(t *testing.T) {
 	expectedError := errors.New("transport error")
 	mocks.TransportWriter.EXPECT().SendAssembleResponse(
 		mock.Anything,
-		txn.GetID(),
-		requestID,
-		txn.pt.PostAssembly,
-		txn.pt.PreAssembly,
 		coordinator,
+		mock.MatchedBy(func(msg *engineProto.AssembleResponse) bool {
+			return msg.TransactionId == txn.GetID().String() &&
+				msg.AssembleRequestId == requestID.String()
+		}),
 	).Return(expectedError)
 
 	// Execute the action

--- a/core/go/internal/sequencer/originator/transaction/prepared_test.go
+++ b/core/go/internal/sequencer/originator/transaction/prepared_test.go
@@ -91,7 +91,6 @@ func TestAction_ResendPreDispatchResponse_TransportError(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
-		mock.Anything,
 	).Return(expectedError)
 
 	// Execute the action

--- a/core/go/internal/sequencer/sequencer_lifecycle_test.go
+++ b/core/go/internal/sequencer/sequencer_lifecycle_test.go
@@ -234,7 +234,7 @@ func TestSequencerManager_LoadSequencer_NewSequencer(t *testing.T) {
 	mocks.stateManager.EXPECT().NewDomainContext(ctx, mockDomain, *contractAddr).Return(componentsmocks.NewDomainContext(t)).Once()
 
 	// Setup transport writer creation
-	mocks.transportWriter.EXPECT().SendDispatched(ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mocks.transportWriter.EXPECT().SendDispatched(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Setup originator creation expectations
 

--- a/core/go/internal/sequencer/testutil/sent_message_recorder.go
+++ b/core/go/internal/sequencer/testutil/sent_message_recorder.go
@@ -17,19 +17,15 @@ package testutil
 
 import (
 	"context"
-	"time"
+	"encoding/json"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
-	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
-	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/grapher"
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
-	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 )
 
 // SentMessageRecorder implements TransportWriter for use in tests.
-// TODO: add test coverage- or consider moving to its own package which we exclude from coverage
 // It records outgoing messages (both coordinator-side and originator-side) so tests can assert on what was sent.
 type SentMessageRecorder struct {
 	// Coordinator-side tracking
@@ -60,7 +56,7 @@ type SentMessageRecorder struct {
 	hasSentPreDispatchRejection    bool
 	preDispatchRejectionReason     engineProto.RejectionReason
 	hasSentDelegationRequest       bool
-	delegatedTransactions          []*components.PrivateTransaction
+	delegatedTransactionIDs        []uuid.UUID
 }
 
 func NewSentMessageRecorder() *SentMessageRecorder {
@@ -94,9 +90,8 @@ func (r *SentMessageRecorder) Reset(ctx context.Context) {
 	r.hasSentPreDispatchRejection = false
 	r.preDispatchRejectionReason = 0
 	r.hasSentDelegationRequest = false
-	r.delegatedTransactions = nil
+	r.delegatedTransactionIDs = nil
 	// per-tx maps are NOT reset — they accumulate across the full test
-
 }
 
 func (r *SentMessageRecorder) StartLoopbackWriter() {}
@@ -162,41 +157,20 @@ func (r *SentMessageRecorder) HasSentHeartbeat() bool {
 	return r.sentHeartbeatCount > 0
 }
 
-func (r *SentMessageRecorder) SendAssembleRequest(
-	ctx context.Context,
-	assemblingNode string,
-	transactionID uuid.UUID,
-	idempotencyKey uuid.UUID,
-	transactionPreassembly *components.TransactionPreAssembly,
-	stateLocks grapher.ExportableStates,
-	coordinatorBlockHeight int64,
-	expiryTime time.Time,
-	blockHeightTolerance int64,
-) error {
+func (r *SentMessageRecorder) SendAssembleRequest(ctx context.Context, node string, msg *engineProto.AssembleRequest) error {
 	r.hasSentAssembleRequest = true
+	idempotencyKey, _ := uuid.Parse(msg.AssembleRequestId)
+	txID, _ := uuid.Parse(msg.TransactionId)
 	r.sentAssembleRequestIdempotencyKey = idempotencyKey
 	r.numberOfSentAssembleRequests++
-	r.assembleKeyByTxID[transactionID] = idempotencyKey
+	r.assembleKeyByTxID[txID] = idempotencyKey
 	return nil
 }
 
-func (r *SentMessageRecorder) SendEndorsementRequest(
-	ctx context.Context,
-	txID uuid.UUID,
-	idempotencyKey uuid.UUID,
-	party string,
-	attRequest *prototk.AttestationRequest,
-	transactionSpecification *prototk.TransactionSpecification,
-	verifiers []*prototk.ResolvedVerifier,
-	signatures []*prototk.AttestationResult,
-	inputStates []*prototk.EndorsableState,
-	readStates []*prototk.EndorsableState,
-	outputStates []*prototk.EndorsableState,
-	infoStates []*prototk.EndorsableState,
-	expiryTime time.Time,
-	coordinatorBlockHeight int64,
-	blockHeightTolerance int64,
-) error {
+func (r *SentMessageRecorder) SendEndorsementRequest(ctx context.Context, node string, msg *engineProto.EndorsementRequest) error {
+	party := msg.Party
+	idempotencyKey, _ := uuid.Parse(msg.IdempotencyKey)
+	txID, _ := uuid.Parse(msg.TransactionId)
 	r.numberOfSentEndorsementRequests++
 	if _, ok := r.numberOfEndorsementRequestsForParty[party]; ok {
 		r.numberOfEndorsementRequestsForParty[party]++
@@ -211,37 +185,33 @@ func (r *SentMessageRecorder) SendEndorsementRequest(
 	return nil
 }
 
-func (r *SentMessageRecorder) SendPreDispatchRequest(
-	ctx context.Context,
-	transactionOriginator string,
-	idempotencyKey uuid.UUID,
-	transactionSpecification *prototk.TransactionSpecification,
-	hash *pldtypes.Bytes32,
-) error {
+func (r *SentMessageRecorder) SendPreDispatchRequest(ctx context.Context, node string, msg *engineProto.PreDispatchRequest) error {
 	r.hasSentDispatchConfirmationRequest = true
+	idempotencyKey, _ := uuid.Parse(msg.Id)
 	r.sentDispatchConfirmationRequestIdempotencyKey = idempotencyKey
 	r.numberOfSentDispatchConfirmationRequests++
-	if transactionSpecification != nil {
-		if txID, err := uuid.Parse(transactionSpecification.TransactionId); err == nil {
-			r.dispatchConfirmKeyByTxID[txID] = idempotencyKey
-		}
+	if txID, err := uuid.Parse(msg.TransactionId); err == nil {
+		r.dispatchConfirmKeyByTxID[txID] = idempotencyKey
 	}
 	return nil
 }
 
-func (r *SentMessageRecorder) SendHeartbeat(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress, coordinatorSnapshot *common.CoordinatorSnapshot) error {
+func (r *SentMessageRecorder) SendHeartbeat(ctx context.Context, node string, msg *engineProto.CoordinatorHeartbeatNotification) error {
 	r.sentHeartbeatCount++
 	return nil
 }
 
-func (r *SentMessageRecorder) SendAssembleResponse(ctx context.Context, txID uuid.UUID, requestID uuid.UUID, postAssembly *components.TransactionPostAssembly, preAssembly *components.TransactionPreAssembly, recipient string) error {
-	switch postAssembly.AssemblyResult {
-	case prototk.AssembleTransactionResponse_OK:
-		r.hasSentAssembleSuccessResponse = true
-	case prototk.AssembleTransactionResponse_REVERT:
-		r.hasSentAssembleRevertResponse = true
-	case prototk.AssembleTransactionResponse_PARK:
-		r.hasSentAssembleParkResponse = true
+func (r *SentMessageRecorder) SendAssembleResponse(ctx context.Context, node string, msg *engineProto.AssembleResponse) error {
+	var postAssembly components.TransactionPostAssembly
+	if err := json.Unmarshal(msg.PostAssembly, &postAssembly); err == nil {
+		switch postAssembly.AssemblyResult {
+		case prototk.AssembleTransactionResponse_OK:
+			r.hasSentAssembleSuccessResponse = true
+		case prototk.AssembleTransactionResponse_REVERT:
+			r.hasSentAssembleRevertResponse = true
+		case prototk.AssembleTransactionResponse_PARK:
+			r.hasSentAssembleParkResponse = true
+		}
 	}
 	return nil
 }
@@ -258,19 +228,19 @@ func (r *SentMessageRecorder) HasSentAssembleParkResponse() bool {
 	return r.hasSentAssembleParkResponse
 }
 
-func (r *SentMessageRecorder) SendAssembleError(ctx context.Context, txID uuid.UUID, requestID uuid.UUID, recipient string) error {
+func (r *SentMessageRecorder) SendAssembleError(ctx context.Context, node string, msg *engineProto.AssembleError) error {
 	r.hasSentAssembleError = true
 	return nil
 }
 
-func (r *SentMessageRecorder) SendAssembleRejection(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string, reason engineProto.RejectionReason, coordinatorBlockHeight, assemblerBlockHeight int64) error {
+func (r *SentMessageRecorder) SendAssembleRejection(ctx context.Context, node string, msg *engineProto.AssembleRejection) error {
 	r.hasSentAssembleRejection = true
 	return nil
 }
 
-func (r *SentMessageRecorder) SendPreDispatchRejection(ctx context.Context, txID uuid.UUID, requestID uuid.UUID, coordinatorNode string, reason engineProto.RejectionReason) error {
+func (r *SentMessageRecorder) SendPreDispatchRejection(ctx context.Context, node string, msg *engineProto.PreDispatchRejection) error {
 	r.hasSentPreDispatchRejection = true
-	r.preDispatchRejectionReason = reason
+	r.preDispatchRejectionReason = msg.RejectionReason
 	return nil
 }
 
@@ -290,7 +260,7 @@ func (r *SentMessageRecorder) HasSentAssembleError() bool {
 	return r.hasSentAssembleError
 }
 
-func (r *SentMessageRecorder) SendPreDispatchResponse(ctx context.Context, transactionOriginator string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error {
+func (r *SentMessageRecorder) SendPreDispatchResponse(ctx context.Context, node string, msg *engineProto.PreDispatchResponse) error {
 	r.hasSentConfirmationResponse = true
 	return nil
 }
@@ -299,21 +269,26 @@ func (r *SentMessageRecorder) HasSentPreDispatchResponse() bool {
 	return r.hasSentConfirmationResponse
 }
 
-func (r *SentMessageRecorder) SendNonceAssigned(ctx context.Context, txID uuid.UUID, transactionOriginator string, contractAddress *pldtypes.EthAddress, nonce uint64) error {
+func (r *SentMessageRecorder) SendNonceAssigned(ctx context.Context, node string, msg *engineProto.NonceAssigned) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendTransactionSubmitted(ctx context.Context, txID uuid.UUID, transactionOriginator string, contractAddress *pldtypes.EthAddress, txHash *pldtypes.Bytes32) error {
+func (r *SentMessageRecorder) SendTransactionSubmitted(ctx context.Context, node string, msg *engineProto.TransactionSubmitted) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendTransactionConfirmed(ctx context.Context, txID uuid.UUID, transactionOriginator string, contractAddress *pldtypes.EthAddress, nonce *pldtypes.HexUint64, outcome engineProto.TransactionConfirmed_Outcome, revertReason pldtypes.HexBytes, failureMessage string, willRetry bool) error {
+func (r *SentMessageRecorder) SendTransactionConfirmed(ctx context.Context, node string, msg *engineProto.TransactionConfirmed) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendDelegationRequest(ctx context.Context, coordinatorLocator string, transactions []*components.PrivateTransaction, blockHeight uint64) error {
+func (r *SentMessageRecorder) SendDelegationRequest(ctx context.Context, node string, msg *engineProto.DelegationRequest) error {
 	r.hasSentDelegationRequest = true
-	r.delegatedTransactions = transactions
+	for _, txBytes := range msg.PrivateTransactions {
+		var tx components.PrivateTransaction
+		if err := json.Unmarshal(txBytes, &tx); err == nil {
+			r.delegatedTransactionIDs = append(r.delegatedTransactionIDs, tx.ID)
+		}
+	}
 	return nil
 }
 
@@ -322,27 +297,23 @@ func (r *SentMessageRecorder) HasSentDelegationRequest() bool {
 }
 
 func (r *SentMessageRecorder) HasDelegatedTransaction(txid uuid.UUID) bool {
-	for _, tx := range r.delegatedTransactions {
-		if tx.ID == txid {
+	for _, id := range r.delegatedTransactionIDs {
+		if id == txid {
 			return true
 		}
 	}
 	return false
 }
 
-func (r *SentMessageRecorder) GetDelegatedTransactions() []*components.PrivateTransaction {
-	return r.delegatedTransactions
-}
-
-func (r *SentMessageRecorder) SendDelegationResponse(ctx context.Context, delegatingNodeName string, delegationId string, transactionIDs []string, errors []int64, blockHeight uint64) error {
+func (r *SentMessageRecorder) SendDelegationResponse(ctx context.Context, node string, msg *engineProto.DelegationResponse) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendDelegationRejection(ctx context.Context, delegatingNodeName string, delegationId string, rejectionReason engineProto.RejectionReason, activeCoordinator string, originatorBlockHeight, coordinatorBlockHeight, blockHeightTolerance int64) error {
+func (r *SentMessageRecorder) SendDelegationRejection(ctx context.Context, node string, msg *engineProto.DelegationRejection) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendHandoverRequest(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress) error {
+func (r *SentMessageRecorder) SendHandoverRequest(ctx context.Context, node string, msg *engineProto.CoordinatorHandoverRequest) error {
 	r.hasSentHandoverRequest = true
 	return nil
 }
@@ -351,18 +322,18 @@ func (r *SentMessageRecorder) HasSentHandoverRequest() bool {
 	return r.hasSentHandoverRequest
 }
 
-func (r *SentMessageRecorder) SendDispatched(ctx context.Context, transactionOriginator string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error {
+func (r *SentMessageRecorder) SendDispatched(ctx context.Context, node string, msg *engineProto.TransactionDispatched) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendEndorsementResponse(ctx context.Context, transactionId, idempotencyKey, contractAddress string, attResult *prototk.AttestationResult, endorsementResult *components.EndorsementResult, revertReason, endorsementName, party, node string) error {
+func (r *SentMessageRecorder) SendEndorsementResponse(ctx context.Context, node string, msg *engineProto.EndorsementResponse) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendEndorsementError(ctx context.Context, transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName, node string) error {
+func (r *SentMessageRecorder) SendEndorsementError(ctx context.Context, node string, msg *engineProto.EndorsementError) error {
 	return nil
 }
 
-func (r *SentMessageRecorder) SendEndorsementRejection(ctx context.Context, transactionId, idempotencyKey, contractAddress, endorsementName, party, node string, reason engineProto.RejectionReason, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance int64) error {
+func (r *SentMessageRecorder) SendEndorsementRejection(ctx context.Context, node string, msg *engineProto.EndorsementRejection) error {
 	return nil
 }

--- a/core/go/internal/sequencer/transport/message_types.go
+++ b/core/go/internal/sequencer/transport/message_types.go
@@ -15,7 +15,6 @@
 
 package transport
 
-
 const (
 	MessageType_AssembleRequest                  = "AssembleRequest"
 	MessageType_AssembleResponse                 = "AssembleResponse"
@@ -39,4 +38,3 @@ const (
 	MessageType_TransactionSubmitted             = "TransactionSubmitted"
 	MessageType_TransactionConfirmed             = "TransactionConfirmed"
 )
-

--- a/core/go/internal/sequencer/transport/transport_writer.go
+++ b/core/go/internal/sequencer/transport/transport_writer.go
@@ -17,28 +17,19 @@ package transport
 
 import (
 	"context"
-	"encoding/json"
-	"time"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
-	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
-	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/coordinator/grapher"
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
-	"github.com/google/uuid"
-
 	"google.golang.org/protobuf/proto"
 )
 
-// jsonMarshalFn and protoMarshalFn are package-level variables so tests can inject errors.
-var (
-	jsonMarshalFn  = json.Marshal
-	protoMarshalFn = proto.MarshalOptions{}.Marshal
-)
+// protoMarshalFn is a package-level variable so tests can inject errors.
+var protoMarshalFn = proto.MarshalOptions{}.Marshal
 
 // Where a request is sent, there are three possible types of message that may be sent back:
 // - response: the result of actioning the request, which may include expected errors (e.g. assembly reverted)
@@ -47,26 +38,26 @@ var (
 type TransportWriter interface {
 	StartLoopbackWriter()
 	WaitForDone(ctx context.Context)
-	SendDelegationRequest(ctx context.Context, coordinatorNode string, transactions []*components.PrivateTransaction, blockHeight uint64) error
-	SendDelegationResponse(ctx context.Context, delegatingNodeName string, delegationId string, transactionIDs []string, errors []int64, blockHeight uint64) error
-	SendDelegationRejection(ctx context.Context, delegatingNodeName string, delegationId string, rejectionReason engineProto.RejectionReason, activeCoordinator string, originatorBlockHeight, coordinatorBlockHeight, blockHeightTolerance int64) error
-	SendHandoverRequest(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress) error
-	SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState, expiryTime time.Time, coordinatorBlockHeight int64, blockHeightTolerance int64) error
-	SendEndorsementResponse(ctx context.Context, transactionId, idempotencyKey, contractAddress string, attResult *prototk.AttestationResult, endorsementResult *components.EndorsementResult, revertReason, endorsementName, party, node string) error
-	SendEndorsementError(ctx context.Context, transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName, node string) error
-	SendEndorsementRejection(ctx context.Context, transactionId, idempotencyKey, contractAddress, endorsementName, party, node string, reason engineProto.RejectionReason, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance int64) error
-	SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, coordinatorBlockHeight int64, expiryTime time.Time, blockHeightTolerance int64) error
-	SendAssembleResponse(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, postAssembly *components.TransactionPostAssembly, preAssembly *components.TransactionPreAssembly, recipient string) error
-	SendAssembleError(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string) error
-	SendAssembleRejection(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string, reason engineProto.RejectionReason, coordinatorBlockHeight, assemblerBlockHeight int64) error
-	SendNonceAssigned(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, nonce uint64) error
-	SendTransactionSubmitted(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, txHash *pldtypes.Bytes32) error
-	SendTransactionConfirmed(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, nonce *pldtypes.HexUint64, outcome engineProto.TransactionConfirmed_Outcome, revertReason pldtypes.HexBytes, failureMessage string, willRetry bool) error
-	SendHeartbeat(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress, coordinatorSnapshot *common.CoordinatorSnapshot) error
-	SendPreDispatchRequest(ctx context.Context, originatorNode string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, hash *pldtypes.Bytes32) error
-	SendPreDispatchResponse(ctx context.Context, transactionOriginator string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error
-	SendPreDispatchRejection(ctx context.Context, txID uuid.UUID, requestID uuid.UUID, coordinatorNode string, reason engineProto.RejectionReason) error
-	SendDispatched(ctx context.Context, transactionOriginator string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error
+	SendDelegationRequest(ctx context.Context, node string, msg *engineProto.DelegationRequest) error
+	SendDelegationResponse(ctx context.Context, node string, msg *engineProto.DelegationResponse) error
+	SendDelegationRejection(ctx context.Context, node string, msg *engineProto.DelegationRejection) error
+	SendHandoverRequest(ctx context.Context, node string, msg *engineProto.CoordinatorHandoverRequest) error
+	SendEndorsementRequest(ctx context.Context, node string, msg *engineProto.EndorsementRequest) error
+	SendEndorsementResponse(ctx context.Context, node string, msg *engineProto.EndorsementResponse) error
+	SendEndorsementError(ctx context.Context, node string, msg *engineProto.EndorsementError) error
+	SendEndorsementRejection(ctx context.Context, node string, msg *engineProto.EndorsementRejection) error
+	SendAssembleRequest(ctx context.Context, node string, msg *engineProto.AssembleRequest) error
+	SendAssembleResponse(ctx context.Context, node string, msg *engineProto.AssembleResponse) error
+	SendAssembleError(ctx context.Context, node string, msg *engineProto.AssembleError) error
+	SendAssembleRejection(ctx context.Context, node string, msg *engineProto.AssembleRejection) error
+	SendNonceAssigned(ctx context.Context, node string, msg *engineProto.NonceAssigned) error
+	SendTransactionSubmitted(ctx context.Context, node string, msg *engineProto.TransactionSubmitted) error
+	SendTransactionConfirmed(ctx context.Context, node string, msg *engineProto.TransactionConfirmed) error
+	SendHeartbeat(ctx context.Context, node string, msg *engineProto.CoordinatorHeartbeatNotification) error
+	SendPreDispatchRequest(ctx context.Context, node string, msg *engineProto.PreDispatchRequest) error
+	SendPreDispatchResponse(ctx context.Context, node string, msg *engineProto.PreDispatchResponse) error
+	SendPreDispatchRejection(ctx context.Context, node string, msg *engineProto.PreDispatchRejection) error
+	SendDispatched(ctx context.Context, node string, msg *engineProto.TransactionDispatched) error
 }
 
 func NewTransportWriter(ctx context.Context, contractAddress *pldtypes.EthAddress, nodeID string, transportManager components.TransportManager, loopbackHandler func(ctx context.Context, message *components.ReceivedMessage)) TransportWriter {
@@ -102,649 +93,101 @@ func (tw *transportWriter) WaitForDone(ctx context.Context) {
 	}
 }
 
-func (tw *transportWriter) SendDelegationRequest(
-	ctx context.Context,
-	coordinatorNode string,
-	transactions []*components.PrivateTransaction,
-	blockHeight uint64,
-) error {
-	allTxBytes := make([][]byte, 0, len(transactions))
-	for _, transaction := range transactions {
-		transactionBytes, err := jsonMarshalFn(transaction)
-		if err != nil {
-			log.L(ctx).Errorf("error marshalling transaction for delegation request: %v", err)
-			return err
-		}
-		allTxBytes = append(allTxBytes, transactionBytes)
-	}
-
-	delegationRequest := &engineProto.DelegationRequest{
-		DelegateNodeId:        coordinatorNode,
-		OriginatorBlockHeight: int64(blockHeight),
-		PrivateTransactions:   allTxBytes,
-	}
-	delegationRequestBytes, err := protoMarshalFn(delegationRequest)
+func (tw *transportWriter) marshalAndSend(ctx context.Context, node string, msgType string, msg proto.Message) error {
+	msgBytes, err := protoMarshalFn(msg)
 	if err != nil {
-		log.L(ctx).Errorf("error marshalling delegationRequest message: %s", err)
+		log.L(ctx).Errorf("error marshalling %s: %s", msgType, err)
 		return err
 	}
-
 	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_DelegationRequest,
-		Payload:     delegationRequestBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        coordinatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending delegationRequest message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendDelegationResponse(
-	ctx context.Context,
-	delegatingNodeName string,
-	delegationId string,
-	transactionIDs []string,
-	errors []int64,
-	blockHeight uint64,
-) error {
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		DelegationId:    delegationId,
-		TransactionIds:  transactionIDs,
-		DelegateNodeId:  delegatingNodeName,
-		ContractAddress: tw.contractAddress.String(),
-		Errors:          errors,
-	}
-	delegationRequestAcknowledgmentBytes, err := protoMarshalFn(delegationRequestAcknowledgment)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling delegationRequestAcknowledgment  message: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_DelegationResponse,
-		Payload:     delegationRequestAcknowledgmentBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        delegatingNodeName,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending delegationResponse message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendDelegationRejection(
-	ctx context.Context,
-	delegatingNodeName string,
-	delegationId string,
-	rejectionReason engineProto.RejectionReason,
-	activeCoordinator string,
-	originatorBlockHeight, coordinatorBlockHeight, blockHeightTolerance int64,
-) error {
-	rejection := &engineProto.DelegationRejection{
-		DelegationId:           delegationId,
-		DelegateNodeId:         delegatingNodeName,
-		ContractAddress:        tw.contractAddress.String(),
-		ActiveCoordinator:      activeCoordinator,
-		RejectionReason:        rejectionReason,
-		OriginatorBlockHeight:  originatorBlockHeight,
-		CoordinatorBlockHeight: coordinatorBlockHeight,
-		BlockHeightTolerance:   blockHeightTolerance,
-	}
-	rejectionBytes, err := protoMarshalFn(rejection)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling delegation rejection message: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_DelegationRejection,
-		Payload:     rejectionBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        delegatingNodeName,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending delegationRejection message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendHandoverRequest(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress) error {
-	log.L(ctx).Debugf("transport writer sending handover request to %s for contract %s", targetNode, contractAddress.String())
-
-	handoverRequest := &engineProto.CoordinatorHandoverRequest{
-		FromNode:        tw.nodeID,
-		ContractAddress: contractAddress.String(),
-	}
-	handoverRequestBytes, err := protoMarshalFn(handoverRequest)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling handover request: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_HandoverRequest,
-		Payload:     handoverRequestBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        targetNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending handover request: %s", err)
-	}
-	return nil
-}
-
-// TODO do we have duplication here?  contractAddress and transactionID are in the transactionSpecification
-func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, txID uuid.UUID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates []*prototk.EndorsableState, readStates []*prototk.EndorsableState, outputStates []*prototk.EndorsableState, infoStates []*prototk.EndorsableState, expiryTime time.Time, coordinatorBlockHeight int64, blockHeightTolerance int64) error {
-	log.L(ctx).Debugf("sending endorse request with TX ID %+v", transactionSpecification.TransactionId)
-	endorsementRequest := &engineProto.EndorsementRequest{
-		IdempotencyKey:           idempotencyKey.String(),
-		ContractAddress:          transactionSpecification.ContractInfo.ContractAddress,
-		TransactionId:            txID.String(),
-		AttestationRequest:       attRequest,
-		Party:                    party,
-		TransactionSpecification: transactionSpecification,
-		Verifiers:                verifiers,
-		Signatures:               signatures,
-		InputStates:              inputStates,
-		ReadStates:               readStates,
-		OutputStates:             outputStates,
-		InfoStates:               infoStates,
-		ExpiryTimeUnixMs:         expiryTime.UnixMilli(),
-		CoordinatorBlockHeight:   coordinatorBlockHeight,
-		BlockHeightTolerance:     blockHeightTolerance,
-	}
-
-	endorsementRequestBytes, err := protoMarshalFn(endorsementRequest)
-	if err != nil {
-		log.L(ctx).Error("error marshalling endorsement request", err)
-		return err
-	}
-
-	partyNode, err := pldtypes.PrivateIdentityLocator(party).Node(ctx, false)
-	if err != nil {
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_EndorsementRequest,
-		Node:        partyNode,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     endorsementRequestBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending endorsement request: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendEndorsementResponse(ctx context.Context, transactionId, idempotencyKey, contractAddress string, attResult *prototk.AttestationResult, endorsementResult *components.EndorsementResult, revertReason, endorsementName, party, node string) error {
-
-	endorsementResponse := &engineProto.EndorsementResponse{
-		Endorsement:            attResult,
-		TransactionId:          transactionId,
-		IdempotencyKey:         idempotencyKey,
-		AttestationRequestName: endorsementName,
-		Party:                  party,
-		ContractAddress:        contractAddress,
-	}
-
-	if revertReason != "" {
-		endorsementResponse.RevertReason = &revertReason
-	}
-
-	endorsementResponseBytes, err := protoMarshalFn(endorsementResponse)
-	if err != nil {
-		log.L(ctx).Error("error marshalling endorsement response", err)
-	}
-
-	payload := &components.FireAndForgetMessageSend{
-		MessageType: MessageType_EndorsementResponse,
-		Node:        node,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     endorsementResponseBytes,
-	}
-
-	if err = tw.send(ctx, payload); err != nil {
-		log.L(ctx).Warnf("error sending endorsement response: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendEndorsementError(ctx context.Context, transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName, node string) error {
-	endorsementError := &engineProto.EndorsementError{
-		TransactionId:          transactionId,
-		IdempotencyKey:         idempotencyKey,
-		ContractAddress:        contractAddress,
-		ErrorMessage:           errorMessage,
-		Party:                  party,
-		AttestationRequestName: attestationRequestName,
-	}
-	endorsementErrorBytes, err := protoMarshalFn(endorsementError)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling endorsement error message: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_EndorsementError,
-		Node:        node,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     endorsementErrorBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending endorsement error message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendEndorsementRejection(ctx context.Context, transactionId, idempotencyKey, contractAddress, endorsementName, party, node string, reason engineProto.RejectionReason, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance int64) error {
-	rejection := &engineProto.EndorsementRejection{
-		TransactionId:          transactionId,
-		IdempotencyKey:         idempotencyKey,
-		ContractAddress:        contractAddress,
-		AttestationRequestName: endorsementName,
-		Party:                  party,
-		RejectionReason:        reason,
-		CoordinatorBlockHeight: coordinatorBlockHeight,
-		EndorserBlockHeight:    endorserBlockHeight,
-		BlockHeightTolerance:   blockHeightTolerance,
-	}
-	rejectionBytes, err := protoMarshalFn(rejection)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling endorsement rejection message: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_EndorsementRejection,
-		Node:        node,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     rejectionBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending endorsement rejection: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendAssembleRequest(ctx context.Context, assemblingNode string, txID uuid.UUID, idempotencyId uuid.UUID, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, coordinatorBlockHeight int64, expiryTime time.Time, blockHeightTolerance int64) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send assemble request to assembling node %s", assemblingNode)
-
-	preAssemblyBytes, err := jsonMarshalFn(preAssembly)
-	if err != nil {
-		log.L(ctx).Error("error marshalling preassembly", err)
-		return err
-	}
-	stateLocksJSON, err := jsonMarshalFn(stateLocks)
-	if err != nil {
-		log.L(ctx).Error("error marshalling state locks", err)
-		return err
-	}
-	log.L(ctx).Debugf("assemble request state locks for tx %s: %s", txID, string(stateLocksJSON))
-
-	assembleRequest := &engineProto.AssembleRequest{
-		TransactionId:          txID.String(),
-		AssembleRequestId:      idempotencyId.String(),
-		ContractAddress:        tw.contractAddress.HexString(),
-		PreAssembly:            preAssemblyBytes,
-		StateLocks:             stateLocksJSON,
-		CoordinatorBlockHeight: coordinatorBlockHeight,
-		ExpiryTimeUnixMs:       expiryTime.UnixMilli(),
-		BlockHeightTolerance:   blockHeightTolerance,
-	}
-
-	assembleRequestBytes, err := protoMarshalFn(assembleRequest)
-	if err != nil {
-		log.L(ctx).Error("error marshalling assemble request", err)
-		return err
-	}
-
-	payload := &components.FireAndForgetMessageSend{
-		MessageType: MessageType_AssembleRequest,
-		Node:        assemblingNode,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     assembleRequestBytes,
-	}
-
-	if err = tw.send(ctx, payload); err != nil {
-		log.L(ctx).Warnf("error sending assemble request: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendAssembleError(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send assemble error response to node %s", recipient)
-
-	assembleError := &engineProto.AssembleError{
-		TransactionId:     txID.String(),
-		AssembleRequestId: assembleRequestId.String(),
-		ContractAddress:   tw.contractAddress.HexString(),
-	}
-	assembleErrorBytes, err := protoMarshalFn(assembleError)
-	if err != nil {
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_AssembleError,
-		Node:        recipient,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     assembleErrorBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending assemble error response to %s: %s", recipient, err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendAssembleRejection(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, recipient string, reason engineProto.RejectionReason, coordinatorBlockHeight, assemblerBlockHeight int64) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send assemble rejection to node %s (reason=%d)", recipient, reason)
-
-	rejection := &engineProto.AssembleRejection{
-		TransactionId:          txID.String(),
-		AssembleRequestId:      assembleRequestId.String(),
-		ContractAddress:        tw.contractAddress.HexString(),
-		RejectionReason:        reason,
-		CoordinatorBlockHeight: coordinatorBlockHeight,
-		AssemblerBlockHeight:   assemblerBlockHeight,
-	}
-	rejectionBytes, err := protoMarshalFn(rejection)
-	if err != nil {
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_AssembleRejection,
-		Node:        recipient,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     rejectionBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending assemble rejection to %s: %s", recipient, err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendPreDispatchRejection(ctx context.Context, txID uuid.UUID, requestID uuid.UUID, coordinatorNode string, reason engineProto.RejectionReason) error {
-	log.L(ctx).Debugf("transport writer sending pre-dispatch rejection for tx %s to coordinator %s (reason=%d)", txID, coordinatorNode, reason)
-
-	if tw.contractAddress == nil {
-		return i18n.NewError(ctx, msgs.MsgSequencerInternalError, "attempt to send pre-dispatch rejection without specifying contract address")
-	}
-
-	msgBytes, err := protoMarshalFn(&engineProto.PreDispatchRejection{
-		TransactionId:   txID.String(),
-		RequestId:       requestID.String(),
-		ContractAddress: tw.contractAddress.HexString(),
-		RejectionReason: reason,
-	})
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling pre-dispatch rejection: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_PreDispatchRejection,
+		MessageType: msgType,
 		Payload:     msgBytes,
 		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        coordinatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending pre-dispatch rejection to %s: %s", coordinatorNode, err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendAssembleResponse(ctx context.Context, txID uuid.UUID, assembleRequestId uuid.UUID, postAssembly *components.TransactionPostAssembly, preAssembly *components.TransactionPreAssembly, recipient string) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send assemble response to node %s", recipient)
-
-	postAssemblyBytes, err := jsonMarshalFn(postAssembly)
-	if err != nil {
-		return err
-	}
-
-	preAssemblyBytes, err := jsonMarshalFn(preAssembly)
-	if err != nil {
-		return err
-	}
-
-	assembleResponse := &engineProto.AssembleResponse{
-		TransactionId:     txID.String(),
-		AssembleRequestId: assembleRequestId.String(),
-		ContractAddress:   tw.contractAddress.HexString(),
-		PostAssembly:      postAssemblyBytes,
-		PreAssembly:       preAssemblyBytes,
-	}
-	assembleResponseBytes, err := protoMarshalFn(assembleResponse)
-	if err != nil {
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_AssembleResponse,
-		Node:        recipient,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Payload:     assembleResponseBytes,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending assemble response to %s: %s", recipient, err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendNonceAssigned(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, nonce uint64) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send nonce assigned message to node %s", originatorNode)
-
-	if contractAddress == nil {
-		err := i18n.NewError(ctx, msgs.MsgSequencerInternalError, "attempt to send nonce assigned event request without specifying contract address")
-		return err
-	}
-	nonceAssigned := &engineProto.NonceAssigned{
-		Id:              uuid.New().String(),
-		TransactionId:   txID.String(),
-		ContractAddress: contractAddress.HexString(),
-		Nonce:           int64(nonce),
-	}
-	nonceAssignedBytes, err := protoMarshalFn(nonceAssigned)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling nonce assigned event: %s", err)
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_NonceAssigned,
-		Payload:     nonceAssignedBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        originatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending nonce assigned event: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendTransactionSubmitted(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, txHash *pldtypes.Bytes32) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send transaction submitted message to node %s", originatorNode)
-
-	if contractAddress == nil {
-		err := i18n.NewError(ctx, msgs.MsgSequencerInternalError, "attempt to send TX submitted event without specifying contract address")
-		return err
-	}
-	txSubmitted := &engineProto.TransactionSubmitted{
-		Id:              uuid.New().String(),
-		TransactionId:   txID.String(),
-		ContractAddress: contractAddress.HexString(),
-		Hash:            txHash.Bytes(),
-	}
-	txSubmittedBytes, err := protoMarshalFn(txSubmitted)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling TX submitted event: %s", err)
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_TransactionSubmitted,
-		Payload:     txSubmittedBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        originatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending transaction submitted event: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendTransactionConfirmed(ctx context.Context, txID uuid.UUID, originatorNode string, contractAddress *pldtypes.EthAddress, nonce *pldtypes.HexUint64, outcome engineProto.TransactionConfirmed_Outcome, revertReason pldtypes.HexBytes, failureMessage string, willRetry bool) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send transaction confirmed message to node %s", originatorNode)
-
-	if contractAddress == nil {
-		err := i18n.NewError(ctx, msgs.MsgSequencerInternalError, "attempt to send TX submitted event without specifying contract address")
-		return err
-	}
-
-	txConfirmed := &engineProto.TransactionConfirmed{
-		Id:              uuid.New().String(),
-		TransactionId:   txID.String(),
-		ContractAddress: contractAddress.HexString(),
-		Outcome:         outcome,
-		RevertReason:    revertReason,
-		FailureMessage:  failureMessage,
-		WillRetry:       willRetry,
-	}
-	if nonce != nil {
-		txConfirmed.Nonce = int64(*nonce)
-	}
-	txConfirmedBytes, err := protoMarshalFn(txConfirmed)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling TX confirmed event: %s", err)
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_TransactionConfirmed,
-		Payload:     txConfirmedBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        originatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending transaction confirmed event: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendHeartbeat(ctx context.Context, targetNode string, contractAddress *pldtypes.EthAddress, coordinatorSnapshot *common.CoordinatorSnapshot) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send haertbeat to node %s", targetNode)
-
-	coordinatorSnapshotBytes, err := jsonMarshalFn(coordinatorSnapshot)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling heartbeat: %s", err)
-		return err
-	}
-
-	heartbeatRequest := &engineProto.CoordinatorHeartbeatNotification{
-		From:                tw.transportManager.LocalNodeName(),
-		ContractAddress:     contractAddress.HexString(),
-		CoordinatorSnapshot: coordinatorSnapshotBytes,
-	}
-	log.L(ctx).Debugf("sending heartbeat: From 	%s, Contract Address %s", tw.transportManager.LocalNodeName(), contractAddress.HexString())
-	heartbeatRequestBytes, err := protoMarshalFn(heartbeatRequest)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling heartbeat request message: %s", err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_CoordinatorHeartbeatNotification,
-		Payload:     heartbeatRequestBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        targetNode,
-	}); err != nil {
-		// Transport failures sending a heartbeat are transient and best-effort — the send layer
-		// itself is fire-and-forget and message loss is expected. Log a warning but don't
-		// propagate the error so callers can continue with subsequent actions.
-		log.L(ctx).Warnf("error sending heartbeat request message: %s", err)
-	}
-
-	return nil
-}
-
-func (tw *transportWriter) SendPreDispatchRequest(ctx context.Context, originatorNode string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, hash *pldtypes.Bytes32) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send pre-dispatch request to node %s", originatorNode)
-
-	dispatchConfirmationRequest := &engineProto.PreDispatchRequest{
-		Id:              idempotencyKey.String(),
-		TransactionId:   transactionSpecification.TransactionId,
-		ContractAddress: tw.contractAddress.HexString(),
-		PostAssembleHash: hash.Bytes(),
-	}
-
-	dispatchConfirmationRequestBytes, err := protoMarshalFn(dispatchConfirmationRequest)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling pre-dispatch request message: %s", err)
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_PreDispatchRequest,
-		Payload:     dispatchConfirmationRequestBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        originatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending pre-dispatch request message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendPreDispatchResponse(ctx context.Context, transactionOriginatorNode string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send pre-dispatch response to node %s", transactionOriginatorNode)
-
-	dispatchResponseEvent := &engineProto.PreDispatchResponse{
-		Id:              idempotencyKey.String(),
-		TransactionId:   transactionSpecification.TransactionId,
-		ContractAddress: tw.contractAddress.HexString(),
-	}
-
-	dispatchResponseEventBytes, err := protoMarshalFn(dispatchResponseEvent)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling pre-dispatch response message: %s", err)
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_PreDispatchResponse,
-		Payload:     dispatchResponseEventBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		Node:        transactionOriginatorNode,
-	}); err != nil {
-		log.L(ctx).Warnf("error sending pre-dispatch response message: %s", err)
-	}
-	return nil
-}
-
-func (tw *transportWriter) SendDispatched(ctx context.Context, transactionOriginator string, idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification) error {
-
-	log.L(ctx).Tracef("transport writer attempting to send dispatched message to node %s", transactionOriginator)
-
-	dispatchedEvent := &engineProto.TransactionDispatched{
-		Id:              idempotencyKey.String(),
-		TransactionId:   transactionSpecification.TransactionId,
-		ContractAddress: tw.contractAddress.HexString(),
-		Signer:          transactionOriginator,
-	}
-
-	dispatchedEventBytes, err := protoMarshalFn(dispatchedEvent)
-	if err != nil {
-		log.L(ctx).Errorf("error marshalling dispatch confirmation request  message: %s", err)
-	}
-
-	node, err := pldtypes.PrivateIdentityLocator(transactionOriginator).Node(ctx, false)
-	if err != nil {
-		log.L(ctx).Errorf("error getting transaction dispatched originator node id for %s: %s", transactionOriginator, err)
-		return err
-	}
-
-	if err = tw.send(ctx, &components.FireAndForgetMessageSend{
-		MessageType: MessageType_Dispatched,
-		Payload:     dispatchedEventBytes,
-		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
 		Node:        node,
 	}); err != nil {
-		log.L(ctx).Warnf("error sending dispatched event: %s", err)
+		log.L(ctx).Warnf("error sending %s to %s: %s", msgType, node, err)
 	}
 	return nil
+}
+
+func (tw *transportWriter) SendDelegationRequest(ctx context.Context, node string, msg *engineProto.DelegationRequest) error {
+	return tw.marshalAndSend(ctx, node, MessageType_DelegationRequest, msg)
+}
+
+func (tw *transportWriter) SendDelegationResponse(ctx context.Context, node string, msg *engineProto.DelegationResponse) error {
+	return tw.marshalAndSend(ctx, node, MessageType_DelegationResponse, msg)
+}
+
+func (tw *transportWriter) SendDelegationRejection(ctx context.Context, node string, msg *engineProto.DelegationRejection) error {
+	return tw.marshalAndSend(ctx, node, MessageType_DelegationRejection, msg)
+}
+
+func (tw *transportWriter) SendHandoverRequest(ctx context.Context, node string, msg *engineProto.CoordinatorHandoverRequest) error {
+	return tw.marshalAndSend(ctx, node, MessageType_HandoverRequest, msg)
+}
+
+func (tw *transportWriter) SendEndorsementRequest(ctx context.Context, node string, msg *engineProto.EndorsementRequest) error {
+	return tw.marshalAndSend(ctx, node, MessageType_EndorsementRequest, msg)
+}
+
+func (tw *transportWriter) SendEndorsementResponse(ctx context.Context, node string, msg *engineProto.EndorsementResponse) error {
+	return tw.marshalAndSend(ctx, node, MessageType_EndorsementResponse, msg)
+}
+
+func (tw *transportWriter) SendEndorsementError(ctx context.Context, node string, msg *engineProto.EndorsementError) error {
+	return tw.marshalAndSend(ctx, node, MessageType_EndorsementError, msg)
+}
+
+func (tw *transportWriter) SendEndorsementRejection(ctx context.Context, node string, msg *engineProto.EndorsementRejection) error {
+	return tw.marshalAndSend(ctx, node, MessageType_EndorsementRejection, msg)
+}
+
+func (tw *transportWriter) SendAssembleRequest(ctx context.Context, node string, msg *engineProto.AssembleRequest) error {
+	return tw.marshalAndSend(ctx, node, MessageType_AssembleRequest, msg)
+}
+
+func (tw *transportWriter) SendAssembleResponse(ctx context.Context, node string, msg *engineProto.AssembleResponse) error {
+	return tw.marshalAndSend(ctx, node, MessageType_AssembleResponse, msg)
+}
+
+func (tw *transportWriter) SendAssembleError(ctx context.Context, node string, msg *engineProto.AssembleError) error {
+	return tw.marshalAndSend(ctx, node, MessageType_AssembleError, msg)
+}
+
+func (tw *transportWriter) SendAssembleRejection(ctx context.Context, node string, msg *engineProto.AssembleRejection) error {
+	return tw.marshalAndSend(ctx, node, MessageType_AssembleRejection, msg)
+}
+
+func (tw *transportWriter) SendNonceAssigned(ctx context.Context, node string, msg *engineProto.NonceAssigned) error {
+	return tw.marshalAndSend(ctx, node, MessageType_NonceAssigned, msg)
+}
+
+func (tw *transportWriter) SendTransactionSubmitted(ctx context.Context, node string, msg *engineProto.TransactionSubmitted) error {
+	return tw.marshalAndSend(ctx, node, MessageType_TransactionSubmitted, msg)
+}
+
+func (tw *transportWriter) SendTransactionConfirmed(ctx context.Context, node string, msg *engineProto.TransactionConfirmed) error {
+	return tw.marshalAndSend(ctx, node, MessageType_TransactionConfirmed, msg)
+}
+
+func (tw *transportWriter) SendHeartbeat(ctx context.Context, node string, msg *engineProto.CoordinatorHeartbeatNotification) error {
+	return tw.marshalAndSend(ctx, node, MessageType_CoordinatorHeartbeatNotification, msg)
+}
+
+func (tw *transportWriter) SendPreDispatchRequest(ctx context.Context, node string, msg *engineProto.PreDispatchRequest) error {
+	return tw.marshalAndSend(ctx, node, MessageType_PreDispatchRequest, msg)
+}
+
+func (tw *transportWriter) SendPreDispatchResponse(ctx context.Context, node string, msg *engineProto.PreDispatchResponse) error {
+	return tw.marshalAndSend(ctx, node, MessageType_PreDispatchResponse, msg)
+}
+
+func (tw *transportWriter) SendPreDispatchRejection(ctx context.Context, node string, msg *engineProto.PreDispatchRejection) error {
+	return tw.marshalAndSend(ctx, node, MessageType_PreDispatchRejection, msg)
+}
+
+func (tw *transportWriter) SendDispatched(ctx context.Context, node string, msg *engineProto.TransactionDispatched) error {
+	return tw.marshalAndSend(ctx, node, MessageType_Dispatched, msg)
 }
 
 func (tw *transportWriter) send(ctx context.Context, payload *components.FireAndForgetMessageSend) error {
@@ -753,7 +196,7 @@ func (tw *transportWriter) send(ctx context.Context, payload *components.FireAnd
 		return err
 	}
 
-	log.L(ctx).Debugf("%+v sent to %s", payload.MessageType, payload.Node)
+	log.L(ctx).Debugf("%s sent to %s", payload.MessageType, payload.Node)
 	if payload.Node == "" || payload.Node == tw.transportManager.LocalNodeName() {
 		// "Localhost" loopback
 		log.L(ctx).Debugf("sending %s to loopback interface", payload.MessageType)

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -239,6 +239,246 @@ func TestSend_WriterContextCancelled_LoopbackQueueFull(t *testing.T) {
 	assert.Equal(t, context.Canceled, err)
 }
 
+// ===== Proto message builder helpers =====
+
+func testTransactionSubmittedMsg(txID uuid.UUID, contractAddress *pldtypes.EthAddress, txHash *pldtypes.Bytes32) *engineProto.TransactionSubmitted {
+	return &engineProto.TransactionSubmitted{
+		Id:              uuid.New().String(),
+		TransactionId:   txID.String(),
+		ContractAddress: contractAddress.HexString(),
+		Hash:            txHash.Bytes(),
+	}
+}
+
+func testDelegationRequestMsg(coordinatorNode string, transactions []*components.PrivateTransaction, blockHeight uint64) (*engineProto.DelegationRequest, error) {
+	allTxBytes := make([][]byte, 0, len(transactions))
+	for _, transaction := range transactions {
+		transactionBytes, err := json.Marshal(transaction)
+		if err != nil {
+			return nil, err
+		}
+		allTxBytes = append(allTxBytes, transactionBytes)
+	}
+	return &engineProto.DelegationRequest{
+		DelegateNodeId:        coordinatorNode,
+		OriginatorBlockHeight: int64(blockHeight),
+		PrivateTransactions:   allTxBytes,
+	}, nil
+}
+
+func testDelegationResponseMsg(delegatingNodeName, delegationId string, transactionIDs []string, contractAddress *pldtypes.EthAddress, errors []int64) *engineProto.DelegationResponse {
+	return &engineProto.DelegationResponse{
+		DelegationId:    delegationId,
+		TransactionIds:  transactionIDs,
+		DelegateNodeId:  delegatingNodeName,
+		ContractAddress: contractAddress.String(),
+		Errors:          errors,
+	}
+}
+
+func testDelegationRejectionMsg(delegatingNodeName, delegationId string, contractAddress *pldtypes.EthAddress, rejectionReason engineProto.RejectionReason, activeCoordinator string, originatorBlockHeight, coordinatorBlockHeight, blockHeightTolerance int64) *engineProto.DelegationRejection {
+	return &engineProto.DelegationRejection{
+		DelegationId:           delegationId,
+		DelegateNodeId:         delegatingNodeName,
+		ContractAddress:        contractAddress.String(),
+		RejectionReason:        rejectionReason,
+		ActiveCoordinator:      activeCoordinator,
+		OriginatorBlockHeight:  originatorBlockHeight,
+		CoordinatorBlockHeight: coordinatorBlockHeight,
+		BlockHeightTolerance:   blockHeightTolerance,
+	}
+}
+
+func testEndorsementRequestMsg(txID, idempotencyKey uuid.UUID, party string, attRequest *prototk.AttestationRequest, transactionSpecification *prototk.TransactionSpecification, verifiers []*prototk.ResolvedVerifier, signatures []*prototk.AttestationResult, inputStates, readStates, outputStates, infoStates []*prototk.EndorsableState, expiry time.Time, coordinatorBlockHeight, blockHeightTolerance int64) *engineProto.EndorsementRequest {
+	return &engineProto.EndorsementRequest{
+		IdempotencyKey:           idempotencyKey.String(),
+		ContractAddress:          transactionSpecification.ContractInfo.ContractAddress,
+		TransactionId:            txID.String(),
+		AttestationRequest:       attRequest,
+		Party:                    party,
+		TransactionSpecification: transactionSpecification,
+		Verifiers:                verifiers,
+		Signatures:               signatures,
+		InputStates:              inputStates,
+		ReadStates:               readStates,
+		OutputStates:             outputStates,
+		InfoStates:               infoStates,
+		ExpiryTimeUnixMs:         expiry.UnixMilli(),
+		CoordinatorBlockHeight:   coordinatorBlockHeight,
+		BlockHeightTolerance:     blockHeightTolerance,
+	}
+}
+
+func testEndorsementResponseMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party string, attResult *prototk.AttestationResult, revertReason string) *engineProto.EndorsementResponse {
+	msg := &engineProto.EndorsementResponse{
+		Endorsement:            attResult,
+		TransactionId:          transactionId,
+		IdempotencyKey:         idempotencyKey,
+		AttestationRequestName: endorsementName,
+		Party:                  party,
+		ContractAddress:        contractAddress,
+	}
+	if revertReason != "" {
+		msg.RevertReason = &revertReason
+	}
+	return msg
+}
+
+func testEndorsementRejectionMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party string, reason engineProto.RejectionReason, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance int64) *engineProto.EndorsementRejection {
+	return &engineProto.EndorsementRejection{
+		TransactionId:          transactionId,
+		IdempotencyKey:         idempotencyKey,
+		ContractAddress:        contractAddress,
+		AttestationRequestName: endorsementName,
+		Party:                  party,
+		RejectionReason:        reason,
+		CoordinatorBlockHeight: coordinatorBlockHeight,
+		EndorserBlockHeight:    endorserBlockHeight,
+		BlockHeightTolerance:   blockHeightTolerance,
+	}
+}
+
+func testEndorsementErrorMsg(transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName string) *engineProto.EndorsementError {
+	return &engineProto.EndorsementError{
+		TransactionId:          transactionId,
+		IdempotencyKey:         idempotencyKey,
+		ContractAddress:        contractAddress,
+		ErrorMessage:           errorMessage,
+		Party:                  party,
+		AttestationRequestName: attestationRequestName,
+	}
+}
+
+func testAssembleRequestMsg(txID, idempotencyId uuid.UUID, contractAddress *pldtypes.EthAddress, preAssembly *components.TransactionPreAssembly, stateLocks grapher.ExportableStates, blockHeight int64, expiry time.Time, blockHeightTolerance int64) (*engineProto.AssembleRequest, error) {
+	preAssemblyBytes, err := json.Marshal(preAssembly)
+	if err != nil {
+		return nil, err
+	}
+	stateLocksJSON, err := json.Marshal(stateLocks)
+	if err != nil {
+		return nil, err
+	}
+	return &engineProto.AssembleRequest{
+		TransactionId:          txID.String(),
+		AssembleRequestId:      idempotencyId.String(),
+		ContractAddress:        contractAddress.HexString(),
+		PreAssembly:            preAssemblyBytes,
+		StateLocks:             stateLocksJSON,
+		CoordinatorBlockHeight: blockHeight,
+		ExpiryTimeUnixMs:       expiry.UnixMilli(),
+		BlockHeightTolerance:   blockHeightTolerance,
+	}, nil
+}
+
+func testAssembleResponseMsg(txID, assembleRequestId uuid.UUID, contractAddress *pldtypes.EthAddress, postAssembly *components.TransactionPostAssembly, preAssembly *components.TransactionPreAssembly) (*engineProto.AssembleResponse, error) {
+	postAssemblyBytes, err := json.Marshal(postAssembly)
+	if err != nil {
+		return nil, err
+	}
+	preAssemblyBytes, err := json.Marshal(preAssembly)
+	if err != nil {
+		return nil, err
+	}
+	return &engineProto.AssembleResponse{
+		TransactionId:     txID.String(),
+		AssembleRequestId: assembleRequestId.String(),
+		ContractAddress:   contractAddress.HexString(),
+		PostAssembly:      postAssemblyBytes,
+		PreAssembly:       preAssemblyBytes,
+	}, nil
+}
+
+func testAssembleErrorMsg(txID, assembleRequestId uuid.UUID, contractAddress *pldtypes.EthAddress) *engineProto.AssembleError {
+	return &engineProto.AssembleError{
+		TransactionId:     txID.String(),
+		AssembleRequestId: assembleRequestId.String(),
+		ContractAddress:   contractAddress.HexString(),
+	}
+}
+
+func testAssembleRejectionMsg(txID, assembleRequestId uuid.UUID, contractAddress *pldtypes.EthAddress, reason engineProto.RejectionReason, coordinatorBlockHeight, assemblerBlockHeight int64) *engineProto.AssembleRejection {
+	return &engineProto.AssembleRejection{
+		TransactionId:          txID.String(),
+		AssembleRequestId:      assembleRequestId.String(),
+		ContractAddress:        contractAddress.HexString(),
+		RejectionReason:        reason,
+		CoordinatorBlockHeight: coordinatorBlockHeight,
+		AssemblerBlockHeight:   assemblerBlockHeight,
+	}
+}
+
+func testNonceAssignedMsg(txID uuid.UUID, contractAddress *pldtypes.EthAddress, nonce uint64) *engineProto.NonceAssigned {
+	return &engineProto.NonceAssigned{
+		Id:              uuid.New().String(),
+		TransactionId:   txID.String(),
+		ContractAddress: contractAddress.HexString(),
+		Nonce:           int64(nonce),
+	}
+}
+
+func testTransactionConfirmedMsg(txID uuid.UUID, contractAddress *pldtypes.EthAddress, nonce *pldtypes.HexUint64, outcome engineProto.TransactionConfirmed_Outcome, revertReason pldtypes.HexBytes, failureMessage string, willRetry bool) *engineProto.TransactionConfirmed {
+	msg := &engineProto.TransactionConfirmed{
+		Id:              uuid.New().String(),
+		TransactionId:   txID.String(),
+		ContractAddress: contractAddress.HexString(),
+		Outcome:         outcome,
+		RevertReason:    revertReason,
+		FailureMessage:  failureMessage,
+		WillRetry:       willRetry,
+	}
+	if nonce != nil {
+		msg.Nonce = int64(*nonce)
+	}
+	return msg
+}
+
+func testHeartbeatMsg(from string, contractAddress *pldtypes.EthAddress, coordinatorSnapshot *common.CoordinatorSnapshot) (*engineProto.CoordinatorHeartbeatNotification, error) {
+	coordinatorSnapshotBytes, err := json.Marshal(coordinatorSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	return &engineProto.CoordinatorHeartbeatNotification{
+		From:                from,
+		ContractAddress:     contractAddress.HexString(),
+		CoordinatorSnapshot: coordinatorSnapshotBytes,
+	}, nil
+}
+
+func testPreDispatchRequestMsg(idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, contractAddress *pldtypes.EthAddress, hash *pldtypes.Bytes32) *engineProto.PreDispatchRequest {
+	return &engineProto.PreDispatchRequest{
+		Id:               idempotencyKey.String(),
+		TransactionId:    transactionSpecification.TransactionId,
+		ContractAddress:  contractAddress.HexString(),
+		PostAssembleHash: hash.Bytes(),
+	}
+}
+
+func testPreDispatchResponseMsg(idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, contractAddress *pldtypes.EthAddress) *engineProto.PreDispatchResponse {
+	return &engineProto.PreDispatchResponse{
+		Id:              idempotencyKey.String(),
+		TransactionId:   transactionSpecification.TransactionId,
+		ContractAddress: contractAddress.HexString(),
+	}
+}
+
+func testDispatchedMsg(idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, contractAddress *pldtypes.EthAddress, transactionOriginator string) *engineProto.TransactionDispatched {
+	return &engineProto.TransactionDispatched{
+		Id:              idempotencyKey.String(),
+		TransactionId:   transactionSpecification.TransactionId,
+		ContractAddress: contractAddress.HexString(),
+		Signer:          transactionOriginator,
+	}
+}
+
+func testPreDispatchRejectionMsg(txID, requestID uuid.UUID, contractAddress *pldtypes.EthAddress, reason engineProto.RejectionReason) *engineProto.PreDispatchRejection {
+	return &engineProto.PreDispatchRejection{
+		TransactionId:   txID.String(),
+		RequestId:       requestID.String(),
+		ContractAddress: contractAddress.HexString(),
+		RejectionReason: reason,
+	}
+}
+
 func TestSendTransactionSubmitted_Success(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
@@ -296,7 +536,7 @@ func TestSendTransactionSubmitted_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionSubmitted(ctx, txID, originatorNode, contractAddress, txHash)
+	err := tw.SendTransactionSubmitted(ctx, originatorNode, testTransactionSubmittedMsg(txID, contractAddress, txHash))
 	require.NoError(t, err)
 }
 
@@ -322,7 +562,7 @@ func TestSendTransactionSubmitted_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionSubmitted(ctx, txID, originatorNode, contractAddress, txHash)
+	err := tw.SendTransactionSubmitted(ctx, originatorNode, testTransactionSubmittedMsg(txID, contractAddress, txHash))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -343,10 +583,10 @@ func TestSendTransactionSubmitted_Loopback(t *testing.T) {
 
 }
 
-func TestSendTransactionSubmitted_NilContractAddress(t *testing.T) {
+func TestSendTransactionSubmitted_EmptyNode(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
-	originatorNode := "originator-node"
+	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 	txHashVal := pldtypes.MustParseBytes32("0x00000000000000000000000000000000000000000000000000000000000000ab")
 	txHash := &txHashVal
 
@@ -357,12 +597,11 @@ func TestSendTransactionSubmitted_NilContractAddress(t *testing.T) {
 		nodeID:            "local-node",
 		transportManager:  mockTransportManager,
 		loopbackTransport: mockLoopbackTransport,
-		contractAddress:   nil,
+		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionSubmitted(ctx, txID, originatorNode, nil, txHash)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "contract address")
+	err := tw.SendTransactionSubmitted(ctx, "", testTransactionSubmittedMsg(txID, contractAddress, txHash))
+	require.NoError(t, err)
 
 	// Verify no messages were sent
 	mockTransportManager.AssertNotCalled(t, "Send")
@@ -389,7 +628,7 @@ func TestSendTransactionSubmitted_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionSubmitted(ctx, txID, originatorNode, contractAddress, txHash)
+	err := tw.SendTransactionSubmitted(ctx, originatorNode, testTransactionSubmittedMsg(txID, contractAddress, txHash))
 	require.NoError(t, err)
 }
 
@@ -419,7 +658,7 @@ func TestSendTransactionSubmitted_VerifyProtoFields(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionSubmitted(ctx, txID, originatorNode, contractAddress, txHash)
+	err := tw.SendTransactionSubmitted(ctx, originatorNode, testTransactionSubmittedMsg(txID, contractAddress, txHash))
 	require.NoError(t, err)
 
 	// Unmarshal and verify all fields
@@ -450,7 +689,6 @@ func TestSendTransactionSubmitted_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -460,11 +698,10 @@ func TestSendTransactionSubmitted_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	// SendTransactionSubmitted logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendTransactionSubmitted(ctx, uuid.New(), "originator-node", contractAddress, &txHashVal)
-	require.NoError(t, err)
+	err := tw.SendTransactionSubmitted(ctx, "originator-node", testTransactionSubmittedMsg(uuid.New(), contractAddress, &txHashVal))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendDelegationRequest Tests =====
 
@@ -515,7 +752,9 @@ func TestSendDelegationRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRequest(ctx, coordinatorNode, transactions, blockHeight)
+	delegationMsg, err := testDelegationRequestMsg(coordinatorNode, transactions, blockHeight)
+	require.NoError(t, err)
+	err = tw.SendDelegationRequest(ctx, coordinatorNode, delegationMsg)
 	require.NoError(t, err)
 
 	assert.Equal(t, coordinatorNode, capturedRequest.DelegateNodeId)
@@ -549,7 +788,7 @@ func TestSendDelegationRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRequest(ctx, coordinatorNode, nil, 0)
+	err := tw.SendDelegationRequest(ctx, coordinatorNode, &engineProto.DelegationRequest{})
 	require.NoError(t, err) // send errors are logged but not propagated
 }
 
@@ -577,35 +816,11 @@ func TestSendDelegationRequest_EmptyTransactions(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRequest(ctx, coordinatorNode, []*components.PrivateTransaction{}, blockHeight)
+	delegationMsg, err := testDelegationRequestMsg(coordinatorNode, []*components.PrivateTransaction{}, blockHeight)
+	require.NoError(t, err)
+	err = tw.SendDelegationRequest(ctx, coordinatorNode, delegationMsg)
 	require.NoError(t, err)
 	assert.Empty(t, capturedRequest.PrivateTransactions)
-}
-
-func TestSendDelegationRequest_JSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(_ any) ([]byte, error) { return nil, errors.New("forced JSON error") }
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	// Need at least one transaction so the json.Marshal in the loop is executed.
-	txns := []*components.PrivateTransaction{{ID: uuid.New()}}
-	err := tw.SendDelegationRequest(ctx, "coordinator-node", txns, 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error")
 }
 
 func TestSendDelegationRequest_ProtoMarshalError(t *testing.T) {
@@ -627,11 +842,10 @@ func TestSendDelegationRequest_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRequest(ctx, "coordinator-node", nil, 0)
+	err := tw.SendDelegationRequest(ctx, "coordinator-node", &engineProto.DelegationRequest{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendDelegationResponse Tests =====
 
@@ -686,7 +900,7 @@ func TestSendDelegationResponse_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationResponse(ctx, delegatingNodeName, delegationId, transactionIDs, []int64{0}, uint64(100))
+	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, transactionIDs, contractAddress, []int64{0}))
 	require.NoError(t, err)
 }
 
@@ -710,7 +924,7 @@ func TestSendDelegationResponse_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationResponse(ctx, delegatingNodeName, delegationId, []string{transactionID}, []int64{0}, uint64(100))
+	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, []string{transactionID}, contractAddress, []int64{0}))
 	require.NoError(t, err)
 }
 
@@ -733,11 +947,10 @@ func TestSendDelegationResponse_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationResponse(ctx, "delegating-node", "del-id", nil, nil, 0)
+	err := tw.SendDelegationResponse(ctx, "delegating-node", &engineProto.DelegationResponse{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendDelegationRejection Tests =====
 
@@ -775,7 +988,7 @@ func TestSendDelegationRejection_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRejection(ctx, delegatingNodeName, delegationId, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, "active-coordinator", int64(blockHeight), int64(90), int64(0))
+	err := tw.SendDelegationRejection(ctx, delegatingNodeName, testDelegationRejectionMsg(delegatingNodeName, delegationId, contractAddress, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, "active-coordinator", int64(blockHeight), int64(90), int64(0)))
 	require.NoError(t, err)
 }
 
@@ -798,7 +1011,7 @@ func TestSendDelegationRejection_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRejection(ctx, delegatingNodeName, delegationId, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, "node1", int64(100), int64(90), int64(0))
+	err := tw.SendDelegationRejection(ctx, delegatingNodeName, testDelegationRejectionMsg(delegatingNodeName, delegationId, contractAddress, engineProto.RejectionReason_NOT_CURRENT_DELEGATE, "node1", int64(100), int64(90), int64(0)))
 	require.NoError(t, err)
 }
 
@@ -821,11 +1034,10 @@ func TestSendDelegationRejection_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationRejection(ctx, "node", "del-id", engineProto.RejectionReason_NOT_CURRENT_DELEGATE, "", 0, 0, 0)
+	err := tw.SendDelegationRejection(ctx, "node", &engineProto.DelegationRejection{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendHandoverRequest Tests =====
 
@@ -856,7 +1068,10 @@ func TestSendHandoverRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHandoverRequest(ctx, targetNode, contractAddress)
+	err := tw.SendHandoverRequest(ctx, targetNode, &engineProto.CoordinatorHandoverRequest{
+		FromNode:        "local-node",
+		ContractAddress: contractAddress.String(),
+	})
 	require.NoError(t, err)
 }
 
@@ -878,7 +1093,7 @@ func TestSendHandoverRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHandoverRequest(ctx, targetNode, contractAddress)
+	err := tw.SendHandoverRequest(ctx, targetNode, &engineProto.CoordinatorHandoverRequest{})
 	require.NoError(t, err) // send errors are logged but not propagated
 }
 
@@ -901,7 +1116,7 @@ func TestSendHandoverRequest_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHandoverRequest(ctx, "target-node", contractAddress)
+	err := tw.SendHandoverRequest(ctx, "target-node", &engineProto.CoordinatorHandoverRequest{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
@@ -991,7 +1206,7 @@ func TestSendEndorsementRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, verifiers, signatures, inputStates, readStates, outputStates, infoStates, time.Time{}, 0, 0)
+	err := tw.SendEndorsementRequest(ctx, "node1", testEndorsementRequestMsg(txID, idempotencyKey, party, attRequest, transactionSpecification, verifiers, signatures, inputStates, readStates, outputStates, infoStates, time.Time{}, 0, 0))
 	require.NoError(t, err)
 }
 
@@ -1027,45 +1242,16 @@ func TestSendEndorsementRequest_SerialisesExpiryTimeIntoProto(t *testing.T) {
 		loopbackTransport: mockLoopbackTransport,
 		contractAddress:   contractAddress,
 	}
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, nil, transactionSpecification, nil, nil, nil, nil, nil, nil, expiry, 0, 0)
+	err := tw.SendEndorsementRequest(ctx, "node1", testEndorsementRequestMsg(txID, idempotencyKey, party, nil, transactionSpecification, nil, nil, nil, nil, nil, nil, expiry, 0, 0))
 	require.NoError(t, err)
 	assert.Equal(t, expiry.UnixMilli(), capturedExpiry, "ExpiryTimeUnixMs should match expiry.UnixMilli()")
 }
 
-func TestSendEndorsementRequest_SendError(t *testing.T) {
+func TestSendEndorsementRequest_EmptyNode(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
 	idempotencyKey := uuid.New()
 	party := "party1@node1"
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-
-	transactionSpecification := &prototk.TransactionSpecification{
-		TransactionId: txID.String(),
-		ContractInfo:  &prototk.ContractInfo{ContractAddress: contractAddress.HexString()},
-	}
-
-	mockTransportManager := componentsmocks.NewTransportManager(t)
-	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
-	mockTransportManager.On("LocalNodeName").Return("local-node").Maybe()
-	mockTransportManager.On("Send", ctx, mock.Anything).Return(errors.New("transport send error"))
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTransportManager,
-		loopbackTransport: mockLoopbackTransport,
-		contractAddress:   contractAddress,
-	}
-
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, nil, transactionSpecification, nil, nil, nil, nil, nil, nil, time.Time{}, 0, 0)
-	require.NoError(t, err) // send errors are logged but not propagated
-}
-
-func TestSendEndorsementRequest_NodeLookupError(t *testing.T) {
-	ctx := context.Background()
-	txID := uuid.New()
-	idempotencyKey := uuid.New()
-	party := "invalid-party" // No @node, will fail Node lookup
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 
 	attRequest := &prototk.AttestationRequest{
@@ -1090,15 +1276,14 @@ func TestSendEndorsementRequest_NodeLookupError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendEndorsementRequest(ctx, txID, idempotencyKey, party, attRequest, transactionSpecification, nil, nil, nil, nil, nil, nil, time.Time{}, 0, 0)
-	require.Error(t, err)
+	err := tw.SendEndorsementRequest(ctx, "", testEndorsementRequestMsg(txID, idempotencyKey, party, attRequest, transactionSpecification, nil, nil, nil, nil, nil, nil, time.Time{}, 0, 0))
+	require.NoError(t, err)
 	mockTransportManager.AssertNotCalled(t, "Send")
 }
 
 func TestSendEndorsementRequest_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -1115,15 +1300,10 @@ func TestSendEndorsementRequest_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	txSpec := &prototk.TransactionSpecification{
-		TransactionId: txID.String(),
-		ContractInfo:  &prototk.ContractInfo{ContractAddress: contractAddress.HexString()},
-	}
-	err := tw.SendEndorsementRequest(ctx, txID, uuid.New(), "party@node1", nil, txSpec, nil, nil, nil, nil, nil, nil, time.Time{}, 0, 0)
+	err := tw.SendEndorsementRequest(ctx, "node1", &engineProto.EndorsementRequest{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendEndorsementResponse Tests =====
 
@@ -1139,10 +1319,6 @@ func TestSendEndorsementResponse_Success(t *testing.T) {
 
 	attResult := &prototk.AttestationResult{
 		Name: "test-result",
-	}
-
-	endorsementResult := &components.EndorsementResult{
-		Result: prototk.EndorseTransactionResponse_SIGN,
 	}
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
@@ -1191,7 +1367,7 @@ func TestSendEndorsementResponse_Success(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementResponse(ctx, transactionId, idempotencyKey, contractAddress, attResult, endorsementResult, revertReason, endorsementName, party, node)
+	err := tw.SendEndorsementResponse(ctx, node, testEndorsementResponseMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party, attResult, revertReason))
 	require.NoError(t, err)
 }
 
@@ -1207,10 +1383,6 @@ func TestSendEndorsementResponse_WithRevertReason(t *testing.T) {
 
 	attResult := &prototk.AttestationResult{
 		Name: "test-result",
-	}
-
-	endorsementResult := &components.EndorsementResult{
-		Result: prototk.EndorseTransactionResponse_REVERT,
 	}
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
@@ -1235,7 +1407,7 @@ func TestSendEndorsementResponse_WithRevertReason(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementResponse(ctx, transactionId, idempotencyKey, contractAddress, attResult, endorsementResult, revertReason, endorsementName, party, node)
+	err := tw.SendEndorsementResponse(ctx, node, testEndorsementResponseMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party, attResult, revertReason))
 	require.NoError(t, err)
 }
 
@@ -1252,8 +1424,6 @@ func TestSendEndorsementResponse_SendError(t *testing.T) {
 		Name: "test-result",
 	}
 
-	endorsementResult := &components.EndorsementResult{}
-
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTransportManager.On("LocalNodeName").Return("local-node").Maybe()
@@ -1266,7 +1436,7 @@ func TestSendEndorsementResponse_SendError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementResponse(ctx, transactionId, idempotencyKey, contractAddress, attResult, endorsementResult, "", endorsementName, party, node)
+	err := tw.SendEndorsementResponse(ctx, node, testEndorsementResponseMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party, attResult, ""))
 	require.NoError(t, err)
 }
 
@@ -1281,7 +1451,6 @@ func TestSendEndorsementResponse_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -1291,11 +1460,10 @@ func TestSendEndorsementResponse_ProtoMarshalError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	// SendEndorsementResponse does NOT return the proto.Marshal error - it logs it and continues.
-	err := tw.SendEndorsementResponse(ctx, uuid.New().String(), uuid.New().String(), contractAddress, nil, &components.EndorsementResult{}, "", "att1", "party", "node")
-	require.NoError(t, err)
+	err := tw.SendEndorsementResponse(ctx, "node", &engineProto.EndorsementResponse{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendEndorsementRejection Tests =====
 
@@ -1343,7 +1511,7 @@ func TestSendEndorsementRejection_Success(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementRejection(ctx, transactionId, idempotencyKey, contractAddress, endorsementName, party, node, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance)
+	err := tw.SendEndorsementRejection(ctx, node, testEndorsementRejectionMsg(transactionId, idempotencyKey, contractAddress, endorsementName, party, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, coordinatorBlockHeight, endorserBlockHeight, blockHeightTolerance))
 	require.NoError(t, err)
 }
 
@@ -1363,7 +1531,7 @@ func TestSendEndorsementRejection_SendError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementRejection(ctx, uuid.New().String(), uuid.New().String(), contractAddress, "att1", "party1@node2", "node2", engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 95, 10)
+	err := tw.SendEndorsementRejection(ctx, "node2", testEndorsementRejectionMsg(uuid.New().String(), uuid.New().String(), contractAddress, "att1", "party1@node2", engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 95, 10))
 	require.NoError(t, err)
 }
 
@@ -1386,11 +1554,10 @@ func TestSendEndorsementRejection_ProtoMarshalError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementRejection(ctx, uuid.New().String(), uuid.New().String(), contractAddress, "att", "party@node", "node", engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 90, 10)
+	err := tw.SendEndorsementRejection(ctx, "node", &engineProto.EndorsementRejection{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendEndorsementError Tests =====
 
@@ -1433,7 +1600,7 @@ func TestSendEndorsementError_Success(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementError(ctx, transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName, node)
+	err := tw.SendEndorsementError(ctx, node, testEndorsementErrorMsg(transactionId, idempotencyKey, contractAddress, errorMessage, party, attestationRequestName))
 	require.NoError(t, err)
 }
 
@@ -1453,7 +1620,7 @@ func TestSendEndorsementError_SendError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementError(ctx, uuid.New().String(), uuid.New().String(), contractAddress, "some error", "party1@node2", "att1", "node2")
+	err := tw.SendEndorsementError(ctx, "node2", testEndorsementErrorMsg(uuid.New().String(), uuid.New().String(), contractAddress, "some error", "party1@node2", "att1"))
 	require.NoError(t, err)
 }
 
@@ -1476,11 +1643,10 @@ func TestSendEndorsementError_ProtoMarshalError(t *testing.T) {
 		contractAddress:   pldtypes.MustEthAddress(contractAddress),
 	}
 
-	err := tw.SendEndorsementError(ctx, uuid.New().String(), uuid.New().String(), contractAddress, "err", "party@node", "att", "node")
+	err := tw.SendEndorsementError(ctx, "node", &engineProto.EndorsementError{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendAssembleRequest Tests =====
 
@@ -1541,7 +1707,9 @@ func TestSendAssembleRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight, time.Time{}, 0)
+	assembleMsg, err := testAssembleRequestMsg(txID, idempotencyId, contractAddress, preAssembly, stateLocks, blockHeight, time.Time{}, 0)
+	require.NoError(t, err)
+	err = tw.SendAssembleRequest(ctx, assemblingNode, assembleMsg)
 	require.NoError(t, err)
 }
 
@@ -1578,7 +1746,9 @@ func TestSendAssembleRequest_SerialisesExpiryTimeIntoProto(t *testing.T) {
 		loopbackTransport: mockLoopbackTransport,
 		contractAddress:   contractAddress,
 	}
-	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight, expiry, 0)
+	assembleMsg, err := testAssembleRequestMsg(txID, idempotencyId, contractAddress, preAssembly, stateLocks, blockHeight, expiry, 0)
+	require.NoError(t, err)
+	err = tw.SendAssembleRequest(ctx, assemblingNode, assembleMsg)
 	require.NoError(t, err)
 	assert.Equal(t, expiry.UnixMilli(), capturedExpiry, "ExpiryTimeUnixMs should match expiry.UnixMilli()")
 }
@@ -1612,77 +1782,15 @@ func TestSendAssembleRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRequest(ctx, assemblingNode, txID, idempotencyId, preAssembly, stateLocks, blockHeight, time.Time{}, 0)
+	assembleMsg, err := testAssembleRequestMsg(txID, idempotencyId, contractAddress, preAssembly, stateLocks, blockHeight, time.Time{}, 0)
 	require.NoError(t, err)
-}
-
-func TestSendAssembleRequest_PreAssemblyJSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
-
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(_ any) ([]byte, error) { return nil, errors.New("forced JSON error") }
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	preAssembly := &components.TransactionPreAssembly{
-		TransactionSpecification: &prototk.TransactionSpecification{TransactionId: txID.String()},
-	}
-	err := tw.SendAssembleRequest(ctx, "node", txID, uuid.New(), preAssembly, grapher.ExportableStates{}, 0, time.Time{}, 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error")
-}
-
-func TestSendAssembleRequest_StateLocksJSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
-
-	callCount := 0
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(v any) ([]byte, error) {
-		callCount++
-		if callCount == 1 {
-			return json.Marshal(v) // first call (preAssembly) succeeds
-		}
-		return nil, errors.New("forced JSON error on stateLocks")
-	}
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	preAssembly := &components.TransactionPreAssembly{
-		TransactionSpecification: &prototk.TransactionSpecification{TransactionId: txID.String()},
-	}
-	err := tw.SendAssembleRequest(ctx, "node", txID, uuid.New(), preAssembly, grapher.ExportableStates{}, 0, time.Time{}, 0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error on stateLocks")
+	err = tw.SendAssembleRequest(ctx, assemblingNode, assembleMsg)
+	require.NoError(t, err)
 }
 
 func TestSendAssembleRequest_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -1699,14 +1807,10 @@ func TestSendAssembleRequest_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	preAssembly := &components.TransactionPreAssembly{
-		TransactionSpecification: &prototk.TransactionSpecification{TransactionId: txID.String()},
-	}
-	err := tw.SendAssembleRequest(ctx, "node", txID, uuid.New(), preAssembly, grapher.ExportableStates{}, 0, time.Time{}, 0)
+	err := tw.SendAssembleRequest(ctx, "node", &engineProto.AssembleRequest{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendAssembleResponse Tests =====
 
@@ -1765,7 +1869,9 @@ func TestSendAssembleResponse_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleResponse(ctx, txID, assembleRequestId, postAssembly, preAssembly, recipient)
+	assembleResponseMsg, err := testAssembleResponseMsg(txID, assembleRequestId, contractAddress, postAssembly, preAssembly)
+	require.NoError(t, err)
+	err = tw.SendAssembleResponse(ctx, recipient, assembleResponseMsg)
 	require.NoError(t, err)
 }
 
@@ -1798,71 +1904,15 @@ func TestSendAssembleResponse_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleResponse(ctx, txID, assembleRequestId, postAssembly, preAssembly, recipient)
+	assembleResponseMsg, err := testAssembleResponseMsg(txID, assembleRequestId, contractAddress, postAssembly, preAssembly)
 	require.NoError(t, err)
-}
-
-func TestSendAssembleResponse_PostAssemblyJSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
-
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(_ any) ([]byte, error) { return nil, errors.New("forced JSON error") }
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	err := tw.SendAssembleResponse(ctx, txID, uuid.New(), &components.TransactionPostAssembly{}, &components.TransactionPreAssembly{}, "recipient")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error")
-}
-
-func TestSendAssembleResponse_PreAssemblyJSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
-
-	callCount := 0
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(v any) ([]byte, error) {
-		callCount++
-		if callCount == 1 {
-			return json.Marshal(v) // first call (postAssembly) succeeds
-		}
-		return nil, errors.New("forced JSON error on preAssembly")
-	}
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	err := tw.SendAssembleResponse(ctx, txID, uuid.New(), &components.TransactionPostAssembly{}, &components.TransactionPreAssembly{}, "recipient")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error on preAssembly")
+	err = tw.SendAssembleResponse(ctx, recipient, assembleResponseMsg)
+	require.NoError(t, err)
 }
 
 func TestSendAssembleResponse_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -1879,11 +1929,10 @@ func TestSendAssembleResponse_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleResponse(ctx, txID, uuid.New(), &components.TransactionPostAssembly{}, &components.TransactionPreAssembly{}, "recipient")
+	err := tw.SendAssembleResponse(ctx, "recipient", &engineProto.AssembleResponse{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendAssembleError Tests =====
 
@@ -1932,7 +1981,7 @@ func TestSendAssembleError_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleError(ctx, txID, assembleRequestId, recipient)
+	err := tw.SendAssembleError(ctx, recipient, testAssembleErrorMsg(txID, assembleRequestId, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -1956,7 +2005,7 @@ func TestSendAssembleError_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleError(ctx, txID, assembleRequestId, recipient)
+	err := tw.SendAssembleError(ctx, recipient, testAssembleErrorMsg(txID, assembleRequestId, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -1981,7 +2030,7 @@ func TestSendAssembleError_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleError(ctx, txID, assembleRequestId, recipient)
+	err := tw.SendAssembleError(ctx, recipient, testAssembleErrorMsg(txID, assembleRequestId, contractAddress))
 	require.NoError(t, err)
 
 	select {
@@ -2019,11 +2068,10 @@ func TestSendAssembleError_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleError(ctx, uuid.New(), uuid.New(), "recipient-node")
+	err := tw.SendAssembleError(ctx, "recipient-node", &engineProto.AssembleError{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendAssembleRejection Tests =====
 
@@ -2066,7 +2114,7 @@ func TestSendAssembleRejection_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRejection(ctx, txID, assembleRequestId, recipient, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, coordinatorBlockHeight, assemblerBlockHeight)
+	err := tw.SendAssembleRejection(ctx, recipient, testAssembleRejectionMsg(txID, assembleRequestId, contractAddress, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, coordinatorBlockHeight, assemblerBlockHeight))
 	require.NoError(t, err)
 }
 
@@ -2090,7 +2138,7 @@ func TestSendAssembleRejection_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRejection(ctx, txID, assembleRequestId, recipient, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 95)
+	err := tw.SendAssembleRejection(ctx, recipient, testAssembleRejectionMsg(txID, assembleRequestId, contractAddress, engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 95))
 	require.NoError(t, err)
 }
 
@@ -2113,11 +2161,10 @@ func TestSendAssembleRejection_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendAssembleRejection(ctx, uuid.New(), uuid.New(), "recipient-node", engineProto.RejectionReason_BLOCK_HEIGHT_TOLERANCE, 100, 90)
+	err := tw.SendAssembleRejection(ctx, "recipient-node", &engineProto.AssembleRejection{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendNonceAssigned Tests =====
 
@@ -2168,14 +2215,14 @@ func TestSendNonceAssigned_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendNonceAssigned(ctx, txID, originatorNode, contractAddress, nonce)
+	err := tw.SendNonceAssigned(ctx, originatorNode, testNonceAssignedMsg(txID, contractAddress, nonce))
 	require.NoError(t, err)
 }
 
-func TestSendNonceAssigned_NilContractAddress(t *testing.T) {
+func TestSendNonceAssigned_EmptyNode(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
-	originatorNode := "originator-node"
+	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 	nonce := uint64(42)
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
@@ -2185,12 +2232,11 @@ func TestSendNonceAssigned_NilContractAddress(t *testing.T) {
 		nodeID:            "local-node",
 		transportManager:  mockTransportManager,
 		loopbackTransport: mockLoopbackTransport,
-		contractAddress:   nil,
+		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendNonceAssigned(ctx, txID, originatorNode, nil, nonce)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "contract address")
+	err := tw.SendNonceAssigned(ctx, "", testNonceAssignedMsg(txID, contractAddress, nonce))
+	require.NoError(t, err)
 	mockTransportManager.AssertNotCalled(t, "Send")
 }
 
@@ -2213,7 +2259,7 @@ func TestSendNonceAssigned_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendNonceAssigned(ctx, txID, originatorNode, contractAddress, nonce)
+	err := tw.SendNonceAssigned(ctx, originatorNode, testNonceAssignedMsg(txID, contractAddress, nonce))
 	require.NoError(t, err)
 }
 
@@ -2241,7 +2287,7 @@ func TestSendNonceAssigned_VerifyGeneratedId(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendNonceAssigned(ctx, txID, originatorNode, contractAddress, nonce)
+	err := tw.SendNonceAssigned(ctx, originatorNode, testNonceAssignedMsg(txID, contractAddress, nonce))
 	require.NoError(t, err)
 
 	var nonceAssigned engineProto.NonceAssigned
@@ -2265,7 +2311,6 @@ func TestSendNonceAssigned_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -2275,11 +2320,10 @@ func TestSendNonceAssigned_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	// SendNonceAssigned logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendNonceAssigned(ctx, uuid.New(), "originator-node", contractAddress, 42)
-	require.NoError(t, err)
+	err := tw.SendNonceAssigned(ctx, "originator-node", &engineProto.NonceAssigned{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendTransactionConfirmed Tests =====
 
@@ -2335,7 +2379,7 @@ func TestSendTransactionConfirmed_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
 	require.NoError(t, err)
 }
 
@@ -2369,14 +2413,14 @@ func TestSendTransactionConfirmed_WithoutNonce(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nil, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nil, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
 	require.NoError(t, err)
 }
 
-func TestSendTransactionConfirmed_NilContractAddress(t *testing.T) {
+func TestSendTransactionConfirmed_EmptyNode(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
-	originatorNode := "originator-node"
+	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 	nonceVal := pldtypes.HexUint64(42)
 	nonce := &nonceVal
 	revertReason := pldtypes.HexBytes([]byte("revert reason"))
@@ -2388,12 +2432,11 @@ func TestSendTransactionConfirmed_NilContractAddress(t *testing.T) {
 		nodeID:            "local-node",
 		transportManager:  mockTransportManager,
 		loopbackTransport: mockLoopbackTransport,
-		contractAddress:   nil,
+		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, nil, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "contract address")
+	err := tw.SendTransactionConfirmed(ctx, "", testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
+	require.NoError(t, err)
 	mockTransportManager.AssertNotCalled(t, "Send")
 }
 
@@ -2418,7 +2461,7 @@ func TestSendTransactionConfirmed_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
 	require.NoError(t, err)
 }
 
@@ -2445,7 +2488,7 @@ func TestSendTransactionConfirmed_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", true)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", true))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -2505,7 +2548,7 @@ func TestSendTransactionConfirmed_WillRetryTrue(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", true)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", true))
 	require.NoError(t, err)
 }
 
@@ -2540,7 +2583,7 @@ func TestSendTransactionConfirmed_WillRetryFalse(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
 	require.NoError(t, err)
 }
 
@@ -2580,7 +2623,7 @@ func TestSendTransactionConfirmed_NilRevertReason(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_SUCCESS, nil, "", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_SUCCESS, nil, "", false))
 	require.NoError(t, err)
 }
 
@@ -2607,7 +2650,7 @@ func TestSendTransactionConfirmed_Loopback_WillRetryFalse(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendTransactionConfirmed(ctx, txID, originatorNode, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false)
+	err := tw.SendTransactionConfirmed(ctx, originatorNode, testTransactionConfirmedMsg(txID, contractAddress, nonce, engineProto.TransactionConfirmed_OUTCOME_REVERTED, revertReason, "decoded failure", false))
 	require.NoError(t, err)
 
 	select {
@@ -2626,7 +2669,6 @@ func TestSendTransactionConfirmed_Loopback_WillRetryFalse(t *testing.T) {
 func TestSendTransactionConfirmed_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	nonceVal := pldtypes.HexUint64(42)
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -2635,7 +2677,6 @@ func TestSendTransactionConfirmed_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -2645,11 +2686,10 @@ func TestSendTransactionConfirmed_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	// SendTransactionConfirmed logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendTransactionConfirmed(ctx, uuid.New(), "originator-node", contractAddress, &nonceVal, engineProto.TransactionConfirmed_OUTCOME_SUCCESS, nil, "", false)
-	require.NoError(t, err)
+	err := tw.SendTransactionConfirmed(ctx, "originator-node", &engineProto.TransactionConfirmed{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendHeartbeat Tests =====
 
@@ -2711,7 +2751,9 @@ func TestSendHeartbeat_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHeartbeat(ctx, targetNode, contractAddress, coordinatorSnapshot)
+	heartbeatMsg, err := testHeartbeatMsg("local-node", contractAddress, coordinatorSnapshot)
+	require.NoError(t, err)
+	err = tw.SendHeartbeat(ctx, targetNode, heartbeatMsg)
 	require.NoError(t, err)
 }
 
@@ -2736,7 +2778,9 @@ func TestSendHeartbeat_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHeartbeat(ctx, targetNode, contractAddress, coordinatorSnapshot)
+	heartbeatMsg, err := testHeartbeatMsg("local-node", contractAddress, coordinatorSnapshot)
+	require.NoError(t, err)
+	err = tw.SendHeartbeat(ctx, targetNode, heartbeatMsg)
 	require.NoError(t, err)
 }
 
@@ -2763,7 +2807,9 @@ func TestSendHeartbeat_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHeartbeat(ctx, targetNode, contractAddress, coordinatorSnapshot)
+	heartbeatMsg, err := testHeartbeatMsg("local-node", contractAddress, coordinatorSnapshot)
+	require.NoError(t, err)
+	err = tw.SendHeartbeat(ctx, targetNode, heartbeatMsg)
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -2781,30 +2827,6 @@ func TestSendHeartbeat_Loopback(t *testing.T) {
 		t.Fatal("Expected message in loopback queue")
 	}
 
-}
-
-func TestSendHeartbeat_JSONMarshalError(t *testing.T) {
-	ctx := context.Background()
-	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-
-	orig := jsonMarshalFn
-	jsonMarshalFn = func(_ any) ([]byte, error) { return nil, errors.New("forced JSON error") }
-	defer func() { jsonMarshalFn = orig }()
-
-	mockTM := componentsmocks.NewTransportManager(t)
-	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
-
-	tw := &transportWriter{
-		ctx:               ctx,
-		nodeID:            "local-node",
-		transportManager:  mockTM,
-		loopbackTransport: mockLT,
-		contractAddress:   contractAddress,
-	}
-
-	err := tw.SendHeartbeat(ctx, "target-node", contractAddress, &common.CoordinatorSnapshot{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "forced JSON error")
 }
 
 func TestSendHeartbeat_ProtoMarshalError(t *testing.T) {
@@ -2827,11 +2849,10 @@ func TestSendHeartbeat_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendHeartbeat(ctx, "target-node", contractAddress, &common.CoordinatorSnapshot{})
+	err := tw.SendHeartbeat(ctx, "target-node", &engineProto.CoordinatorHeartbeatNotification{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendPreDispatchRequest Tests =====
 
@@ -2887,7 +2908,7 @@ func TestSendPreDispatchRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, idempotencyKey, transactionSpecification, hash)
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
 	require.NoError(t, err)
 }
 
@@ -2915,7 +2936,7 @@ func TestSendPreDispatchRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, idempotencyKey, transactionSpecification, hash)
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
 	require.NoError(t, err)
 }
 
@@ -2945,7 +2966,7 @@ func TestSendPreDispatchRequest_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, idempotencyKey, transactionSpecification, hash)
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -2970,8 +2991,6 @@ func TestSendPreDispatchRequest_Loopback(t *testing.T) {
 func TestSendPreDispatchRequest_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
-	hashVal := pldtypes.MustParseBytes32("0x00000000000000000000000000000000000000000000000000000000000000ab")
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -2980,7 +2999,6 @@ func TestSendPreDispatchRequest_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -2990,12 +3008,10 @@ func TestSendPreDispatchRequest_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	txSpec := &prototk.TransactionSpecification{TransactionId: txID.String()}
-	// SendPreDispatchRequest logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendPreDispatchRequest(ctx, "originator-node", uuid.New(), txSpec, &hashVal)
-	require.NoError(t, err)
+	err := tw.SendPreDispatchRequest(ctx, "originator-node", &engineProto.PreDispatchRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendPreDispatchResponse Tests =====
 
@@ -3046,7 +3062,7 @@ func TestSendPreDispatchResponse_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, idempotencyKey, transactionSpecification)
+	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, testPreDispatchResponseMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -3072,7 +3088,7 @@ func TestSendPreDispatchResponse_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, idempotencyKey, transactionSpecification)
+	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, testPreDispatchResponseMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -3100,7 +3116,7 @@ func TestSendPreDispatchResponse_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, idempotencyKey, transactionSpecification)
+	err := tw.SendPreDispatchResponse(ctx, transactionOriginatorNode, testPreDispatchResponseMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -3124,7 +3140,6 @@ func TestSendPreDispatchResponse_Loopback(t *testing.T) {
 func TestSendPreDispatchResponse_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -3133,7 +3148,6 @@ func TestSendPreDispatchResponse_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -3143,12 +3157,10 @@ func TestSendPreDispatchResponse_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	txSpec := &prototk.TransactionSpecification{TransactionId: txID.String()}
-	// SendPreDispatchResponse logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendPreDispatchResponse(ctx, "originator-node", uuid.New(), txSpec)
-	require.NoError(t, err)
+	err := tw.SendPreDispatchResponse(ctx, "originator-node", &engineProto.PreDispatchResponse{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendDispatched Tests =====
 
@@ -3202,13 +3214,13 @@ func TestSendDispatched_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDispatched(ctx, transactionOriginator, idempotencyKey, transactionSpecification)
+	err := tw.SendDispatched(ctx, "originator-node", testDispatchedMsg(idempotencyKey, transactionSpecification, contractAddress, transactionOriginator))
 	require.NoError(t, err)
 }
 
-func TestSendDispatched_NodeLookupError(t *testing.T) {
+func TestSendDispatched_EmptyNode(t *testing.T) {
 	ctx := context.Background()
-	transactionOriginator := "invalid-originator" // No @node, will fail Node lookup
+	transactionOriginator := "originator@originator-node"
 	idempotencyKey := uuid.New()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 	txID := uuid.New()
@@ -3226,8 +3238,8 @@ func TestSendDispatched_NodeLookupError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDispatched(ctx, transactionOriginator, idempotencyKey, transactionSpecification)
-	require.Error(t, err)
+	err := tw.SendDispatched(ctx, "", testDispatchedMsg(idempotencyKey, transactionSpecification, contractAddress, transactionOriginator))
+	require.NoError(t, err)
 	mockTransportManager.AssertNotCalled(t, "Send")
 }
 
@@ -3253,7 +3265,7 @@ func TestSendDispatched_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDispatched(ctx, transactionOriginator, idempotencyKey, transactionSpecification)
+	err := tw.SendDispatched(ctx, "originator-node", testDispatchedMsg(idempotencyKey, transactionSpecification, contractAddress, transactionOriginator))
 	require.NoError(t, err)
 }
 
@@ -3281,7 +3293,7 @@ func TestSendDispatched_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDispatched(ctx, transactionOriginator, idempotencyKey, transactionSpecification)
+	err := tw.SendDispatched(ctx, "local-node", testDispatchedMsg(idempotencyKey, transactionSpecification, contractAddress, transactionOriginator))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -3306,7 +3318,6 @@ func TestSendDispatched_Loopback(t *testing.T) {
 func TestSendDispatched_ProtoMarshalError(t *testing.T) {
 	ctx := context.Background()
 	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
-	txID := uuid.New()
 
 	orig := protoMarshalFn
 	protoMarshalFn = func(_ proto.Message) ([]byte, error) { return nil, errors.New("forced proto error") }
@@ -3315,7 +3326,6 @@ func TestSendDispatched_ProtoMarshalError(t *testing.T) {
 	mockTM := componentsmocks.NewTransportManager(t)
 	mockLT := sequencertransportmocks.NewLoopbackTransportManager(t)
 	mockTM.On("LocalNodeName").Return("local-node").Maybe()
-	mockTM.On("Send", ctx, mock.Anything).Return(nil)
 
 	tw := &transportWriter{
 		ctx:               ctx,
@@ -3325,12 +3335,10 @@ func TestSendDispatched_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	txSpec := &prototk.TransactionSpecification{TransactionId: txID.String()}
-	// SendDispatched logs but does NOT return the proto.Marshal error; it continues.
-	err := tw.SendDispatched(ctx, "originator@originator-node", uuid.New(), txSpec)
-	require.NoError(t, err)
+	err := tw.SendDispatched(ctx, "originator-node", &engineProto.TransactionDispatched{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced proto error")
 }
-
 
 // ===== SendPreDispatchRejection Tests =====
 
@@ -3369,15 +3377,15 @@ func TestSendPreDispatchRejection_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRejection(ctx, txID, requestID, coordinatorNode, engineProto.RejectionReason_NOT_CURRENT_DELEGATE)
+	err := tw.SendPreDispatchRejection(ctx, coordinatorNode, testPreDispatchRejectionMsg(txID, requestID, contractAddress, engineProto.RejectionReason_NOT_CURRENT_DELEGATE))
 	require.NoError(t, err)
 }
 
-func TestSendPreDispatchRejection_NilContractAddress(t *testing.T) {
+func TestSendPreDispatchRejection_EmptyNode(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
 	requestID := uuid.New()
-	coordinatorNode := "coordinator-node"
+	contractAddress := pldtypes.MustEthAddress("0x1234567890123456789012345678901234567890")
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
@@ -3387,12 +3395,12 @@ func TestSendPreDispatchRejection_NilContractAddress(t *testing.T) {
 		nodeID:            "local-node",
 		transportManager:  mockTransportManager,
 		loopbackTransport: mockLoopbackTransport,
-		contractAddress:   nil,
+		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRejection(ctx, txID, requestID, coordinatorNode, engineProto.RejectionReason_NOT_CURRENT_DELEGATE)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "attempt to send pre-dispatch rejection without specifying contract address")
+	err := tw.SendPreDispatchRejection(ctx, "", testPreDispatchRejectionMsg(txID, requestID, contractAddress, engineProto.RejectionReason_NOT_CURRENT_DELEGATE))
+	require.NoError(t, err)
+	mockTransportManager.AssertNotCalled(t, "Send")
 }
 
 func TestSendPreDispatchRejection_SendError(t *testing.T) {
@@ -3414,7 +3422,7 @@ func TestSendPreDispatchRejection_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRejection(ctx, txID, requestID, coordinatorNode, engineProto.RejectionReason_TRANSACTION_UNKNOWN)
+	err := tw.SendPreDispatchRejection(ctx, coordinatorNode, testPreDispatchRejectionMsg(txID, requestID, contractAddress, engineProto.RejectionReason_TRANSACTION_UNKNOWN))
 	require.NoError(t, err)
 }
 
@@ -3437,8 +3445,7 @@ func TestSendPreDispatchRejection_ProtoMarshalError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRejection(ctx, uuid.New(), uuid.New(), "coordinator-node", engineProto.RejectionReason_NOT_CURRENT_DELEGATE)
+	err := tw.SendPreDispatchRejection(ctx, "coordinator-node", &engineProto.PreDispatchRejection{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forced proto error")
 }
-

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -89,7 +89,7 @@ func (sMgr *sequencerManager) HandlePaladinMsg(ctx context.Context, message *com
 }
 
 func (sMgr *sequencerManager) logPaladinMessageUnmarshalError(ctx context.Context, message *components.ReceivedMessage, err error) {
-	log.L(ctx).Errorf("<< ERROR unmarshalling proto message%s from %s: %s", message.MessageType, message.FromNode, err)
+	log.L(ctx).Errorf("<< ERROR unmarshalling proto message %s from %s: %s", message.MessageType, message.FromNode, err)
 }
 
 func (sMgr *sequencerManager) logPaladinMessageFieldMissingError(ctx context.Context, message *components.ReceivedMessage, field string) {

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -342,7 +342,7 @@ func (sMgr *sequencerManager) handlePreDispatchRequest(ctx context.Context, mess
 		Coordinator:      message.FromNode,
 		PostAssemblyHash: &postAssemblyHash,
 	}
-	preDispatchRequestReceivedEvent.TransactionID = uuid.MustParse(preDispatchRequest.TransactionId[2:34])
+	preDispatchRequestReceivedEvent.TransactionID = uuid.MustParse(preDispatchRequest.TransactionId)
 	preDispatchRequestReceivedEvent.EventTime = time.Now()
 
 	// TODO - not sure where we should make the decision as to whether or not to approve dispatch.
@@ -379,7 +379,7 @@ func (sMgr *sequencerManager) handlePreDispatchResponse(ctx context.Context, mes
 	dispatchRequestApprovedEvent := &coordTransaction.DispatchRequestApprovedEvent{
 		RequestID: uuid.MustParse(preDispatchResponse.Id),
 	}
-	dispatchRequestApprovedEvent.TransactionID = uuid.MustParse(preDispatchResponse.TransactionId[2:34])
+	dispatchRequestApprovedEvent.TransactionID = uuid.MustParse(preDispatchResponse.TransactionId)
 	dispatchRequestApprovedEvent.EventTime = time.Now()
 	seq.GetCoordinator().QueueEvent(ctx, dispatchRequestApprovedEvent)
 }
@@ -407,7 +407,7 @@ func (sMgr *sequencerManager) handleDispatchedEvent(ctx context.Context, message
 	}
 
 	dispatchConfirmedEvent := &originatorTransaction.DispatchedEvent{}
-	dispatchConfirmedEvent.TransactionID = uuid.MustParse(dispatchedEvent.TransactionId[2:34])
+	dispatchConfirmedEvent.TransactionID = uuid.MustParse(dispatchedEvent.TransactionId)
 	dispatchConfirmedEvent.Coordinator = message.FromNode
 	dispatchConfirmedEvent.EventTime = time.Now()
 

--- a/core/go/internal/sequencer/transport_client_test.go
+++ b/core/go/internal/sequencer/transport_client_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -719,12 +718,8 @@ func TestHandleDispatchedEvent_Success(t *testing.T) {
 	contractAddr := pldtypes.RandAddress()
 
 	txID := uuid.New()
-	// TransactionId format is "0x" + 32 hex characters (16 bytes)
-	// UUID is 16 bytes, convert to hex without dashes
-	txIDBytes := [16]byte(txID)
-	txIDHex := "0x" + fmt.Sprintf("%032x", txIDBytes)
 	dispatchedEvent := &engineProto.TransactionDispatched{
-		TransactionId:   txIDHex,
+		TransactionId:   txID.String(),
 		ContractAddress: contractAddr.String(),
 	}
 	payload, _ := proto.Marshal(dispatchedEvent)
@@ -742,8 +737,7 @@ func TestHandleDispatchedEvent_Success(t *testing.T) {
 
 	mocks.originator.EXPECT().QueueEvent(ctx, mock.MatchedBy(func(e interface{}) bool {
 		event, ok := e.(*originatorTransaction.DispatchedEvent)
-		// Note: TransactionID parsing from hex string may not match exactly due to format conversion
-		return ok && event.TransactionID != uuid.Nil
+		return ok && event.TransactionID == txID
 	})).Once()
 
 	sm.handleDispatchedEvent(ctx, message)
@@ -847,13 +841,10 @@ func TestHandlePreDispatchRequest_Success(t *testing.T) {
 	txID := uuid.New()
 	requestID := uuid.New()
 	hash := pldtypes.RandBytes32()
-	// TransactionId format is "0x" + 32 hex characters (16 bytes)
-	txIDBytes := [16]byte(txID)
-	txIDHex := "0x" + fmt.Sprintf("%032x", txIDBytes)
 
 	preDispatchRequest := &engineProto.PreDispatchRequest{
 		Id:               requestID.String(),
-		TransactionId:    txIDHex,
+		TransactionId:    txID.String(),
 		ContractAddress:  contractAddr.String(),
 		PostAssembleHash: hash[:],
 	}
@@ -888,13 +879,10 @@ func TestHandlePreDispatchResponse_Success(t *testing.T) {
 
 	txID := uuid.New()
 	requestID := uuid.New()
-	// TransactionId format is "0x" + 32 hex characters (16 bytes)
-	txIDBytes := [16]byte(txID)
-	txIDHex := "0x" + fmt.Sprintf("%032x", txIDBytes)
 
 	preDispatchResponse := &engineProto.PreDispatchResponse{
 		Id:              requestID.String(),
-		TransactionId:   txIDHex,
+		TransactionId:   txID.String(),
 		ContractAddress: contractAddr.String(),
 	}
 	payload, _ := proto.Marshal(preDispatchResponse)
@@ -2392,7 +2380,7 @@ func TestHandlePreDispatchRequest_InvalidContractAddress(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	payload, _ := proto.Marshal(&engineProto.PreDispatchRequest{ContractAddress: "invalid", Id: uuid.New().String(), TransactionId: "0x00000000000000000000000000000001"})
+	payload, _ := proto.Marshal(&engineProto.PreDispatchRequest{ContractAddress: "invalid", Id: uuid.New().String(), TransactionId: uuid.New().String()})
 	sm.handlePreDispatchRequest(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_PreDispatchRequest, Payload: payload})
 }
 
@@ -2401,7 +2389,7 @@ func TestHandlePreDispatchRequest_SequencerNotLoaded(t *testing.T) {
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
 	contractAddr := pldtypes.RandAddress()
-	payload, _ := proto.Marshal(&engineProto.PreDispatchRequest{ContractAddress: contractAddr.String(), Id: uuid.New().String(), TransactionId: "0x00000000000000000000000000000001"})
+	payload, _ := proto.Marshal(&engineProto.PreDispatchRequest{ContractAddress: contractAddr.String(), Id: uuid.New().String(), TransactionId: uuid.New().String()})
 	sm.handlePreDispatchRequest(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_PreDispatchRequest, Payload: payload})
 }
 
@@ -2409,7 +2397,7 @@ func TestHandlePreDispatchResponse_InvalidContractAddress(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	payload, _ := proto.Marshal(&engineProto.PreDispatchResponse{ContractAddress: "invalid", Id: uuid.New().String(), TransactionId: "0x00000000000000000000000000000001"})
+	payload, _ := proto.Marshal(&engineProto.PreDispatchResponse{ContractAddress: "invalid", Id: uuid.New().String(), TransactionId: uuid.New().String()})
 	sm.handlePreDispatchResponse(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_PreDispatchResponse, Payload: payload})
 }
 
@@ -2418,7 +2406,7 @@ func TestHandlePreDispatchResponse_SequencerNotLoaded(t *testing.T) {
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
 	contractAddr := pldtypes.RandAddress()
-	payload, _ := proto.Marshal(&engineProto.PreDispatchResponse{ContractAddress: contractAddr.String(), Id: uuid.New().String(), TransactionId: "0x00000000000000000000000000000001"})
+	payload, _ := proto.Marshal(&engineProto.PreDispatchResponse{ContractAddress: contractAddr.String(), Id: uuid.New().String(), TransactionId: uuid.New().String()})
 	sm.handlePreDispatchResponse(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_PreDispatchResponse, Payload: payload})
 }
 
@@ -2426,7 +2414,7 @@ func TestHandleDispatchedEvent_InvalidContractAddress(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	payload, _ := proto.Marshal(&engineProto.TransactionDispatched{ContractAddress: "invalid", TransactionId: "0x00000000000000000000000000000001"})
+	payload, _ := proto.Marshal(&engineProto.TransactionDispatched{ContractAddress: "invalid", TransactionId: uuid.New().String()})
 	sm.handleDispatchedEvent(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_Dispatched, Payload: payload})
 }
 

--- a/core/go/internal/transportmgr/transport_test.go
+++ b/core/go/internal/transportmgr/transport_test.go
@@ -119,7 +119,7 @@ func testMessage() *components.FireAndForgetMessageSend {
 	return &components.FireAndForgetMessageSend{
 		Node:          "node2",
 		CorrelationID: confutil.P(uuid.New()),
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("something"),
 	}
 }
@@ -330,7 +330,7 @@ func TestReceiveMessageTransactionEngine(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P(uuid.NewString()),
 		Component:     prototk.PaladinMsg_TRANSACTION_ENGINE,
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 
@@ -358,7 +358,7 @@ func TestReceiveMessageIdentityResolver(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P(uuid.NewString()),
 		Component:     prototk.PaladinMsg_IDENTITY_RESOLVER,
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 
@@ -380,7 +380,7 @@ func TestReceiveMessageInvalidComponent(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P(uuid.NewString()),
 		Component:     prototk.PaladinMsg_Component(42),
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 
@@ -399,7 +399,7 @@ func TestReceiveMessageInvalidNode(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P(uuid.NewString()),
 		Component:     prototk.PaladinMsg_Component(42),
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 
@@ -420,7 +420,7 @@ func TestReceiveMessageNotInit(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P(uuid.NewString()),
 		Component:     prototk.PaladinMsg_TRANSACTION_ENGINE,
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 	_, err := tp.t.ReceiveMessage(ctx, &prototk.ReceiveMessageRequest{
@@ -447,7 +447,7 @@ func TestReceiveMessageBadDestination(t *testing.T) {
 	msg := &prototk.PaladinMsg{
 		MessageId:   uuid.NewString(),
 		Component:   prototk.PaladinMsg_Component(42),
-		MessageType: "myMessageType",
+		MessageType: "test-message-type",
 		Payload:     []byte("some data"),
 	}
 	_, err := tp.t.ReceiveMessage(ctx, &prototk.ReceiveMessageRequest{
@@ -463,7 +463,7 @@ func TestReceiveMessageBadMsgID(t *testing.T) {
 
 	msg := &prototk.PaladinMsg{
 		Component:   prototk.PaladinMsg_TRANSACTION_ENGINE,
-		MessageType: "myMessageType",
+		MessageType: "test-message-type",
 		Payload:     []byte("some data"),
 	}
 	_, err := tp.t.ReceiveMessage(ctx, &prototk.ReceiveMessageRequest{
@@ -480,7 +480,7 @@ func TestReceiveMessageBadCorrelID(t *testing.T) {
 		MessageId:     uuid.NewString(),
 		CorrelationId: confutil.P("wrong"),
 		Component:     prototk.PaladinMsg_TRANSACTION_ENGINE,
-		MessageType:   "myMessageType",
+		MessageType:   "test-message-type",
 		Payload:       []byte("some data"),
 	}
 	_, err := tp.t.ReceiveMessage(ctx, &prototk.ReceiveMessageRequest{

--- a/transports/grpc/internal/grpctransport/grpc_transport.go
+++ b/transports/grpc/internal/grpctransport/grpc_transport.go
@@ -296,7 +296,7 @@ func (t *grpcTransport) SendMessage(ctx context.Context, req *prototk.SendMessag
 		// This is an error in the Paladin layer
 		return nil, i18n.NewError(ctx, msgs.MsgNodeNotActive, req.Node)
 	}
-	log.L(ctx).Infof("GRPC sending message id=%s cid=%v component=%s messageType=%s to peer %s",
+	log.L(ctx).Infof("GRPC sending message id=%s cid=%v component=%d messageType=%s to peer %s",
 		msg.MessageId, msg.CorrelationId, msg.Component, msg.MessageType, req.Node)
 	err := oc.send(&proto.Message{
 		MessageId:     msg.MessageId,


### PR DESCRIPTION
https://github.com/LFDT-Paladin/paladin/issues/948

This issue linked to comments raising three different points
1. The transport writer accepting a flat list of parameters rather than the prototype defining the whole message
2. A golang list of message types rather than a proto enum
3. Protos being defined inside the sequencer and not in the `prototk` package

I have addressed the first of these.

I have opted not to address the second two.

2 - This message type is a string across the transport/messaging packages, and the sequencer is not the only package which provides values for it. Each message has a component value, which is a proto enum, for top level routing, and then a string message type which is specific to the component. This message type could be made to be an int32 so it could be used with proto enums but there is limited value when the value is entirely internal to one component communicating with other instances of itself. I.e. it is not an true external interface. Changing it would impact on identity resolver and reliable messages, with reliable messages in particular using the string as a value that gets persisted in its database.

3. These protos are just ways that sequencers interact with each other. The protos in the toolkit represent component boundaries, specifically those which are pluggable. The PR comment referenced in the issue alluded to the sequencer moving in that direction, but in that case we would be defining the sequencer/transactionmanager interface as new protos. This proto interface is internal to this implementation of the sequencer.

What I did observe is that we have a few types that we serialise into bytes before putting into proto structs - specifically the private transaction, and pre/post assembly within it. There is genuine inconsistency there. But when this is a fully internal interface is there any value in using protos at all over go structs serialised to bytes. This implementation of the sequencer is a golang implementation- we don't need to support it interacting with an equivalent implementation in another language...