### PR TITLE
Take lock when writing or deleting pending private states

### DIFF
--- a/core/go/internal/statemgr/state_completion.go
+++ b/core/go/internal/statemgr/state_completion.go
@@ -24,6 +24,15 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// pendingPrivateStateDataLock is the advisory lock name used to serialize writes to
+// pending_private_state_data against concurrent state arrivals. Both
+// WritePendingPrivateStateDataBatch (event-indexer path) and updatePendingPrivateStateData
+// (state-arrival path) acquire this lock at the start of their DB transaction so that the
+// read-then-write in WritePendingPrivateStateDataBatch and the delete in
+// updatePendingPrivateStateData cannot interleave under PostgreSQL READ COMMITTED isolation.
+// On SQLite and in tests the lock is a no-op.
+const pendingPrivateStateDataLock = "pending_private_state_data"
+
 // pendingPrivateStateData tracks confirmed states for opted-in domains that are still
 // waiting for private data. One row exists per state ID; rows are deleted when
 // the corresponding state data arrives.
@@ -41,9 +50,16 @@ func (pendingPrivateStateData) TableName() string {
 // transaction after the entire event batch has been processed for a domain that supports the
 // completion index. It makes a single getStateIDsMissingPrivateData query for all state IDs
 // in the batch, then writes one row per missing state.
+//
+// An advisory lock (pendingPrivateStateDataLock) is taken before the read so that a concurrent
+// reliable-messaging transaction delivering state data cannot delete a pending row between this
+// function's read of the states table and its write to pending_private_state_data.
 func (ss *stateManager) WritePendingPrivateStateDataBatch(ctx context.Context, dbTX persistence.DBTX, domainName string, states []components.PendingPrivateStateDataEntry) error {
 	if len(states) == 0 {
 		return nil
+	}
+	if err := ss.p.TakeNamedLock(ctx, dbTX, pendingPrivateStateDataLock); err != nil {
+		return err
 	}
 
 	allStateIDs := make([]pldtypes.HexBytes, len(states))
@@ -88,9 +104,17 @@ func (ss *stateManager) WritePendingPrivateStateDataBatch(ctx context.Context, d
 
 // updatePendingPrivateStateData is called internally from writeStates after new states are written.
 // It deletes rows whose state_id matches one of the arrived states.
+//
+// An advisory lock (pendingPrivateStateDataLock) is taken before the delete so that this
+// operation is serialized against WritePendingPrivateStateDataBatch running concurrently in
+// the event-indexer transaction. Without the lock, the delete could run (finding no rows)
+// before the event-indexer transaction commits the pending row, leaving it stranded.
 func (ss *stateManager) updatePendingPrivateStateData(ctx context.Context, dbTX persistence.DBTX, arrivedStateIDs []pldtypes.HexBytes) error {
 	if len(arrivedStateIDs) == 0 {
 		return nil
+	}
+	if err := ss.p.TakeNamedLock(ctx, dbTX, pendingPrivateStateDataLock); err != nil {
+		return err
 	}
 
 	arrivedStrs := make([]string, len(arrivedStateIDs))

--- a/core/go/internal/statemgr/state_completion_test.go
+++ b/core/go/internal/statemgr/state_completion_test.go
@@ -29,6 +29,19 @@ import (
 
 const testDomain = "domain1"
 
+// lockControlledPersistence wraps a real Persistence and allows tests to control the
+// outcome of TakeNamedLock without touching the underlying DB connection.
+type lockControlledPersistence struct {
+	persistence.Persistence
+	lockErr   error
+	lockCalls int
+}
+
+func (p *lockControlledPersistence) TakeNamedLock(_ context.Context, _ persistence.DBTX, _ string) error {
+	p.lockCalls++
+	return p.lockErr
+}
+
 // queryAllPendingRows fetches every row from pending_private_state_data.
 func queryAllPendingRows(t *testing.T, ss *stateManager) []pendingPrivateStateData {
 	t.Helper()
@@ -222,6 +235,35 @@ func TestWritePendingPrivateStateDataBatch_MultipleContracts(t *testing.T) {
 	assert.Equal(t, int64(51), rowByID[id2.String()].BlockNumber)
 }
 
+func TestWritePendingPrivateStateDataBatch_LockAcquisitionError(t *testing.T) {
+	ctx, ss, _, done := newDBTestStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p, lockErr: fmt.Errorf("lock error")}
+	ss.p = wrapper
+
+	contractAddr := *pldtypes.RandAddress()
+	stateID := pldtypes.HexBytes(pldtypes.RandBytes(32))
+	entries := []components.PendingPrivateStateDataEntry{makePendingEntry(stateID, contractAddr, 10)}
+
+	err := ss.WritePendingPrivateStateDataBatch(ctx, ss.p.NOTX(), testDomain, entries)
+	require.ErrorContains(t, err, "lock error")
+	assert.Equal(t, 1, wrapper.lockCalls)
+	assert.Empty(t, queryAllPendingRows(t, ss))
+}
+
+func TestWritePendingPrivateStateDataBatch_EmptyBatch_SkipsLock(t *testing.T) {
+	ctx, ss, _, done := newDBTestStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p}
+	ss.p = wrapper
+
+	err := ss.WritePendingPrivateStateDataBatch(ctx, ss.p.NOTX(), testDomain, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, wrapper.lockCalls)
+}
+
 // ─── updatePendingPrivateStateData ─────────────────────────────────────────────────────
 
 func TestUpdatePendingPrivateStateData_EmptyList(t *testing.T) {
@@ -313,6 +355,36 @@ func TestUpdatePendingPrivateStateData_PartialArrivals(t *testing.T) {
 	rows := queryAllPendingRows(t, ss)
 	require.Len(t, rows, 1)
 	assert.Equal(t, id2.String(), rows[0].StateID)
+}
+
+func TestUpdatePendingPrivateStateData_LockAcquisitionError(t *testing.T) {
+	ctx, ss, _, done := newDBTestStateManager(t)
+	defer done()
+
+	contractAddr := *pldtypes.RandAddress()
+	stateID := pldtypes.HexBytes(pldtypes.RandBytes(32))
+	seedPendingRow(t, ss, contractAddr.String(), stateID, 10)
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p, lockErr: fmt.Errorf("lock error")}
+	ss.p = wrapper
+
+	err := ss.updatePendingPrivateStateData(ctx, ss.p.NOTX(), []pldtypes.HexBytes{stateID})
+	require.ErrorContains(t, err, "lock error")
+	assert.Equal(t, 1, wrapper.lockCalls)
+	// Row must still be present — the delete did not run.
+	assert.Len(t, queryAllPendingRows(t, ss), 1)
+}
+
+func TestUpdatePendingPrivateStateData_EmptyList_SkipsLock(t *testing.T) {
+	ctx, ss, _, done := newDBTestStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p}
+	ss.p = wrapper
+
+	err := ss.updatePendingPrivateStateData(ctx, ss.p.NOTX(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, wrapper.lockCalls)
 }
 
 // ─── CheckPendingPrivateStateDataForContract ──────────────────────────────────────────


### PR DESCRIPTION
It is currently possible for the DBTX that a domain event stream makes when checking for and writing pending private state data to interleave with a reliable message DBTX which is writing new private state data and deleting pending state data entries. This has the effect that neither is atomic and we can have orphaned private state data entries which will never be cleared and permanently block assembly of transactions for affected contracts.

It isn't possible to craft the SQL queries on either side to ensure each DB transaction is atomic, so this PR adds an advisory lock that enforces synchronisation between the two goroutines.