### PR TITLE
Snapshot improvements

### DIFF
--- a/core/go/internal/sequencer/common/engine_integration.go
+++ b/core/go/internal/sequencer/common/engine_integration.go
@@ -142,7 +142,6 @@ func (e *engineIntegration) AssembleAndSign(ctx context.Context, transactionID u
 		})
 	}
 
-	// TODO AM: could assembly and sign not do this resolution
 	return e.assembleAndSign(ctx, transactionID, preAssembly, resolvedVerifiers, dCtx)
 }
 

--- a/core/go/internal/sequencer/common/types.go
+++ b/core/go/internal/sequencer/common/types.go
@@ -25,6 +25,7 @@ type CoordinatorSnapshot struct {
 	DispatchedTransactions []*SnapshotDispatchedTransaction `json:"dispatchedTransactions"`
 	PooledTransactions     []*SnapshotPooledTransaction     `json:"pooledTransactions"`
 	ConfirmedTransactions  []*SnapshotConfirmedTransaction  `json:"confirmedTransactions"`
+	RevertedTransactions   []*SnapshotRevertedTransaction   `json:"revertedTransactions"`
 	CoordinatorState       CoordinatorState                 `json:"coordinatorState"`
 	BlockHeight            uint64                           `json:"blockHeight"`
 	EndorserCandidates     []string                         `json:"endorserCandidates,omitempty"` // (COORDINATOR_ENDORSER selection mode only)
@@ -56,6 +57,10 @@ type SnapshotDispatchedTransaction struct {
 
 type SnapshotConfirmedTransaction struct {
 	SnapshotDispatchedTransaction
-	Hash         pldtypes.Bytes32
+	Hash pldtypes.Bytes32
+}
+
+type SnapshotRevertedTransaction struct {
+	SnapshotPooledTransaction
 	RevertReason pldtypes.HexBytes
 }

--- a/core/go/internal/sequencer/common/types.go
+++ b/core/go/internal/sequencer/common/types.go
@@ -21,6 +21,11 @@ import (
 	"github.com/google/uuid"
 )
 
+// CoordinatorSnapshot must only contain information about transactions which is (or will eventually be)
+// known on the base ledger (e.g. hash, nonce, signer, revert reason). It must not contain information
+// such as the transaction originator.
+// The exception to this is OutputStates, since this is already filtered to only include output states
+// that the receiver is allowed to see.
 type CoordinatorSnapshot struct {
 	DispatchedTransactions []*SnapshotDispatchedTransaction `json:"dispatchedTransactions"`
 	PooledTransactions     []*SnapshotPooledTransaction     `json:"pooledTransactions"`
@@ -40,8 +45,7 @@ type CoordinatorSnapshot struct {
 }
 
 type SnapshotPooledTransaction struct {
-	ID         uuid.UUID
-	Originator string
+	ID uuid.UUID
 }
 
 func (t *SnapshotPooledTransaction) GetID() string {

--- a/core/go/internal/sequencer/coordinator/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/snapshot.go
@@ -66,6 +66,7 @@ func (c *coordinator) sendHeartbeat(ctx context.Context, includeLocks bool) erro
 				DispatchedTransactions: baseSnapshot.DispatchedTransactions,
 				PooledTransactions:     baseSnapshot.PooledTransactions,
 				ConfirmedTransactions:  baseSnapshot.ConfirmedTransactions,
+				RevertedTransactions:   baseSnapshot.RevertedTransactions,
 				CoordinatorState:       baseSnapshot.CoordinatorState,
 				BlockHeight:            baseSnapshot.BlockHeight,
 				Locks:                  statesAndLocks.LockedState,
@@ -115,9 +116,10 @@ func (c *coordinator) getSnapshot(ctx context.Context) *common.CoordinatorSnapsh
 	pooledTransactions := make([]*common.SnapshotPooledTransaction, 0, len(c.transactionsByID))
 	dispatchedTransactions := make([]*common.SnapshotDispatchedTransaction, 0, len(c.transactionsByID))
 	confirmedTransactions := make([]*common.SnapshotConfirmedTransaction, 0, len(c.transactionsByID))
+	revertedTransactions := make([]*common.SnapshotRevertedTransaction, 0, len(c.transactionsByID))
 
 	for _, txn := range c.transactionsByID {
-		pooledTransaction, dispatchedTransaction, confirmedTransaction := txn.GetSnapshot(ctx)
+		pooledTransaction, dispatchedTransaction, confirmedTransaction, revertedTransaction := txn.GetSnapshot(ctx)
 		if pooledTransaction != nil {
 			pooledTransactions = append(pooledTransactions, pooledTransaction)
 		}
@@ -127,17 +129,21 @@ func (c *coordinator) getSnapshot(ctx context.Context) *common.CoordinatorSnapsh
 		if confirmedTransaction != nil {
 			confirmedTransactions = append(confirmedTransactions, confirmedTransaction)
 		}
+		if revertedTransaction != nil {
+			revertedTransactions = append(revertedTransactions, revertedTransaction)
+		}
 	}
 
 	coordinatorState := c.stateMachineEventLoop.GetCurrentState()
-	log.L(ctx).Debugf("created snapshot for sequencer %s with %d transactions (%d pooled, %d dispatched, %d confirmed)",
-		c.contractAddress.String(), len(pooledTransactions)+len(dispatchedTransactions)+len(confirmedTransactions),
-		len(pooledTransactions), len(dispatchedTransactions), len(confirmedTransactions))
+	log.L(ctx).Debugf("created snapshot for sequencer %s with %d transactions (%d pooled, %d dispatched, %d confirmed, %d reverted)",
+		c.contractAddress.String(), len(pooledTransactions)+len(dispatchedTransactions)+len(confirmedTransactions)+len(revertedTransactions),
+		len(pooledTransactions), len(dispatchedTransactions), len(confirmedTransactions), len(revertedTransactions))
 
 	return &common.CoordinatorSnapshot{
 		DispatchedTransactions: dispatchedTransactions,
 		PooledTransactions:     pooledTransactions,
 		ConfirmedTransactions:  confirmedTransactions,
+		RevertedTransactions:   revertedTransactions,
 		CoordinatorState:       coordinatorState,
 		BlockHeight:            uint64(c.currentBlockHeight),
 		EndorserCandidates:     c.endorserCandidates,

--- a/core/go/internal/sequencer/coordinator/snapshot_test.go
+++ b/core/go/internal/sequencer/coordinator/snapshot_test.go
@@ -40,7 +40,7 @@ func TestGetSnapshot_OK(t *testing.T) {
 
 func TestGetSnapshot_AggregatesTransactionsBySnapshotType(t *testing.T) {
 	ctx := context.Background()
-	pooledTxnID, dispatchedTxnID, confirmedTxnID, excludedTxnID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	pooledTxnID, dispatchedTxnID, confirmedTxnID, revertedTxnID, excludedTxnID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	pooledSnapshot := &common.SnapshotPooledTransaction{
 		ID: pooledTxnID,
 	}
@@ -48,22 +48,27 @@ func TestGetSnapshot_AggregatesTransactionsBySnapshotType(t *testing.T) {
 	dispatchedSnapshot.ID = dispatchedTxnID
 	confirmedSnapshot := &common.SnapshotConfirmedTransaction{}
 	confirmedSnapshot.ID = confirmedTxnID
+	revertedSnapshot := &common.SnapshotRevertedTransaction{}
+	revertedSnapshot.ID = revertedTxnID
 
 	pooledTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	pooledTxn.EXPECT().GetID().Return(pooledTxnID)
-	pooledTxn.EXPECT().GetSnapshot(mock.Anything).Return(pooledSnapshot, nil, nil)
+	pooledTxn.EXPECT().GetSnapshot(mock.Anything).Return(pooledSnapshot, nil, nil, nil)
 	dispatchedTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	dispatchedTxn.EXPECT().GetID().Return(dispatchedTxnID)
-	dispatchedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, dispatchedSnapshot, nil)
+	dispatchedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, dispatchedSnapshot, nil, nil)
 	confirmedTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	confirmedTxn.EXPECT().GetID().Return(confirmedTxnID)
-	confirmedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, confirmedSnapshot)
+	confirmedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, confirmedSnapshot, nil)
+	revertedTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
+	revertedTxn.EXPECT().GetID().Return(revertedTxnID)
+	revertedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil, revertedSnapshot)
 	excludedTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
 	excludedTxn.EXPECT().GetID().Return(excludedTxnID)
-	excludedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil)
+	excludedTxn.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil, nil)
 
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Idle).
-		Transactions(pooledTxn, dispatchedTxn, confirmedTxn, excludedTxn).
+		Transactions(pooledTxn, dispatchedTxn, confirmedTxn, revertedTxn, excludedTxn).
 		Build()
 
 	snapshot := c.getSnapshot(ctx)
