### PR TITLE
Missing reset handlers in preassembly blocked

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine.go
@@ -104,14 +104,14 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{
-					{
-						To:  State_Reverted,
-						If:  guard_HasRevertedChainedDependency,
-						Actions: []ActionRule{
-							{Action: action_FinalizeOnRevertedChainedDependencyAtCreation},
-							{Action: action_NotifyOriginatorOfChainedDependencyFailureAtCreation},
+						{
+							To: State_Reverted,
+							If: guard_HasRevertedChainedDependency,
+							Actions: []ActionRule{
+								{Action: action_FinalizeOnRevertedChainedDependencyAtCreation},
+								{Action: action_NotifyOriginatorOfChainedDependencyFailureAtCreation},
+							},
 						},
-					},
 						{
 							To: State_Evicted,
 							If: guard_HasEvictedChainedDependency,
@@ -156,6 +156,25 @@ var stateDefinitionsMap = StateDefinitions{
 							If: statemachine.GuardNot(guard_HasUnassembledDependencies),
 						},
 					},
+				}},
+			},
+			// A chained dependency has reset or been confirmed reverted while this transaction
+			// is still waiting to be assembled
+			Event_DependencyReset: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Validator: validator_IsChainedDependency,
+					Actions:   []ActionRule{{Action: action_MarkChainedDependencyUnassembled}},
+					// No state transition — already in the correct waiting state.
+				}},
+			},
+			Event_DependencyConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Validator: validator_IsChainedDependency,
+					Actions:   []ActionRule{{Action: action_MarkChainedDependencyUnassembled}},
+					// No state transition — ChainedDependencyFailed will follow for non-retryable
+					// reverts and handle the cascade finalization via the existing handler below.
 				}},
 			},
 			// The pre-assemble predecessor reached a terminal state — sever the FIFO link

--- a/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/state_machine_test.go
@@ -138,6 +138,7 @@ func Test_DependencyConfirmedReverted_ChainedDependency_AllStates(t *testing.T) 
 		fromState State
 		toState   State
 	}{
+		{State_PreAssembly_Blocked, State_PreAssembly_Blocked},
 		{State_Pooled, State_PreAssembly_Blocked},
 		{State_Assembling, State_PreAssembly_Blocked},
 		{State_Endorsement_Gathering, State_PreAssembly_Blocked},
@@ -174,6 +175,7 @@ func Test_DependencyReset_ChainedDependency_AllStates(t *testing.T) {
 		fromState State
 		toState   State
 	}{
+		{State_PreAssembly_Blocked, State_PreAssembly_Blocked},
 		{State_Pooled, State_PreAssembly_Blocked},
 		{State_Assembling, State_PreAssembly_Blocked},
 		{State_Endorsement_Gathering, State_PreAssembly_Blocked},
@@ -401,6 +403,47 @@ func TestCoordinatorTransaction_PreAssemblyBlocked_ToPooled_OnPreAssembleDepende
 	require.NoError(t, err)
 	assert.Equal(t, State_Pooled, txn.GetCurrentState())
 }
+
+func TestCoordinatorTransaction_PreAssemblyBlocked_StaysBlocked_OnPreAssembleDependencyTerminated_WhenChainedDepWasReset(t *testing.T) {
+	// A chained dependency that was marked "assembled" in a previous cycle must be
+	// reset to "unassembled" when a DependencyReset arrives in State_PreAssembly_Blocked.
+	ctx := context.Background()
+	depTracker := dependencytracker.NewDependencyTracker()
+	chainedDepID := uuid.New()
+	predecessorID := uuid.New()
+
+	txn, _ := NewTransactionBuilderForTesting(t, State_PreAssembly_Blocked).
+		ChainedDependencies(chainedDepID).
+		DependencyTracker(depTracker).
+		Build()
+	depTracker.GetPreassemblyDeps().AddPrerequisite(ctx, txn.pt.ID, predecessorID)
+
+	// Simulate the chained dependency having been selected for assembly in a previous cycle:
+	// AddPrerequisites records the dependency link
+	depTracker.GetChainedDeps().AddPrerequisites(ctx, txn.pt.ID, chainedDepID)
+	depTracker.GetChainedDeps().DeleteUnassembledDependencies(ctx, txn.pt.ID, chainedDepID)
+	assert.Empty(t, depTracker.GetChainedDeps().GetUnassembledDependencies(ctx, txn.pt.ID))
+
+	// The chained dep resets (e.g. confirmed-reverted and retrying). The handler must
+	// re-mark it as unassembled and leave the transaction in PreAssembly_Blocked.
+	err := txn.HandleEvent(ctx, &DependencyResetEvent{
+		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.GetID()},
+		SourceTransactionID:  chainedDepID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, State_PreAssembly_Blocked, txn.GetCurrentState())
+	assert.Contains(t, depTracker.GetChainedDeps().GetUnassembledDependencies(ctx, txn.pt.ID), chainedDepID)
+
+	// The FIFO pre-assembly prereq terminates. Because the chained dep is unassembled,
+	// guard_HasUnassembledDependencies still returns true and the transaction must NOT
+	// advance to Pooled.
+	err = txn.HandleEvent(ctx, &PreAssembleDependencyTerminatedEvent{
+		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.GetID()},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, State_PreAssembly_Blocked, txn.GetCurrentState())
+}
+
 func TestCoordinatorTransaction_Pooled_ToAssembling_OnSelected(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Preassembly blocked was not handling dependencies being reset as it is already the state that transactions must transition to if their dependencies are reset.

However, a transaction may be in preassembly blocked for both preassembly and and chained dependencies, meaning that if the unassembled status of a chained dependency is not restored, it becomes possible for the transaction to transition to pooled, when its preassembly dependency is selected, and eventually get assembled ahead of its chained dependency. This can result in a circular dependency between transactions A and B, where B has A as a chained dependency, but B has A as a post assemble dependency. In this case neither transaction can be dispatched.