### PR TITLE
Accept no revert data/retry failed finalize

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/confirming.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming.go
@@ -138,23 +138,28 @@ func action_NotifyOriginatorOfChainedDependencyFailure(ctx context.Context, t *c
 func action_FinalizeNonRetryableRevert(ctx context.Context, t *coordinatorTransaction, _ common.Event) error {
 	failureMessage := t.decodedRevertReason
 	log.L(ctx).Infof("finalizing transaction %s as reverted (revertCount=%d): %s", t.pt.ID.String(), t.revertCount, failureMessage)
-	t.syncPoints.QueueTransactionFinalize(ctx,
-		&syncpoints.TransactionFinalizeRequest{
-			Domain:          t.pt.Domain,
-			ContractAddress: pldtypes.EthAddress{},
-			Originator:      t.originator,
-			TransactionID:   t.pt.ID,
-			FailureMessage:  failureMessage,
-			RevertData:      t.revertReason,
-			OnChain:         t.revertOnChain,
-		},
-		func(ctx context.Context) {
-			log.L(ctx).Debugf("finalized non-retryable revert for transaction %s", t.pt.ID)
-		},
-		func(ctx context.Context, err error) {
-			log.L(ctx).Errorf("error finalizing non-retryable revert for transaction %s: %s", t.pt.ID, err)
-		},
-	)
+	var tryFinalize func()
+	tryFinalize = func() {
+		t.syncPoints.QueueTransactionFinalize(ctx,
+			&syncpoints.TransactionFinalizeRequest{
+				Domain:          t.pt.Domain,
+				ContractAddress: pldtypes.EthAddress{},
+				Originator:      t.originator,
+				TransactionID:   t.pt.ID,
+				FailureMessage:  failureMessage,
+				RevertData:      t.revertReason,
+				OnChain:         t.revertOnChain,
+			},
+			func(ctx context.Context) {
+				log.L(ctx).Debugf("finalized non-retryable revert for transaction %s", t.pt.ID)
+			},
+			func(ctx context.Context, err error) {
+				log.L(ctx).Errorf("error finalizing non-retryable revert for transaction %s: %s", t.pt.ID, err)
+				tryFinalize()
+			},
+		)
+	}
+	tryFinalize()
 	return nil
 }
 
@@ -204,21 +209,26 @@ func action_CascadeChainedDependencyFailure(ctx context.Context, t *coordinatorT
 func action_FinalizeOnChainedDependencyFailure(ctx context.Context, t *coordinatorTransaction, event common.Event) error {
 	e := event.(*ChainedDependencyFailedEvent)
 	log.L(ctx).Infof("finalizing TX %s due to chained dependency failure from TX %s", t.pt.ID, e.FailedTxID)
-	t.syncPoints.QueueTransactionFinalize(ctx,
-		&syncpoints.TransactionFinalizeRequest{
-			Domain:          t.pt.Domain,
-			ContractAddress: t.pt.Address,
-			Originator:      t.originator,
-			TransactionID:   t.pt.ID,
-			FailureMessage:  i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, e.FailedTxID).Error(),
-		},
-		func(ctx context.Context) {
-			log.L(ctx).Debugf("finalized TX %s due to chained dependency failure", t.pt.ID)
-		},
-		func(ctx context.Context, err error) {
-			log.L(ctx).Errorf("error finalizing TX %s due to chained dependency failure: %s", t.pt.ID, err)
-		},
-	)
+	var tryFinalize func()
+	tryFinalize = func() {
+		t.syncPoints.QueueTransactionFinalize(ctx,
+			&syncpoints.TransactionFinalizeRequest{
+				Domain:          t.pt.Domain,
+				ContractAddress: t.pt.Address,
+				Originator:      t.originator,
+				TransactionID:   t.pt.ID,
+				FailureMessage:  i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, e.FailedTxID).Error(),
+			},
+			func(ctx context.Context) {
+				log.L(ctx).Debugf("finalized TX %s due to chained dependency failure", t.pt.ID)
+			},
+			func(ctx context.Context, err error) {
+				log.L(ctx).Errorf("error finalizing TX %s due to chained dependency failure: %s", t.pt.ID, err)
+				tryFinalize()
+			},
+		)
+	}
+	tryFinalize()
 	return nil
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_test.go
@@ -592,16 +592,16 @@ func Test_action_FinalizeNonRetryableRevert_OnCommitCallback(t *testing.T) {
 	assert.True(t, onCommitCalled, "onCommit callback should have been invoked")
 }
 
-func Test_action_FinalizeNonRetryableRevert_OnRollbackCallback(t *testing.T) {
+func Test_action_FinalizeNonRetryableRevert_OnRollbackRetry(t *testing.T) {
 	ctx := t.Context()
 	txn, mocks := NewTransactionBuilderForTesting(t, State_Confirmed).
 		RevertCount(2).
 		RevertReason(pldtypes.MustParseHexBytes("0xdeadbeef")).
 		Build()
 
-	rollbackErr := errors.New("finalize failed")
-	onRollbackCalled := false
-	mocks.SyncPoints.EXPECT().QueueTransactionFinalize(
+	callCount := 0
+	maxCalls := 2
+	mocks.SyncPoints.On("QueueTransactionFinalize",
 		mock.Anything,
 		mock.MatchedBy(func(req *syncpoints.TransactionFinalizeRequest) bool {
 			return req.Domain == txn.pt.Domain &&
@@ -609,14 +609,20 @@ func Test_action_FinalizeNonRetryableRevert_OnRollbackCallback(t *testing.T) {
 				req.TransactionID == txn.pt.ID
 		}),
 		mock.Anything, mock.Anything,
-	).Run(func(_ context.Context, _ *syncpoints.TransactionFinalizeRequest, _ func(context.Context), onRollback func(context.Context, error)) {
-		onRollback(ctx, rollbackErr)
-		onRollbackCalled = true
+	).Run(func(args mock.Arguments) {
+		callCount++
+		if callCount < maxCalls {
+			onRollback := args.Get(3).(func(context.Context, error))
+			onRollback(ctx, errors.New("finalize failed"))
+		} else {
+			onCommit := args.Get(2).(func(context.Context))
+			onCommit(ctx)
+		}
 	}).Return()
 
 	err := action_FinalizeNonRetryableRevert(ctx, txn, nil)
 	require.NoError(t, err)
-	assert.True(t, onRollbackCalled, "onRollback callback should have been invoked")
+	assert.Equal(t, maxCalls, callCount)
 }
 
 func Test_action_NotifyDependantsOfRevertedConfirmation_SendsRevertedEvent(t *testing.T) {
@@ -823,9 +829,7 @@ func TestDependsOn_FinalizeOnChainedDependencyFailure(t *testing.T) {
 		mock.Anything,
 	).Run(func(args mock.Arguments) {
 		onCommit := args.Get(2).(func(context.Context))
-		onRollback := args.Get(3).(func(context.Context, error))
 		onCommit(ctx)
-		onRollback(ctx, assert.AnError)
 	}).Return()
 
 	event := &ChainedDependencyFailedEvent{
@@ -834,6 +838,42 @@ func TestDependsOn_FinalizeOnChainedDependencyFailure(t *testing.T) {
 	}
 	err := action_FinalizeOnChainedDependencyFailure(ctx, txn, event)
 	require.NoError(t, err)
+}
+
+func TestDependsOn_FinalizeOnChainedDependencyFailure_OnRollbackRetry(t *testing.T) {
+	ctx := t.Context()
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Dispatched).Build()
+	dependencyID := uuid.New()
+	failureMsg := i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, dependencyID).Error()
+
+	callCount := 0
+	maxCalls := 2
+	mocks.SyncPoints.On("QueueTransactionFinalize",
+		mock.Anything,
+		mock.MatchedBy(func(req *syncpoints.TransactionFinalizeRequest) bool {
+			return req.TransactionID == txn.pt.ID &&
+				req.FailureMessage == failureMsg
+		}),
+		mock.Anything,
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		callCount++
+		if callCount < maxCalls {
+			onRollback := args.Get(3).(func(context.Context, error))
+			onRollback(ctx, errors.New("finalize failed"))
+		} else {
+			onCommit := args.Get(2).(func(context.Context))
+			onCommit(ctx)
+		}
+	}).Return()
+
+	event := &ChainedDependencyFailedEvent{
+		BaseCoordinatorEvent: BaseCoordinatorEvent{TransactionID: txn.pt.ID},
+		FailedTxID:           dependencyID,
+	}
+	err := action_FinalizeOnChainedDependencyFailure(ctx, txn, event)
+	require.NoError(t, err)
+	assert.Equal(t, maxCalls, callCount)
 }
 
 func TestDependsOn_CascadeFailure_ErrorsWhenDependentMissing(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/transaction/pooled.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled.go
@@ -163,21 +163,26 @@ func action_FinalizeOnRevertedChainedDependencyAtCreation(ctx context.Context, t
 		state, ok := t.getCoordinatorTransactionState(ctx, depID)
 		if ok && state == State_Reverted {
 			log.L(ctx).Infof("finalizing TX %s at creation due to chained dependency %s already reverted", t.pt.ID, depID)
-			t.syncPoints.QueueTransactionFinalize(ctx,
-				&syncpoints.TransactionFinalizeRequest{
-					Domain:          t.pt.Domain,
-					ContractAddress: t.pt.Address,
-					Originator:      t.originator,
-					TransactionID:   t.pt.ID,
-					FailureMessage:  i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error(),
-				},
-				func(ctx context.Context) {
-					log.L(ctx).Debugf("finalized TX %s due to chained dependency failure at creation", t.pt.ID)
-				},
-				func(ctx context.Context, err error) {
-					log.L(ctx).Errorf("error finalizing TX %s due to chained dependency failure at creation: %s", t.pt.ID, err)
-				},
-			)
+			var tryFinalize func()
+			tryFinalize = func() {
+				t.syncPoints.QueueTransactionFinalize(ctx,
+					&syncpoints.TransactionFinalizeRequest{
+						Domain:          t.pt.Domain,
+						ContractAddress: t.pt.Address,
+						Originator:      t.originator,
+						TransactionID:   t.pt.ID,
+						FailureMessage:  i18n.NewError(ctx, msgs.MsgTxMgrDependencyFailed, depID).Error(),
+					},
+					func(ctx context.Context) {
+						log.L(ctx).Debugf("finalized TX %s due to chained dependency failure at creation", t.pt.ID)
+					},
+					func(ctx context.Context, err error) {
+						log.L(ctx).Errorf("error finalizing TX %s due to chained dependency failure at creation: %s", t.pt.ID, err)
+						tryFinalize()
+					},
+				)
+			}
+			tryFinalize()
 			return nil
 		}
 	}

--- a/core/go/internal/sequencer/coordinator/transaction/pooled_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/pooled_test.go
@@ -16,6 +16,7 @@ package transaction
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
@@ -894,19 +895,53 @@ func Test_action_FinalizeOnRevertedChainedDependencyAtCreation(t *testing.T) {
 
 	mocks.SyncPoints.EXPECT().QueueTransactionFinalize(
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(_ context.Context, req *syncpoints.TransactionFinalizeRequest, onSuccess func(context.Context), onFailure func(context.Context, error)) {
+	).Run(func(_ context.Context, req *syncpoints.TransactionFinalizeRequest, onSuccess func(context.Context), _ func(context.Context, error)) {
 		assert.Equal(t, txn.pt.ID, req.TransactionID)
 		assert.Contains(t, req.FailureMessage, depTx.pt.ID.String())
 		if onSuccess != nil {
 			onSuccess(ctx)
 		}
-		if onFailure != nil {
-			onFailure(ctx, assert.AnError)
+	}).Return()
+
+	err := action_FinalizeOnRevertedChainedDependencyAtCreation(ctx, txn, nil)
+	require.NoError(t, err)
+}
+
+func Test_action_FinalizeOnRevertedChainedDependencyAtCreation_OnRollbackRetry(t *testing.T) {
+	ctx := t.Context()
+	grapher, depTracker := newTestGrapher()
+
+	depTx, _ := NewTransactionBuilderForTesting(t, State_Reverted).
+		Grapher(grapher).DependencyTracker(depTracker).
+		Build()
+
+	txn, mocks := NewTransactionBuilderForTesting(t, State_Initial).
+		Grapher(grapher).DependencyTracker(depTracker).
+		CoordinatorTransactions(map[uuid.UUID]CoordinatorTransaction{
+			depTx.pt.ID: depTx,
+		}).
+		Build()
+
+	depTracker.GetChainedDeps().AddPrerequisites(ctx, txn.pt.ID, depTx.pt.ID)
+
+	callCount := 0
+	maxCalls := 2
+	mocks.SyncPoints.On("QueueTransactionFinalize",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		callCount++
+		if callCount < maxCalls {
+			onFailure := args.Get(3).(func(context.Context, error))
+			onFailure(ctx, errors.New("finalize failed"))
+		} else {
+			onSuccess := args.Get(2).(func(context.Context))
+			onSuccess(ctx)
 		}
 	}).Return()
 
 	err := action_FinalizeOnRevertedChainedDependencyAtCreation(ctx, txn, nil)
 	require.NoError(t, err)
+	assert.Equal(t, maxCalls, callCount)
 }
 
 func Test_action_FinalizeOnRevertedChainedDependencyAtCreation_NoRevertedDependency(t *testing.T) {

--- a/core/go/internal/sequencer/syncpoints/finalize.go
+++ b/core/go/internal/sequencer/syncpoints/finalize.go
@@ -19,10 +19,8 @@ package syncpoints
 import (
 	"context"
 
-	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
-	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
@@ -79,10 +77,6 @@ func (s *syncPoints) writeFailureOperations(ctx context.Context, dbTX persistenc
 	receiptsToDistribute := make([]*components.ReceiptInputWithOriginator, 0, len(finalizeOperations))
 	for _, op := range finalizeOperations {
 		if op.OnChain != nil && op.OnChain.Type != pldtypes.NotOnChain {
-			failureMessage := op.FailureMessage
-			if len(op.RevertData) == 0 && failureMessage == "" {
-				failureMessage = i18n.NewError(ctx, msgs.MsgTxMgrRevertedNoData).Error()
-			}
 			receiptsToDistribute = append(receiptsToDistribute, &components.ReceiptInputWithOriginator{
 				Originator: op.Originator,
 				ReceiptInput: components.ReceiptInput{
@@ -91,7 +85,7 @@ func (s *syncPoints) writeFailureOperations(ctx context.Context, dbTX persistenc
 					TransactionID:  op.TransactionID,
 					OnChain:        *op.OnChain,
 					RevertData:     op.RevertData,
-					FailureMessage: failureMessage,
+					FailureMessage: op.FailureMessage,
 				},
 			})
 		} else if op.FailureMessage != "" {

--- a/core/go/internal/sequencer/syncpoints/finalize.go
+++ b/core/go/internal/sequencer/syncpoints/finalize.go
@@ -19,8 +19,10 @@ package syncpoints
 import (
 	"context"
 
+	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
@@ -74,12 +76,13 @@ func (s *syncPoints) writeFailureOperations(ctx context.Context, dbTX persistenc
 	// Chained outcomes are handled separately in txmgr receipt propagation; in this code path,
 	// only off-chain assembly reverts are propagated post-submit (on-chain reverts are handled
 	// by coordinator retry logic, and chained successes are not propagated here).
-	//
-	// We still trigger a syncpoint for each finalize so Domain Context state is flushed before
-	// removing the transaction from in-memory Domain Context.
 	receiptsToDistribute := make([]*components.ReceiptInputWithOriginator, 0, len(finalizeOperations))
 	for _, op := range finalizeOperations {
-		if op.OnChain != nil && op.OnChain.Type != pldtypes.NotOnChain && len(op.RevertData) > 0 {
+		if op.OnChain != nil && op.OnChain.Type != pldtypes.NotOnChain {
+			failureMessage := op.FailureMessage
+			if len(op.RevertData) == 0 && failureMessage == "" {
+				failureMessage = i18n.NewError(ctx, msgs.MsgTxMgrRevertedNoData).Error()
+			}
 			receiptsToDistribute = append(receiptsToDistribute, &components.ReceiptInputWithOriginator{
 				Originator: op.Originator,
 				ReceiptInput: components.ReceiptInput{
@@ -88,7 +91,7 @@ func (s *syncPoints) writeFailureOperations(ctx context.Context, dbTX persistenc
 					TransactionID:  op.TransactionID,
 					OnChain:        *op.OnChain,
 					RevertData:     op.RevertData,
-					FailureMessage: op.FailureMessage,
+					FailureMessage: failureMessage,
 				},
 			})
 		} else if op.FailureMessage != "" {
@@ -101,6 +104,9 @@ func (s *syncPoints) writeFailureOperations(ctx context.Context, dbTX persistenc
 					FailureMessage: op.FailureMessage,
 				},
 			})
+		} else {
+			log.L(ctx).Errorf("Failed to build receipt for transaction %s (domain=%s, contractAddress=%s, originator=%s, failureMessage=%s, revertData=%s, onChain=%+v)",
+				op.TransactionID, op.Domain, op.ContractAddress, op.Originator, op.FailureMessage, op.RevertData.HexString0xPrefix(), op.OnChain)
 		}
 	}
 	return s.WriteOrDistributeReceipts(ctx, dbTX, receiptsToDistribute)
@@ -115,10 +121,8 @@ func (s *syncPoints) WriteOrDistributeReceipts(ctx context.Context, dbTX persist
 	remoteSends := make([]*pldapi.ReliableMessage, 0)
 	for _, r := range receipts {
 		node, _ := pldtypes.PrivateIdentityLocator(r.Originator).Node(ctx, true)
-		if r.ReceiptType != components.RT_Success {
-			log.L(ctx).Warnf("Failure receipt %s with sender %s (node='%s') and address %v: %s",
-				r.TransactionID, r.Originator, node, r.DomainContractAddress, r.FailureMessage)
-		}
+		log.L(ctx).Debugf("Failure receipt %s with sender %s (node='%s') and address %v: %s",
+			r.TransactionID, r.Originator, node, r.DomainContractAddress, r.FailureMessage)
 		if node != "" && node != s.transportMgr.LocalNodeName() {
 			remoteSends = append(remoteSends, &pldapi.ReliableMessage{
 				Node:        node,


### PR DESCRIPTION
An on chain revert may not have revert data. Previously the code would silently drop the finalize operation if this was the case. There is already code in place to handle no revert data being turned into an i18n message to explain this. I have also
- added an error message at the point where we currently silently drop finalize operations, should a future bug/regression cause us to drop other finalize operations
- moved a warn log down to debug level as it is not a system level warning
- removed an inaccurate comment about flushing domain context at finalize

Fixes https://github.com/LFDT-Paladin/paladin/issues/1257

---

Fix a bug where transaction finalization failures were not being consistently retried.