@@ -71,9 +76,11 @@ func TestGetSnapshot_AggregatesTransactionsBySnapshotType(t *testing.T) {
 	assert.Len(t, snapshot.PooledTransactions, 1)
 	assert.Len(t, snapshot.DispatchedTransactions, 1)
 	assert.Len(t, snapshot.ConfirmedTransactions, 1)
+	assert.Len(t, snapshot.RevertedTransactions, 1)
 	assert.Equal(t, pooledTxnID, snapshot.PooledTransactions[0].ID)
 	assert.Equal(t, dispatchedTxnID, snapshot.DispatchedTransactions[0].ID)
 	assert.Equal(t, confirmedTxnID, snapshot.ConfirmedTransactions[0].ID)
+	assert.Equal(t, revertedTxnID, snapshot.RevertedTransactions[0].ID)
 }
 
 func TestGetSnapshot_IncludesCoordinatorStateAndBlockHeight(t *testing.T) {

--- a/core/go/internal/sequencer/coordinator/state_machine_test.go
+++ b/core/go/internal/sequencer/coordinator/state_machine_test.go
@@ -49,7 +49,7 @@ func newDispatchedTxMock(t *testing.T) (*coordinatortransactionmocks.Coordinator
 	// GetSnapshot is called by action_SendHeartbeat when building the coordinator heartbeat payload.
 	tx.EXPECT().GetSnapshot(mock.Anything).Return(nil, &common.SnapshotDispatchedTransaction{
 		SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID},
-	}, nil).Maybe()
+	}, nil, nil).Maybe()
 	// HandleEvent is called by action_PropagateHeartbeatIntervalToTransactions on each heartbeat tick.
 	tx.EXPECT().HandleEvent(mock.Anything, mock.AnythingOfType("*common.HeartbeatIntervalEvent")).Return(nil).Maybe()
 	// HasDispatchedPublicTransaction is called by action_NudgeDispatchLoop to track in-flight counts.
@@ -656,7 +656,7 @@ func TestCoordinator_WhenElect_HigherPriorityHeartbeat_HasInflightNoDispatched_T
 	txConfirmed.EXPECT().GetID().Return(txID).Maybe()
 	txConfirmed.EXPECT().GetCurrentState().Return(transaction.State_Confirmed).Maybe()
 	// GetSnapshot is called by action_SendHeartbeat in OnTransitionTo Closing.
-	txConfirmed.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil).Maybe()
+	txConfirmed.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil, nil).Maybe()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Elect).
 		NodeName("node2").
 		CurrentActiveCoordinator("node3").
@@ -1069,7 +1069,7 @@ func TestCoordinator_WhenPreparedReceivesClosingHeartbeat_ConfirmedTransactionsI
 	confirmedTxID := uuid.New()
 	confirmedTx.EXPECT().GetID().Return(confirmedTxID).Maybe()
 	confirmedTx.EXPECT().GetCurrentState().Return(transaction.State_Pooled).Maybe()
-	confirmedTx.EXPECT().GetSnapshot(mock.Anything).Return(&common.SnapshotPooledTransaction{ID: confirmedTxID}, nil, nil).Maybe()
+	confirmedTx.EXPECT().GetSnapshot(mock.Anything).Return(&common.SnapshotPooledTransaction{ID: confirmedTxID}, nil, nil, nil).Maybe()
 
 	c, mocks := NewCoordinatorBuilderForTesting(t, State_Prepared).
 		NodeName("node1").
@@ -1142,7 +1142,7 @@ func TestCoordinator_WhenPrepared_HeartbeatReceived_HigherPriority_HasInflightNo
 	txConfirmed.EXPECT().GetID().Return(txID).Maybe()
 	txConfirmed.EXPECT().GetCurrentState().Return(transaction.State_Confirmed).Maybe()
 	// GetSnapshot is called by action_SendHeartbeat in OnTransitionTo Closing.
-	txConfirmed.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil).Maybe()
+	txConfirmed.EXPECT().GetSnapshot(mock.Anything).Return(nil, nil, nil, nil).Maybe()
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Prepared).
 		NodeName("node2").
 		CurrentActiveCoordinator("node3").
@@ -1321,7 +1321,7 @@ func TestCoordinator_WhenPreparedTransitionsToActive_RefreshesSigningIdentityAnd
 	pooledTx.EXPECT().GetID().Return(pooledTxID).Maybe()
 	pooledTx.EXPECT().GetCurrentState().Return(transaction.State_Pooled).Maybe()
 	// action_SendHeartbeat (OnTransitionTo Active) builds the payload by calling GetSnapshot on each transaction.
-	pooledTx.EXPECT().GetSnapshot(mock.Anything).Return(&common.SnapshotPooledTransaction{ID: pooledTxID}, nil, nil).Maybe()
+	pooledTx.EXPECT().GetSnapshot(mock.Anything).Return(&common.SnapshotPooledTransaction{ID: pooledTxID}, nil, nil, nil).Maybe()
 	pooledTx.EXPECT().HandleEvent(mock.Anything, mock.AnythingOfType("*transaction.SelectedEvent")).Return(nil).Once()
 
 	c, _ := NewCoordinatorBuilderForTesting(t, State_Prepared).
@@ -1704,7 +1704,7 @@ func TestCoordinator_WhenActive_TransactionStateTransition_ToPooled_PoolsAndSele
 	txReverting.EXPECT().GetCurrentState().Return(transaction.State_Dispatched).Maybe()
 	txReverting.EXPECT().GetSnapshot(mock.Anything).Return(nil, &common.SnapshotDispatchedTransaction{
 		SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID},
-	}, nil).Maybe()
+	}, nil, nil).Maybe()
 	// action_NudgeDispatchLoop calls HasDispatchedPublicTransaction on each dispatched transaction.
 	txReverting.EXPECT().HasDispatchedPublicTransaction().Return(true).Maybe()
 	// action_SelectTransaction will call HandleEvent(SelectedEvent) after pooling.

--- a/core/go/internal/sequencer/coordinator/transaction/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/transaction/snapshot.go
@@ -22,7 +22,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 )
 
-func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.SnapshotPooledTransaction, *common.SnapshotDispatchedTransaction, *common.SnapshotConfirmedTransaction) {
+func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.SnapshotPooledTransaction, *common.SnapshotDispatchedTransaction, *common.SnapshotConfirmedTransaction, *common.SnapshotRevertedTransaction) {
 	t.RLock()
 	defer t.RUnlock()
 
@@ -39,8 +39,9 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 		State_Assembling,
 		State_Pooled:
 		return &common.SnapshotPooledTransaction{
-			ID: t.pt.ID,
-		}, nil, nil
+			ID:         t.pt.ID,
+			Originator: t.originator,
+		}, nil, nil, nil
 
 	// State_Ready_For_Dispatch is already past the point of no return. It is as good as dispatched, just waiting for
 	// the dispatcher thread to collect it so we include it in the dispatched transactions of the snapshot
@@ -57,27 +58,36 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 			dispatchedTransaction.Nonce = t.nonce
 			dispatchedTransaction.LatestSubmissionHash = t.latestSubmissionHash
 		}
-		return nil, dispatchedTransaction, nil
+		return nil, dispatchedTransaction, nil, nil
 
 	case State_Confirmed:
 		log.L(ctx).Debugf("heartbeat snapshot building, transaction ID %s is in State_Confirmed, sending to heartbeat receipients", t.pt.ID.String())
 		confirmedTransaction := &common.SnapshotConfirmedTransaction{
 			SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
 				SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-					ID: t.pt.ID,
+					ID:         t.pt.ID,
+					Originator: t.originator,
 				},
 				Nonce:                t.nonce,
 				LatestSubmissionHash: t.latestSubmissionHash,
 			},
-			RevertReason: t.revertReason,
 		}
 		if t.signerAddress != nil {
 			confirmedTransaction.Signer = *t.signerAddress
 		}
-		return nil, nil, confirmedTransaction
+		return nil, nil, confirmedTransaction, nil
+
+	case State_Reverted:
+		log.L(ctx).Debugf("heartbeat snapshot building, transaction ID %s is in State_Reverted, sending to heartbeat recipients", t.pt.ID.String())
+		return nil, nil, nil, &common.SnapshotRevertedTransaction{
+			SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+				ID:         t.pt.ID,
+				Originator: t.originator,
+			},
+			RevertReason: t.revertReason,
+		}
 	}
 
-	// Reverted/final/other states are excluded from snapshots.
-	return nil, nil, nil
+	// Final/Evicted/Initial states are excluded from snapshots.
+	return nil, nil, nil, nil
 }
-

--- a/core/go/internal/sequencer/coordinator/transaction/snapshot.go
+++ b/core/go/internal/sequencer/coordinator/transaction/snapshot.go
@@ -39,8 +39,7 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 		State_Assembling,
 		State_Pooled:
 		return &common.SnapshotPooledTransaction{
-			ID:         t.pt.ID,
-			Originator: t.originator,
+			ID: t.pt.ID,
 		}, nil, nil, nil
 
 	// State_Ready_For_Dispatch is already past the point of no return. It is as good as dispatched, just waiting for
@@ -49,8 +48,7 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 		State_Dispatched:
 		dispatchedTransaction := &common.SnapshotDispatchedTransaction{
 			SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-				ID:         t.pt.ID,
-				Originator: t.originator,
+				ID: t.pt.ID,
 			},
 		}
 		if t.signerAddress != nil {
@@ -65,8 +63,7 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 		confirmedTransaction := &common.SnapshotConfirmedTransaction{
 			SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
 				SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-					ID:         t.pt.ID,
-					Originator: t.originator,
+					ID: t.pt.ID,
 				},
 				Nonce:                t.nonce,
 				LatestSubmissionHash: t.latestSubmissionHash,
@@ -81,13 +78,12 @@ func (t *coordinatorTransaction) GetSnapshot(ctx context.Context) (*common.Snaps
 		log.L(ctx).Debugf("heartbeat snapshot building, transaction ID %s is in State_Reverted, sending to heartbeat recipients", t.pt.ID.String())
 		return nil, nil, nil, &common.SnapshotRevertedTransaction{
 			SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-				ID:         t.pt.ID,
-				Originator: t.originator,
+				ID: t.pt.ID,
 			},
 			RevertReason: t.revertReason,
 		}
 	}
 
-	// Final/Evicted/Initial states are excluded from snapshots.
+	// Other states are excluded from snapshots.
 	return nil, nil, nil, nil
 }

--- a/core/go/internal/sequencer/coordinator/transaction/snapshot_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/snapshot_test.go
@@ -25,9 +25,8 @@ import (
 
 func TestGetSnapshot_PooledStates_StateBlocked(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Blocked).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -36,14 +35,12 @@ func TestGetSnapshot_PooledStates_StateBlocked(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_PooledStates_StateConfirmingDispatchable(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirming_Dispatchable).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -52,14 +49,12 @@ func TestGetSnapshot_PooledStates_StateConfirmingDispatchable(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_PooledStates_StateEndorsementGathering(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -68,14 +63,12 @@ func TestGetSnapshot_PooledStates_StateEndorsementGathering(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_PooledStates_StatePreAssemblyBlocked(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_PreAssembly_Blocked).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -84,14 +77,12 @@ func TestGetSnapshot_PooledStates_StatePreAssemblyBlocked(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_PooledStates_StateAssembling(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Assembling).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -100,14 +91,12 @@ func TestGetSnapshot_PooledStates_StateAssembling(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_PooledStates_StatePooled(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Pooled).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -116,18 +105,16 @@ func TestGetSnapshot_PooledStates_StatePooled(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
-	assert.Equal(t, "", pooledSnapshot.Originator)
 }
 
 func TestGetSnapshot_DispatchedStates_WithSigner_StateReadyForDispatch(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	nonce := uint64(42)
 	submissionHash := pldtypes.Bytes32(pldtypes.RandBytes(32))
 	signer := pldtypes.RandAddress()
 
 	txn, _ := NewTransactionBuilderForTesting(t, State_Ready_For_Dispatch).
-		Originator(originator).
+		Originator("sender@node1").
 		SignerAddress(signer).
 		Nonce(&nonce).
 		LatestSubmissionHash(&submissionHash).
@@ -139,7 +126,6 @@ func TestGetSnapshot_DispatchedStates_WithSigner_StateReadyForDispatch(t *testin
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, dispatchedSnapshot.ID)
-	assert.Equal(t, originator, dispatchedSnapshot.Originator)
 	assert.Equal(t, *signer, dispatchedSnapshot.Signer)
 	assert.Equal(t, &nonce, dispatchedSnapshot.Nonce)
 	assert.Equal(t, &submissionHash, dispatchedSnapshot.LatestSubmissionHash)
@@ -147,13 +133,12 @@ func TestGetSnapshot_DispatchedStates_WithSigner_StateReadyForDispatch(t *testin
 
 func TestGetSnapshot_DispatchedStates_WithSigner_StateDispatched(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	nonce := uint64(42)
 	submissionHash := pldtypes.Bytes32(pldtypes.RandBytes(32))
 	signer := pldtypes.RandAddress()
 
 	txn, _ := NewTransactionBuilderForTesting(t, State_Dispatched).
-		Originator(originator).
+		Originator("sender@node1").
 		SignerAddress(signer).
 		Nonce(&nonce).
 		LatestSubmissionHash(&submissionHash).
@@ -165,7 +150,6 @@ func TestGetSnapshot_DispatchedStates_WithSigner_StateDispatched(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, dispatchedSnapshot.ID)
-	assert.Equal(t, originator, dispatchedSnapshot.Originator)
 	assert.Equal(t, *signer, dispatchedSnapshot.Signer)
 	assert.Equal(t, &nonce, dispatchedSnapshot.Nonce)
 	assert.Equal(t, &submissionHash, dispatchedSnapshot.LatestSubmissionHash)
@@ -193,13 +177,12 @@ func TestGetSnapshot_DispatchedState_WithoutSigner(t *testing.T) {
 
 func TestGetSnapshot_Confirmed_WithSigner(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	nonce := uint64(11)
 	submissionHash := pldtypes.Bytes32(pldtypes.RandBytes(32))
 	signer := pldtypes.RandAddress()
 
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
-		Originator(originator).
+		Originator("sender@node1").
 		SignerAddress(signer).
 		Nonce(&nonce).
 		LatestSubmissionHash(&submissionHash).
@@ -211,7 +194,6 @@ func TestGetSnapshot_Confirmed_WithSigner(t *testing.T) {
 	require.NotNil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, confirmedSnapshot.ID)
-	assert.Equal(t, originator, confirmedSnapshot.Originator)
 	assert.Equal(t, *signer, confirmedSnapshot.Signer)
 	assert.Equal(t, &nonce, confirmedSnapshot.Nonce)
 	assert.Equal(t, &submissionHash, confirmedSnapshot.LatestSubmissionHash)
@@ -219,9 +201,8 @@ func TestGetSnapshot_Confirmed_WithSigner(t *testing.T) {
 
 func TestGetSnapshot_Confirmed_WithoutSigner(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
-		Originator(originator).
+		Originator("sender@node1").
 		SignerAddress(nil).
 		Build()
 
@@ -230,17 +211,15 @@ func TestGetSnapshot_Confirmed_WithoutSigner(t *testing.T) {
 	assert.Nil(t, dispatchedSnapshot)
 	require.NotNil(t, confirmedSnapshot)
 	assert.Nil(t, revertedSnapshot)
-	assert.Equal(t, originator, confirmedSnapshot.Originator)
 	assert.Equal(t, pldtypes.EthAddress{}, confirmedSnapshot.Signer)
 }
 
 func TestGetSnapshot_Reverted_WithRevertReason(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
 	revertReason := pldtypes.MustParseHexBytes("0xdeadbeef")
 
 	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).
-		Originator(originator).
+		Originator("sender@node1").
 		RevertReason(revertReason).
 		Build()
 
@@ -250,16 +229,13 @@ func TestGetSnapshot_Reverted_WithRevertReason(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	require.NotNil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, revertedSnapshot.ID)
-	assert.Equal(t, originator, revertedSnapshot.Originator)
 	assert.Equal(t, revertReason, revertedSnapshot.RevertReason)
 }
 
 func TestGetSnapshot_Reverted_WithoutRevertReason(t *testing.T) {
 	ctx := t.Context()
-	originator := "sender@node1"
-
 	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).
-		Originator(originator).
+		Originator("sender@node1").
 		Build()
 
 	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
@@ -268,7 +244,6 @@ func TestGetSnapshot_Reverted_WithoutRevertReason(t *testing.T) {
 	assert.Nil(t, confirmedSnapshot)
 	require.NotNil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, revertedSnapshot.ID)
-	assert.Equal(t, originator, revertedSnapshot.Originator)
 	assert.Nil(t, revertedSnapshot.RevertReason)
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/snapshot_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/snapshot_test.go
@@ -30,10 +30,11 @@ func TestGetSnapshot_PooledStates_StateBlocked(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -45,10 +46,11 @@ func TestGetSnapshot_PooledStates_StateConfirmingDispatchable(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -60,10 +62,11 @@ func TestGetSnapshot_PooledStates_StateEndorsementGathering(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -75,10 +78,11 @@ func TestGetSnapshot_PooledStates_StatePreAssemblyBlocked(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -90,10 +94,11 @@ func TestGetSnapshot_PooledStates_StateAssembling(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -105,10 +110,11 @@ func TestGetSnapshot_PooledStates_StatePooled(t *testing.T) {
 		Originator(originator).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	require.NotNil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, pooledSnapshot.ID)
 	assert.Equal(t, "", pooledSnapshot.Originator)
 }
@@ -127,10 +133,11 @@ func TestGetSnapshot_DispatchedStates_WithSigner_StateReadyForDispatch(t *testin
 		LatestSubmissionHash(&submissionHash).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	require.NotNil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, dispatchedSnapshot.ID)
 	assert.Equal(t, originator, dispatchedSnapshot.Originator)
 	assert.Equal(t, *signer, dispatchedSnapshot.Signer)
@@ -152,10 +159,11 @@ func TestGetSnapshot_DispatchedStates_WithSigner_StateDispatched(t *testing.T) {
 		LatestSubmissionHash(&submissionHash).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	require.NotNil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, dispatchedSnapshot.ID)
 	assert.Equal(t, originator, dispatchedSnapshot.Originator)
 	assert.Equal(t, *signer, dispatchedSnapshot.Signer)
@@ -174,10 +182,11 @@ func TestGetSnapshot_DispatchedState_WithoutSigner(t *testing.T) {
 		LatestSubmissionHash(&submissionHash).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	require.NotNil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Nil(t, dispatchedSnapshot.Nonce)
 	assert.Nil(t, dispatchedSnapshot.LatestSubmissionHash)
 }
@@ -188,63 +197,97 @@ func TestGetSnapshot_Confirmed_WithSigner(t *testing.T) {
 	nonce := uint64(11)
 	submissionHash := pldtypes.Bytes32(pldtypes.RandBytes(32))
 	signer := pldtypes.RandAddress()
-	revertReason := pldtypes.MustParseHexBytes("0x1234")
 
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
 		Originator(originator).
 		SignerAddress(signer).
 		Nonce(&nonce).
 		LatestSubmissionHash(&submissionHash).
-		RevertReason(revertReason).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	require.NotNil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 	assert.Equal(t, txn.pt.ID, confirmedSnapshot.ID)
+	assert.Equal(t, originator, confirmedSnapshot.Originator)
 	assert.Equal(t, *signer, confirmedSnapshot.Signer)
 	assert.Equal(t, &nonce, confirmedSnapshot.Nonce)
 	assert.Equal(t, &submissionHash, confirmedSnapshot.LatestSubmissionHash)
-	assert.Equal(t, revertReason, confirmedSnapshot.RevertReason)
 }
 
 func TestGetSnapshot_Confirmed_WithoutSigner(t *testing.T) {
 	ctx := t.Context()
+	originator := "sender@node1"
 	txn, _ := NewTransactionBuilderForTesting(t, State_Confirmed).
+		Originator(originator).
 		SignerAddress(nil).
 		Build()
 
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	require.NotNil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
+	assert.Equal(t, originator, confirmedSnapshot.Originator)
 	assert.Equal(t, pldtypes.EthAddress{}, confirmedSnapshot.Signer)
+}
+
+func TestGetSnapshot_Reverted_WithRevertReason(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@node1"
+	revertReason := pldtypes.MustParseHexBytes("0xdeadbeef")
+
+	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).
+		Originator(originator).
+		RevertReason(revertReason).
+		Build()
+
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
+	assert.Nil(t, pooledSnapshot)
+	assert.Nil(t, dispatchedSnapshot)
+	assert.Nil(t, confirmedSnapshot)
+	require.NotNil(t, revertedSnapshot)
+	assert.Equal(t, txn.pt.ID, revertedSnapshot.ID)
+	assert.Equal(t, originator, revertedSnapshot.Originator)
+	assert.Equal(t, revertReason, revertedSnapshot.RevertReason)
+}
+
+func TestGetSnapshot_Reverted_WithoutRevertReason(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@node1"
+
+	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).
+		Originator(originator).
+		Build()
+
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
+	assert.Nil(t, pooledSnapshot)
+	assert.Nil(t, dispatchedSnapshot)
+	assert.Nil(t, confirmedSnapshot)
+	require.NotNil(t, revertedSnapshot)
+	assert.Equal(t, txn.pt.ID, revertedSnapshot.ID)
+	assert.Equal(t, originator, revertedSnapshot.Originator)
+	assert.Nil(t, revertedSnapshot.RevertReason)
 }
 
 func TestGetSnapshot_ExcludedStates_StateInitial(t *testing.T) {
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Initial).Build()
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
-}
-
-func TestGetSnapshot_ExcludedStates_StateReverted(t *testing.T) {
-	ctx := t.Context()
-	txn, _ := NewTransactionBuilderForTesting(t, State_Reverted).Build()
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
-	assert.Nil(t, pooledSnapshot)
-	assert.Nil(t, dispatchedSnapshot)
-	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 }
 
 func TestGetSnapshot_ExcludedStates_StateFinal(t *testing.T) {
 	ctx := t.Context()
 	txn, _ := NewTransactionBuilderForTesting(t, State_Final).Build()
-	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot := txn.GetSnapshot(ctx)
+	pooledSnapshot, dispatchedSnapshot, confirmedSnapshot, revertedSnapshot := txn.GetSnapshot(ctx)
 	assert.Nil(t, pooledSnapshot)
 	assert.Nil(t, dispatchedSnapshot)
 	assert.Nil(t, confirmedSnapshot)
+	assert.Nil(t, revertedSnapshot)
 }

--- a/core/go/internal/sequencer/coordinator/transaction/transaction.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction.go
@@ -38,7 +38,7 @@ type CoordinatorTransaction interface {
 	GetID() uuid.UUID
 	GetCurrentState() State
 	HasDispatchedPublicTransaction() bool
-	GetSnapshot(ctx context.Context) (*common.SnapshotPooledTransaction, *common.SnapshotDispatchedTransaction, *common.SnapshotConfirmedTransaction)
+	GetSnapshot(ctx context.Context) (*common.SnapshotPooledTransaction, *common.SnapshotDispatchedTransaction, *common.SnapshotConfirmedTransaction, *common.SnapshotRevertedTransaction)
 	GetOriginatorNode() string
 }
 

--- a/core/go/internal/sequencer/originator/observing.go
+++ b/core/go/internal/sequencer/originator/observing.go
@@ -34,6 +34,13 @@ func action_ProcessConfirmedTransactions(ctx context.Context, o *originator, eve
 	return o.processConfirmedTransactions(ctx, e)
 }
 
+// action_ProcessRevertedTransactions notifies originator transactions of any reverts
+// included in the heartbeat snapshot. Only runs for heartbeats from the current coordinator.
+func action_ProcessRevertedTransactions(ctx context.Context, o *originator, event common.Event) error {
+	e := event.(*common.HeartbeatReceivedEvent)
+	return o.processRevertedTransactions(ctx, e)
+}
+
 // action_ProcessCurrentCoordinatorHeartbeat handles a live heartbeat from the currently tracked
 // coordinator. It resets the liveness timer and propagates dispatch state updates to local
 // transaction state machines. Dropped-transaction detection is handled separately in
@@ -94,8 +101,8 @@ func (o *originator) processDispatchedTransactions(ctx context.Context, event *c
 	return nil
 }
 
-// processConfirmedTransactions notifies originator transactions of any confirmations
-// included in the heartbeat snapshot, regardless of sender or state.
+// processConfirmedTransactions notifies originator transactions of any on-chain successes
+// included in the heartbeat snapshot, regardless of originator or coordinator state.
 func (o *originator) processConfirmedTransactions(ctx context.Context, event *common.HeartbeatReceivedEvent) error {
 	for _, confirmedTransaction := range event.CoordinatorSnapshot.ConfirmedTransactions {
 		if confirmedTransaction.Originator != o.nodeName {
@@ -107,24 +114,40 @@ func (o *originator) processConfirmedTransactions(ctx context.Context, event *co
 				confirmedTransaction.ID, event.FromNode)
 			continue
 		}
-		if len(confirmedTransaction.RevertReason) > 0 {
-			err := txn.HandleEvent(ctx, &transaction.ConfirmedRevertedEvent{
-				BaseEvent:    transaction.BaseEvent{TransactionID: confirmedTransaction.ID},
-				RevertReason: confirmedTransaction.RevertReason,
-				WillRetry:    false,
-			})
-			if err != nil {
-				msg := fmt.Errorf("error handling confirmed reverted event for transaction %s: %v", txn.GetID(), err)
-				return i18n.NewError(ctx, msgs.MsgSequencerInternalError, msg)
-			}
-		} else {
-			err := txn.HandleEvent(ctx, &transaction.ConfirmedSuccessEvent{
-				BaseEvent: transaction.BaseEvent{TransactionID: confirmedTransaction.ID},
-			})
-			if err != nil {
-				msg := fmt.Errorf("error handling confirmed success event for transaction %s: %v", txn.GetID(), err)
-				return i18n.NewError(ctx, msgs.MsgSequencerInternalError, msg)
-			}
+		err := txn.HandleEvent(ctx, &transaction.ConfirmedSuccessEvent{
+			BaseEvent: transaction.BaseEvent{TransactionID: confirmedTransaction.ID},
+		})
+		if err != nil {
+			msg := fmt.Errorf("error handling confirmed success event for transaction %s: %v", txn.GetID(), err)
+			return i18n.NewError(ctx, msgs.MsgSequencerInternalError, msg)
+		}
+	}
+	return nil
+}
+
+// processRevertedTransactions notifies originator transactions of any reverts included in the
+// heartbeat snapshot from the current coordinator. Only the raw on-chain revert bytes are
+// propagated; the coordinator does not send failure message as a transaction revereted at assembly time
+// may have private data in its failure message.
+func (o *originator) processRevertedTransactions(ctx context.Context, event *common.HeartbeatReceivedEvent) error {
+	for _, revertedTransaction := range event.CoordinatorSnapshot.RevertedTransactions {
+		if revertedTransaction.Originator != o.nodeName {
+			continue
+		}
+		txn := o.transactionsByID[revertedTransaction.ID]
+		if txn == nil {
+			log.L(ctx).Debugf("received reverted transaction %s in heartbeat from %s but no transaction found in memory",
+				revertedTransaction.ID, event.FromNode)
+			continue
+		}
+		err := txn.HandleEvent(ctx, &transaction.ConfirmedRevertedEvent{
+			BaseEvent:    transaction.BaseEvent{TransactionID: revertedTransaction.ID},
+			RevertReason: revertedTransaction.RevertReason,
+			WillRetry:    false,
+		})
+		if err != nil {
+			msg := fmt.Errorf("error handling confirmed reverted event for transaction %s: %v", txn.GetID(), err)
+			return i18n.NewError(ctx, msgs.MsgSequencerInternalError, msg)
 		}
 	}
 	return nil
@@ -154,6 +177,11 @@ func transactionFoundInSnapshot(snapshot *common.CoordinatorSnapshot, txn transa
 		}
 	}
 	for _, t := range snapshot.ConfirmedTransactions {
+		if t.ID == txn.GetID() {
+			return true
+		}
+	}
+	for _, t := range snapshot.RevertedTransactions {
 		if t.ID == txn.GetID() {
 			return true
 		}

--- a/core/go/internal/sequencer/originator/observing.go
+++ b/core/go/internal/sequencer/originator/observing.go
@@ -62,15 +62,11 @@ func action_SwitchActiveCoordinator(ctx context.Context, o *originator, event co
 
 // processDispatchedTransactions propagates dispatch state updates (submission hash, nonce)
 // from the active coordinator's heartbeat to our local transaction state machines.
+// Transactions not found in our in-memory map belong to other originators and are silently skipped.
 func (o *originator) processDispatchedTransactions(ctx context.Context, event *common.HeartbeatReceivedEvent) error {
 	for _, dispatchedTransaction := range event.CoordinatorSnapshot.DispatchedTransactions {
-		if dispatchedTransaction.Originator != o.nodeName {
-			continue
-		}
 		txn := o.transactionsByID[dispatchedTransaction.ID]
 		if txn == nil {
-			log.L(ctx).Warnf("received heartbeat from %s with dispatched transaction %s but no transaction found in memory",
-				o.currentActiveCoordinator, dispatchedTransaction.ID)
 			continue
 		}
 		if dispatchedTransaction.LatestSubmissionHash != nil {
@@ -102,16 +98,13 @@ func (o *originator) processDispatchedTransactions(ctx context.Context, event *c
 }
 
 // processConfirmedTransactions notifies originator transactions of any on-chain successes
-// included in the heartbeat snapshot, regardless of originator or coordinator state.
+// included in the heartbeat snapshot, regardless of coordinator state.
+// Coordinator State_Confirmed is only reached via success; revert reason is never present here.
+// Transactions not found in our in-memory map belong to other originators and are silently skipped.
 func (o *originator) processConfirmedTransactions(ctx context.Context, event *common.HeartbeatReceivedEvent) error {
 	for _, confirmedTransaction := range event.CoordinatorSnapshot.ConfirmedTransactions {
-		if confirmedTransaction.Originator != o.nodeName {
-			continue
-		}
 		txn := o.transactionsByID[confirmedTransaction.ID]
 		if txn == nil {
-			log.L(ctx).Debugf("received confirmed transaction %s in heartbeat from %s but no transaction found in memory",
-				confirmedTransaction.ID, event.FromNode)
 			continue
 		}
 		err := txn.HandleEvent(ctx, &transaction.ConfirmedSuccessEvent{
@@ -127,17 +120,12 @@ func (o *originator) processConfirmedTransactions(ctx context.Context, event *co
 
 // processRevertedTransactions notifies originator transactions of any reverts included in the
 // heartbeat snapshot from the current coordinator. Only the raw on-chain revert bytes are
-// propagated; the coordinator does not send failure message as a transaction revereted at assembly time
+// propagated; the coordinator does not send failure message as a transaction reverted at assembly time
 // may have private data in its failure message.
 func (o *originator) processRevertedTransactions(ctx context.Context, event *common.HeartbeatReceivedEvent) error {
 	for _, revertedTransaction := range event.CoordinatorSnapshot.RevertedTransactions {
-		if revertedTransaction.Originator != o.nodeName {
-			continue
-		}
 		txn := o.transactionsByID[revertedTransaction.ID]
 		if txn == nil {
-			log.L(ctx).Debugf("received reverted transaction %s in heartbeat from %s but no transaction found in memory",
-				revertedTransaction.ID, event.FromNode)
 			continue
 		}
 		err := txn.HandleEvent(ctx, &transaction.ConfirmedRevertedEvent{

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -120,6 +120,30 @@ func Test_validator_HasDroppedTransactions_FalseWhenAllTransactionsPresentInSnap
 	assert.False(t, ok)
 }
 
+func Test_validator_HasDroppedTransactions_FalseWhenTransactionPresentInRevertedList(t *testing.T) {
+	ctx := context.Background()
+	txID := uuid.New()
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID)
+	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		NodeName("member1@node1").
+		CurrentActiveCoordinator("coordinator@node1").
+		Transactions(mockTxn).
+		Build()
+	event := &common.HeartbeatReceivedEvent{
+		FromNode: "coordinator@node1",
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
+				{SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID}},
+			},
+		},
+	}
+	ok, err := validator_HasDroppedTransactions(ctx, o, event)
+	require.NoError(t, err)
+	assert.False(t, ok, "transaction in reverted list must not be treated as dropped")
+}
+
 func Test_validator_HasDroppedTransactions_FalseWhenNoInFlightTransactions(t *testing.T) {
 	ctx := context.Background()
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
@@ -244,47 +268,6 @@ func Test_action_ProcessConfirmedTransactions_ConfirmedSuccess(t *testing.T) {
 	mockTxn.AssertExpectations(t)
 }
 
-func Test_action_ProcessConfirmedTransactions_ConfirmedReverted(t *testing.T) {
-	ctx := context.Background()
-	txID := uuid.New()
-
-	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
-	mockTxn.On("GetID").Return(txID)
-	mockTxn.On("HandleEvent", mock.Anything, mock.MatchedBy(func(e transaction.Event) bool {
-		rev, ok := e.(*transaction.ConfirmedRevertedEvent)
-		return ok && len(rev.RevertReason) > 0
-	})).Return(nil)
-
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		NodeName("member1@node1").
-		CurrentActiveCoordinator("coordinator@node1").
-		Transactions(mockTxn).
-		Build()
-
-	contractAddress := *pldtypes.RandAddress()
-	event := &common.HeartbeatReceivedEvent{
-		FromNode:        "any@node",
-		ContractAddress: &contractAddress,
-		CoordinatorSnapshot: &common.CoordinatorSnapshot{
-			ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{
-				{
-					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
-						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         txID,
-							Originator: "member1@node1",
-						},
-					},
-					RevertReason: pldtypes.HexBytes{0x01, 0x02},
-				},
-			},
-		},
-	}
-
-	err := action_ProcessConfirmedTransactions(ctx, o, event)
-	require.NoError(t, err)
-	mockTxn.AssertExpectations(t)
-}
-
 func Test_action_ProcessConfirmedTransactions_NotOurNode_Skipped(t *testing.T) {
 	ctx := context.Background()
 
@@ -381,16 +364,19 @@ func Test_action_ProcessConfirmedTransactions_HandleEventError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func Test_action_ProcessConfirmedTransactions_RevertedHandleEventError(t *testing.T) {
+// ── action_ProcessRevertedTransactions ───────────────────────────────────────
+
+func Test_action_ProcessRevertedTransactions_FiresConfirmedRevertedEvent(t *testing.T) {
 	ctx := context.Background()
 	txID := uuid.New()
+	revertReason := pldtypes.HexBytes{0x01, 0x02}
 
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("HandleEvent", mock.Anything, mock.MatchedBy(func(e transaction.Event) bool {
-		_, ok := e.(*transaction.ConfirmedRevertedEvent)
-		return ok
-	})).Return(fmt.Errorf("revert handle error"))
+		rev, ok := e.(*transaction.ConfirmedRevertedEvent)
+		return ok && !rev.WillRetry && rev.RevertReason.Equals(revertReason)
+	})).Return(nil)
 
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		NodeName("member1@node1").
@@ -400,24 +386,153 @@ func Test_action_ProcessConfirmedTransactions_RevertedHandleEventError(t *testin
 
 	contractAddress := *pldtypes.RandAddress()
 	event := &common.HeartbeatReceivedEvent{
-		FromNode:        "any@node",
+		FromNode:        "coordinator@node1",
 		ContractAddress: &contractAddress,
 		CoordinatorSnapshot: &common.CoordinatorSnapshot{
-			ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
 				{
-					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
-						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         txID,
-							Originator: "member1@node1",
-						},
+					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+						ID:         txID,
+						Originator: "member1@node1",
 					},
-					RevertReason: pldtypes.HexBytes("out of gas"),
+					RevertReason: revertReason,
 				},
 			},
 		},
 	}
 
-	err := action_ProcessConfirmedTransactions(ctx, o, event)
+	err := action_ProcessRevertedTransactions(ctx, o, event)
+	require.NoError(t, err)
+	mockTxn.AssertExpectations(t)
+}
+
+func Test_action_ProcessRevertedTransactions_NilRevertReason_StillFiresEvent(t *testing.T) {
+	ctx := context.Background()
+	txID := uuid.New()
+
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID)
+	mockTxn.On("HandleEvent", mock.Anything, mock.MatchedBy(func(e transaction.Event) bool {
+		rev, ok := e.(*transaction.ConfirmedRevertedEvent)
+		return ok && !rev.WillRetry && rev.RevertReason == nil
+	})).Return(nil)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		NodeName("member1@node1").
+		CurrentActiveCoordinator("coordinator@node1").
+		Transactions(mockTxn).
+		Build()
+
+	contractAddress := *pldtypes.RandAddress()
+	event := &common.HeartbeatReceivedEvent{
+		FromNode:        "coordinator@node1",
+		ContractAddress: &contractAddress,
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
+				{
+					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+						ID:         txID,
+						Originator: "member1@node1",
+					},
+				},
+			},
+		},
+	}
+
+	err := action_ProcessRevertedTransactions(ctx, o, event)
+	require.NoError(t, err)
+	mockTxn.AssertExpectations(t)
+}
+
+func Test_action_ProcessRevertedTransactions_NotOurNode_Skipped(t *testing.T) {
+	ctx := context.Background()
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		NodeName("member1@node1").
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	contractAddress := *pldtypes.RandAddress()
+	event := &common.HeartbeatReceivedEvent{
+		FromNode:        "coordinator@node1",
+		ContractAddress: &contractAddress,
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
+				{
+					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+						ID:         uuid.New(),
+						Originator: "other@otherNode",
+					},
+				},
+			},
+		},
+	}
+
+	// No HandleEvent expectation registered — mock will fail the test if called.
+	err := action_ProcessRevertedTransactions(ctx, o, event)
+	require.NoError(t, err)
+}
+
+func Test_action_ProcessRevertedTransactions_NotInMemory_Skipped(t *testing.T) {
+	ctx := context.Background()
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		NodeName("member1@node1").
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	contractAddress := *pldtypes.RandAddress()
+	event := &common.HeartbeatReceivedEvent{
+		FromNode:        "coordinator@node1",
+		ContractAddress: &contractAddress,
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
+				{
+					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+						ID:         uuid.New(),
+						Originator: "member1@node1",
+					},
+				},
+			},
+		},
+	}
+
+	err := action_ProcessRevertedTransactions(ctx, o, event)
+	require.NoError(t, err)
+}
+
+func Test_action_ProcessRevertedTransactions_HandleEventError_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	txID := uuid.New()
+
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID)
+	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(fmt.Errorf("revert handle error"))
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		NodeName("member1@node1").
+		CurrentActiveCoordinator("coordinator@node1").
+		Transactions(mockTxn).
+		Build()
+
+	contractAddress := *pldtypes.RandAddress()
+	event := &common.HeartbeatReceivedEvent{
+		FromNode:        "coordinator@node1",
+		ContractAddress: &contractAddress,
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			RevertedTransactions: []*common.SnapshotRevertedTransaction{
+				{
+					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
+						ID:         txID,
+						Originator: "member1@node1",
+					},
+					RevertReason: pldtypes.HexBytes{0xde, 0xad},
+				},
+			},
+		},
+	}
+
+	err := action_ProcessRevertedTransactions(ctx, o, event)
 	require.Error(t, err)
 }
 

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -254,8 +254,7 @@ func Test_action_ProcessConfirmedTransactions_ConfirmedSuccess(t *testing.T) {
 				{
 					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
 						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         txID,
-							Originator: "member1@node1",
+							ID: txID,
 						},
 					},
 				},
@@ -266,36 +265,6 @@ func Test_action_ProcessConfirmedTransactions_ConfirmedSuccess(t *testing.T) {
 	err := action_ProcessConfirmedTransactions(ctx, o, event)
 	require.NoError(t, err)
 	mockTxn.AssertExpectations(t)
-}
-
-func Test_action_ProcessConfirmedTransactions_NotOurNode_Skipped(t *testing.T) {
-	ctx := context.Background()
-
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		NodeName("member1@node1").
-		CurrentActiveCoordinator("coordinator@node1").
-		Build()
-
-	contractAddress := *pldtypes.RandAddress()
-	event := &common.HeartbeatReceivedEvent{
-		FromNode:        "any@node",
-		ContractAddress: &contractAddress,
-		CoordinatorSnapshot: &common.CoordinatorSnapshot{
-			ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{
-				{
-					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
-						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         uuid.New(),
-							Originator: "other@otherNode",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err := action_ProcessConfirmedTransactions(ctx, o, event)
-	require.NoError(t, err)
 }
 
 func Test_action_ProcessConfirmedTransactions_NotInMemory_Skipped(t *testing.T) {
@@ -315,8 +284,7 @@ func Test_action_ProcessConfirmedTransactions_NotInMemory_Skipped(t *testing.T) 
 				{
 					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
 						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         uuid.New(),
-							Originator: "member1@node1",
+							ID: uuid.New(),
 						},
 					},
 				},
@@ -351,8 +319,7 @@ func Test_action_ProcessConfirmedTransactions_HandleEventError(t *testing.T) {
 				{
 					SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
 						SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-							ID:         txID,
-							Originator: "member1@node1",
+							ID: txID,
 						},
 					},
 				},
@@ -392,8 +359,7 @@ func Test_action_ProcessRevertedTransactions_FiresConfirmedRevertedEvent(t *test
 			RevertedTransactions: []*common.SnapshotRevertedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txID,
-						Originator: "member1@node1",
+						ID: txID,
 					},
 					RevertReason: revertReason,
 				},
@@ -431,8 +397,7 @@ func Test_action_ProcessRevertedTransactions_NilRevertReason_StillFiresEvent(t *
 			RevertedTransactions: []*common.SnapshotRevertedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txID,
-						Originator: "member1@node1",
+						ID: txID,
 					},
 				},
 			},
@@ -442,35 +407,6 @@ func Test_action_ProcessRevertedTransactions_NilRevertReason_StillFiresEvent(t *
 	err := action_ProcessRevertedTransactions(ctx, o, event)
 	require.NoError(t, err)
 	mockTxn.AssertExpectations(t)
-}
-
-func Test_action_ProcessRevertedTransactions_NotOurNode_Skipped(t *testing.T) {
-	ctx := context.Background()
-
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		NodeName("member1@node1").
-		CurrentActiveCoordinator("coordinator@node1").
-		Build()
-
-	contractAddress := *pldtypes.RandAddress()
-	event := &common.HeartbeatReceivedEvent{
-		FromNode:        "coordinator@node1",
-		ContractAddress: &contractAddress,
-		CoordinatorSnapshot: &common.CoordinatorSnapshot{
-			RevertedTransactions: []*common.SnapshotRevertedTransaction{
-				{
-					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         uuid.New(),
-						Originator: "other@otherNode",
-					},
-				},
-			},
-		},
-	}
-
-	// No HandleEvent expectation registered — mock will fail the test if called.
-	err := action_ProcessRevertedTransactions(ctx, o, event)
-	require.NoError(t, err)
 }
 
 func Test_action_ProcessRevertedTransactions_NotInMemory_Skipped(t *testing.T) {
@@ -489,8 +425,7 @@ func Test_action_ProcessRevertedTransactions_NotInMemory_Skipped(t *testing.T) {
 			RevertedTransactions: []*common.SnapshotRevertedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         uuid.New(),
-						Originator: "member1@node1",
+						ID: uuid.New(),
 					},
 				},
 			},
@@ -523,8 +458,7 @@ func Test_action_ProcessRevertedTransactions_HandleEventError_ReturnsError(t *te
 			RevertedTransactions: []*common.SnapshotRevertedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txID,
-						Originator: "member1@node1",
+						ID: txID,
 					},
 					RevertReason: pldtypes.HexBytes{0xde, 0xad},
 				},
@@ -561,7 +495,7 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_ResetsLivenessTimer(t *testi
 	assert.Equal(t, coordinatorLocator, o.currentActiveCoordinator, "coordinator must be unchanged")
 }
 
-func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionNotFoundLogsAndContinues(t *testing.T) {
+func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionNotFoundContinues(t *testing.T) {
 	ctx := context.Background()
 	originatorLocator := "sender@senderNode"
 	coordinatorLocator := "coordinator@coordinatorNode"
@@ -579,8 +513,7 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionNotFoun
 			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         unknownTxID,
-						Originator: originatorLocator,
+						ID: unknownTxID,
 					},
 				},
 			},
@@ -617,8 +550,7 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionWithHas
 			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txn.ID,
-						Originator: originatorLocator,
+						ID: txn.ID,
 					},
 					Signer:               *signerAddress,
 					LatestSubmissionHash: &submissionHash,
@@ -656,36 +588,9 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionWithNon
 			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txn.ID,
-						Originator: originatorLocator,
+						ID: txn.ID,
 					},
 					Nonce: &nonce,
-				},
-			},
-		},
-	}
-	err := action_ProcessCurrentCoordinatorHeartbeat(ctx, o, event)
-	assert.NoError(t, err)
-}
-
-func Test_action_ProcessCurrentCoordinatorHeartbeat_DispatchedTransactionFromDifferentOriginatorIgnored(t *testing.T) {
-	ctx := context.Background()
-	coordinatorLocator := "coordinator@coordinatorNode"
-	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
-		CurrentActiveCoordinator(coordinatorLocator).
-		Build()
-
-	contractAddress := *pldtypes.RandAddress()
-	event := &common.HeartbeatReceivedEvent{
-		FromNode:        coordinatorLocator,
-		ContractAddress: &contractAddress,
-		CoordinatorSnapshot: &common.CoordinatorSnapshot{
-			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
-				{
-					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         uuid.New(),
-						Originator: "otherSender@otherNode",
-					},
 				},
 			},
 		},
@@ -719,8 +624,7 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_SubmittedHandleEventError(t 
 			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txnID,
-						Originator: originatorLocator,
+						ID: txnID,
 					},
 					Signer:               *signerAddress,
 					LatestSubmissionHash: &submissionHash,
@@ -759,8 +663,7 @@ func Test_action_ProcessCurrentCoordinatorHeartbeat_NonceAssignedHandleEventErro
 			DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 				{
 					SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-						ID:         txnID,
-						Originator: originatorLocator,
+						ID: txnID,
 					},
 					Nonce: &nonce,
 				},

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -200,7 +200,6 @@ func Test_hasDroppedTransactions_TrueWhenDelegatedTxnNotInSnapshot(t *testing.T)
 }
 func Test_hasDroppedTransactions_FalseWhenDelegatedTxnInSnapshot(t *testing.T) {
 	ctx := context.Background()
-	originatorLocator := "sender@senderNode"
 	txID := uuid.New()
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
@@ -210,19 +209,18 @@ func Test_hasDroppedTransactions_FalseWhenDelegatedTxnInSnapshot(t *testing.T) {
 		Build()
 	snapshot := &common.CoordinatorSnapshot{
 		PooledTransactions: []*common.SnapshotPooledTransaction{
-			{ID: txID, Originator: originatorLocator},
+			{ID: txID},
 		},
 	}
 	assert.False(t, o.hasDroppedTransactions(ctx, snapshot))
 }
 func Test_transactionFoundInSnapshot_TrueWhenInDispatchedTransactions(t *testing.T) {
-	originatorLocator := "sender@senderNode"
 	txID := uuid.New()
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	snapshot := &common.CoordinatorSnapshot{
 		DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
-			{SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID, Originator: originatorLocator}},
+			{SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID}},
 		},
 		PooledTransactions:    []*common.SnapshotPooledTransaction{},
 		ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{},
@@ -230,21 +228,19 @@ func Test_transactionFoundInSnapshot_TrueWhenInDispatchedTransactions(t *testing
 	assert.True(t, transactionFoundInSnapshot(snapshot, mockTxn))
 }
 func Test_transactionFoundInSnapshot_TrueWhenInPooledTransactions(t *testing.T) {
-	originatorLocator := "sender@senderNode"
 	txID := uuid.New()
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	snapshot := &common.CoordinatorSnapshot{
 		DispatchedTransactions: []*common.SnapshotDispatchedTransaction{},
 		PooledTransactions: []*common.SnapshotPooledTransaction{
-			{ID: txID, Originator: originatorLocator},
+			{ID: txID},
 		},
 		ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{},
 	}
 	assert.True(t, transactionFoundInSnapshot(snapshot, mockTxn))
 }
 func Test_transactionFoundInSnapshot_TrueWhenInConfirmedTransactions(t *testing.T) {
-	originatorLocator := "sender@senderNode"
 	txID := uuid.New()
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
@@ -253,7 +249,7 @@ func Test_transactionFoundInSnapshot_TrueWhenInConfirmedTransactions(t *testing.
 		PooledTransactions:     []*common.SnapshotPooledTransaction{},
 		ConfirmedTransactions: []*common.SnapshotConfirmedTransaction{
 			{SnapshotDispatchedTransaction: common.SnapshotDispatchedTransaction{
-				SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID, Originator: originatorLocator},
+				SnapshotPooledTransaction: common.SnapshotPooledTransaction{ID: txID},
 			}},
 		},
 	}
@@ -261,14 +257,13 @@ func Test_transactionFoundInSnapshot_TrueWhenInConfirmedTransactions(t *testing.
 }
 
 func Test_transactionFoundInSnapshot_FalseWhenOnlyOtherTxnsInSnapshot(t *testing.T) {
-	originatorLocator := "sender@senderNode"
 	txID := uuid.New()
 	otherID := uuid.New()
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	snapshot := &common.CoordinatorSnapshot{
 		PooledTransactions: []*common.SnapshotPooledTransaction{
-			{ID: otherID, Originator: originatorLocator},
+			{ID: otherID},
 		},
 		DispatchedTransactions: []*common.SnapshotDispatchedTransaction{},
 		ConfirmedTransactions:  []*common.SnapshotConfirmedTransaction{},

--- a/core/go/internal/sequencer/originator/originator_test.go
+++ b/core/go/internal/sequencer/originator/originator_test.go
@@ -120,8 +120,7 @@ func TestOriginator_SingleTransactionLifecycle(t *testing.T) {
 		DispatchedTransactions: []*common.SnapshotDispatchedTransaction{
 			{
 				SnapshotPooledTransaction: common.SnapshotPooledTransaction{
-					ID:         txn.ID,
-					Originator: "member1@node1",
+					ID: txn.ID,
 				},
 				Signer:               *signerAddress,
 				Nonce:                &nonce,

--- a/core/go/internal/sequencer/originator/state_machine.go
+++ b/core/go/internal/sequencer/originator/state_machine.go
@@ -212,6 +212,10 @@ var stateDefinitionsMap = StateDefinitions{
 					// Process confirmed transactions from every heartbeat regardless of sender state or identity.
 					Actions: []ActionRule{{Action: action_ProcessConfirmedTransactions}},
 				}, {
+					// Process reverted transactions from the current coordinator only.
+					Validator: validator_IsFromCurrentCoordinator,
+					Actions:   []ActionRule{{Action: action_ProcessRevertedTransactions}},
+				}, {
 					// Higher-priority coordinator announced; redirect and reset liveness timer.
 					Validator: statemachine.ValidatorAnd(
 						validator_IsHeartbeatSenderLive,

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -624,7 +624,7 @@ func TestStateMachine_Sending_HeartbeatReceived_NoDroppedTransactions_NoRedelega
 		CoordinatorSnapshot: &common.CoordinatorSnapshot{
 			CoordinatorState: common.CoordinatorState_Active,
 			PooledTransactions: []*common.SnapshotPooledTransaction{
-				{ID: txID, Originator: "sender@node1"},
+				{ID: txID},
 			},
 		},
 	}))

--- a/core/go/internal/sequencer/originator/transaction/finalizing.go
+++ b/core/go/internal/sequencer/originator/transaction/finalizing.go
@@ -70,12 +70,6 @@ func action_QueueFinalizeEvent(ctx context.Context, txn *originatorTransaction, 
 	return nil
 }
 
-func action_RecordWillRetry(ctx context.Context, t *originatorTransaction, event common.Event) error {
-	e := event.(*ConfirmedRevertedEvent)
-	t.lastReceivedWillRetry = e.WillRetry
-	return nil
-}
-
-func guard_WillRetry(ctx context.Context, t *originatorTransaction) bool {
-	return t.lastReceivedWillRetry
+func validator_WillRetry(_ context.Context, _ *originatorTransaction, event common.Event) (bool, error) {
+	return event.(*ConfirmedRevertedEvent).WillRetry, nil
 }

--- a/core/go/internal/sequencer/originator/transaction/finalizing_test.go
+++ b/core/go/internal/sequencer/originator/transaction/finalizing_test.go
@@ -88,36 +88,22 @@ func Test_action_QueueFinalizeEvent_QueuesFinalizeEvent(t *testing.T) {
 	assert.Equal(t, txn.pt.ID, finalizeEv.TransactionID)
 }
 
-func Test_action_RecordWillRetry(t *testing.T) {
+func Test_validator_WillRetry(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Dispatched)
 	txn, _ := builder.BuildWithMocks()
 
-	event := &ConfirmedRevertedEvent{
+	ok, err := validator_WillRetry(ctx, txn, &ConfirmedRevertedEvent{
 		BaseEvent: BaseEvent{TransactionID: txn.pt.ID},
 		WillRetry: true,
-	}
-	err := action_RecordWillRetry(ctx, txn, event)
+	})
 	require.NoError(t, err)
-	assert.True(t, txn.lastReceivedWillRetry)
+	assert.True(t, ok)
 
-	event2 := &ConfirmedRevertedEvent{
+	ok, err = validator_WillRetry(ctx, txn, &ConfirmedRevertedEvent{
 		BaseEvent: BaseEvent{TransactionID: txn.pt.ID},
 		WillRetry: false,
-	}
-	err = action_RecordWillRetry(ctx, txn, event2)
+	})
 	require.NoError(t, err)
-	assert.False(t, txn.lastReceivedWillRetry)
-}
-
-func Test_guard_WillRetry(t *testing.T) {
-	ctx := context.Background()
-	builder := NewTransactionBuilderForTesting(t, State_Dispatched)
-	txn, _ := builder.BuildWithMocks()
-
-	txn.lastReceivedWillRetry = true
-	assert.True(t, guard_WillRetry(ctx, txn))
-
-	txn.lastReceivedWillRetry = false
-	assert.False(t, guard_WillRetry(ctx, txn))
+	assert.False(t, ok)
 }

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -110,6 +110,17 @@ var stateDefinitionsMap = StateDefinitions{
 					}},
 				}},
 			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					// TODO AM: use a validator rather than recording here
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
+						To: State_Confirmed,
+					}},
+				}},
+			},
 			Event_Delegated: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
@@ -129,6 +140,16 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{{
+						To: State_Confirmed,
+					}},
+				}},
+			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
 						To: State_Confirmed,
 					}},
 				}},
@@ -196,6 +217,16 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{{
+						To: State_Confirmed,
+					}},
+				}},
+			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
 						To: State_Confirmed,
 					}},
 				}},
@@ -312,6 +343,16 @@ var stateDefinitionsMap = StateDefinitions{
 					}},
 				}},
 			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
+						To: State_Confirmed,
+					}},
+				}},
+			},
 			Event_Delegated: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
@@ -382,6 +423,16 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{{
+						To: State_Confirmed,
+					}},
+				}},
+			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
 						To: State_Confirmed,
 					}},
 				}},
@@ -748,6 +799,16 @@ var stateDefinitionsMap = StateDefinitions{
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
 					Transitions: []Transition{{
+						To: State_Confirmed,
+					}},
+				}},
+			},
+			Event_ConfirmedReverted: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Actions: []ActionRule{{Action: action_RecordWillRetry}},
+					Transitions: []Transition{{
+						If: statemachine.GuardNot(guard_WillRetry),
 						To: State_Confirmed,
 					}},
 				}},

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -113,12 +113,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					// TODO AM: use a validator rather than recording here
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -147,11 +143,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -224,11 +217,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -346,11 +336,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -430,11 +417,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -539,17 +523,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{
-						{
-							If: guard_WillRetry,
-							To: State_Delegated,
-						},
-						{
-							If: statemachine.GuardNot(guard_WillRetry),
-							To: State_Confirmed,
-						},
-					},
+					Validator:   validator_WillRetry,
+					Transitions: []Transition{{To: State_Delegated}},
+				}, {
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -637,17 +614,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{
-						{
-							If: guard_WillRetry,
-							To: State_Delegated,
-						},
-						{
-							If: statemachine.GuardNot(guard_WillRetry),
-							To: State_Confirmed,
-						},
-					},
+					Validator:   validator_WillRetry,
+					Transitions: []Transition{{To: State_Delegated}},
+				}, {
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -729,17 +699,10 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{
-						{
-							If: guard_WillRetry,
-							To: State_Delegated,
-						},
-						{
-							If: statemachine.GuardNot(guard_WillRetry),
-							To: State_Confirmed,
-						},
-					},
+					Validator:   validator_WillRetry,
+					Transitions: []Transition{{To: State_Delegated}},
+				}, {
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {
@@ -806,11 +769,8 @@ var stateDefinitionsMap = StateDefinitions{
 			Event_ConfirmedReverted: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_RecordWillRetry}},
-					Transitions: []Transition{{
-						If: statemachine.GuardNot(guard_WillRetry),
-						To: State_Confirmed,
-					}},
+					Validator:   statemachine.ValidatorNot(validator_WillRetry),
+					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
 			Event_Delegated: {

--- a/core/go/internal/sequencer/originator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine_test.go
@@ -61,6 +61,7 @@ func Test_initializeStateMachine_InvokesTransitionCallback(t *testing.T) {
 
 func Test_HandleEvent_ConfirmedReverted_WillRetry_TransitionsToDelegated(t *testing.T) {
 	ctx := context.Background()
+	// Post-dispatch states support retryable reverts by returning to State_Delegated.
 	states := []State{
 		State_Dispatched,
 		State_Sequenced,
@@ -83,10 +84,18 @@ func Test_HandleEvent_ConfirmedReverted_WillRetry_TransitionsToDelegated(t *test
 
 func Test_HandleEvent_ConfirmedReverted_WillNotRetry_TransitionsToConfirmed(t *testing.T) {
 	ctx := context.Background()
+	// All non-final states transition to State_Confirmed on a non-retryable revert,
+	// mirroring the ConfirmedSuccess fast-forward path used by snapshot recovery.
 	states := []State{
+		State_Pending,
+		State_Delegated,
+		State_Assembling,
+		State_Endorsement_Gathering,
+		State_Prepared,
 		State_Dispatched,
 		State_Sequenced,
 		State_Submitted,
+		State_Parked,
 	}
 
 	for _, state := range states {

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -67,7 +67,6 @@ type originatorTransaction struct {
 	latestSubmissionHash             *pldtypes.Bytes32
 	nonce                            *uint64
 	metrics                          metrics.DistributedSequencerMetrics
-	lastReceivedWillRetry            bool
 	refreshBlockHeight               func(context.Context)
 	getBlockHeight                   func() int64
 	cancelCurrentAssembly            context.CancelFunc

--- a/doc-site/docs/architecture/distributed_sequencer_state_machine_transitions.md
+++ b/doc-site/docs/architecture/distributed_sequencer_state_machine_transitions.md
@@ -231,43 +231,49 @@ stateDiagram-v2
     Initial --> Confirmed : ConfirmedSuccess
     Initial --> Pending : Created
     Pending --> Confirmed : ConfirmedSuccess
+    Pending --> Confirmed : ConfirmedReverted
     Pending --> Delegated : Delegated
     Delegated --> Confirmed : ConfirmedSuccess
+    Delegated --> Confirmed : ConfirmedReverted
     Delegated --> Assembling : AssembleRequestReceived
     Delegated --> Dispatched : Dispatched
     Assembling --> Confirmed : ConfirmedSuccess
+    Assembling --> Confirmed : ConfirmedReverted
     Assembling --> Delegated : Delegated
     Assembling --> Endorsement_Gathering : AssembleAndSignSuccess
     Assembling --> Reverted : AssembleRevert
     Assembling --> Parked : AssemblePark
     Assembling --> Delegated : AssembleError
     Endorsement_Gathering --> Confirmed : ConfirmedSuccess
+    Endorsement_Gathering --> Confirmed : ConfirmedReverted
     Endorsement_Gathering --> Delegated : Delegated
     Endorsement_Gathering --> Assembling : AssembleRequestReceived [!AssembleRequestMatchesPreviousResponse]
     Endorsement_Gathering --> Prepared : PreDispatchRequestReceived
     Prepared --> Confirmed : ConfirmedSuccess
+    Prepared --> Confirmed : ConfirmedReverted
     Prepared --> Delegated : Delegated
     Prepared --> Dispatched : Dispatched
     Prepared --> Assembling : AssembleRequestReceived [!AssembleRequestMatchesPreviousResponse]
     Dispatched --> Confirmed : ConfirmedSuccess
-    Dispatched --> Delegated : ConfirmedReverted [WillRetry]
-    Dispatched --> Confirmed : ConfirmedReverted [!WillRetry]
+    Dispatched --> Delegated : ConfirmedReverted
+    Dispatched --> Confirmed : ConfirmedReverted
     Dispatched --> Delegated : Delegated
     Dispatched --> Sequenced : NonceAssigned
     Dispatched --> Submitted : Submitted
     Dispatched --> Assembling : AssembleRequestReceived
     Sequenced --> Confirmed : ConfirmedSuccess
-    Sequenced --> Delegated : ConfirmedReverted [WillRetry]
-    Sequenced --> Confirmed : ConfirmedReverted [!WillRetry]
+    Sequenced --> Delegated : ConfirmedReverted
+    Sequenced --> Confirmed : ConfirmedReverted
     Sequenced --> Delegated : Delegated
     Sequenced --> Submitted : Submitted
     Sequenced --> Assembling : AssembleRequestReceived
     Submitted --> Confirmed : ConfirmedSuccess
-    Submitted --> Delegated : ConfirmedReverted [WillRetry]
-    Submitted --> Confirmed : ConfirmedReverted [!WillRetry]
+    Submitted --> Delegated : ConfirmedReverted
+    Submitted --> Confirmed : ConfirmedReverted
     Submitted --> Delegated : Delegated
     Submitted --> Assembling : AssembleRequestReceived
     Parked --> Confirmed : ConfirmedSuccess
+    Parked --> Confirmed : ConfirmedReverted
     Parked --> Delegated : Delegated
     Parked --> Pending : Resumed
     Confirmed --> Final : Finalize


### PR DESCRIPTION
* Always include originator in snapshot - this was missing on confirmed. An originator removes a transaction from memory as soon as it is finalized, a coordinator keeps it in memory for a further number of heartbeat intervals. If the transaction is resumed in this time on the originator then processing the confirmed transaction in the heartbeat will cause the resumed transaction to complete also, preventing it from beign redelegated back to the coordinator once it has been removed from memory 
* Include reverted transactions in snapshots too, to allow the same fast forward logic
* Make use of multiple validators to stop storing a temporary will retry value on an originator transaction