### PR TITLE
Split transaction state query to allow existing DB indexes to be exploited

### DIFF
--- a/core/go/internal/statemgr/statestore.go
+++ b/core/go/internal/statemgr/statestore.go
@@ -181,15 +181,9 @@ func (ss *stateManager) GetTransactionStates(ctx context.Context, dbTX persisten
 	var records []*transactionStateRecord
 	err := dbTX.DB().
 		WithContext(ctx).
-		// Split the original single query with an OR join condition into two UNION ALL parts.
-		// The OR prevented the planner from using the states.id index, forcing a full table scan.
-		//
-		// Part 1: all four record types resolved by direct state ID.
-		//   Spend records that reference a nullifier ID (not a state ID) are excluded via NOT EXISTS
-		//   so they do not appear as "unavailable" here while Part 2 returns them with state data.
-		//
-		// Part 2: spend records resolved through state_nullifiers → states (nullifier-spent states).
-		//   LEFT JOIN preserves the unavailable row when the state itself is missing.
+		// Previously we used OR join condition to join the records table with the states table.
+		// This prevented the planner from using the states.id index, forcing a full table scan.
+		// Instead we use union all to join the records table with the states table.
 		Raw(`SELECT "states".*, "records"."state", "records"."transaction", "records"."record_type" FROM ( `+
 			`SELECT "transaction", "state", 'spent' AS "record_type" FROM "state_spend_records" WHERE "transaction" = ? `+
 			`  AND NOT EXISTS (SELECT 1 FROM "state_nullifiers" WHERE "state_nullifiers"."id" = "state_spend_records"."state") `+

--- a/core/go/internal/statemgr/statestore.go
+++ b/core/go/internal/statemgr/statestore.go
@@ -181,27 +181,30 @@ func (ss *stateManager) GetTransactionStates(ctx context.Context, dbTX persisten
 	var records []*transactionStateRecord
 	err := dbTX.DB().
 		WithContext(ctx).
-		// This query joins across three tables in a single query - pushing the complexity to the DB.
-		// The reason we have three tables is to make the queries for available states simpler.
-		Raw(`SELECT "states".*, "records"."state", "records"."transaction", "records"."record_type" from "states" RIGHT JOIN ( `+
-			`SELECT "transaction", "state", 'spent'     AS "record_type" FROM "state_spend_records"   WHERE "transaction" = ? UNION ALL `+
+		// Split the original single query with an OR join condition into two UNION ALL parts.
+		// The OR prevented the planner from using the states.id index, forcing a full table scan.
+		//
+		// Part 1: all four record types resolved by direct state ID.
+		//   Spend records that reference a nullifier ID (not a state ID) are excluded via NOT EXISTS
+		//   so they do not appear as "unavailable" here while Part 2 returns them with state data.
+		//
+		// Part 2: spend records resolved through state_nullifiers → states (nullifier-spent states).
+		//   LEFT JOIN preserves the unavailable row when the state itself is missing.
+		Raw(`SELECT "states".*, "records"."state", "records"."transaction", "records"."record_type" FROM ( `+
+			`SELECT "transaction", "state", 'spent' AS "record_type" FROM "state_spend_records" WHERE "transaction" = ? `+
+			`  AND NOT EXISTS (SELECT 1 FROM "state_nullifiers" WHERE "state_nullifiers"."id" = "state_spend_records"."state") `+
+			`UNION ALL `+
 			`SELECT "transaction", "state", 'read'      AS "record_type" FROM "state_read_records"    WHERE "transaction" = ? UNION ALL `+
 			`SELECT "transaction", "state", 'confirmed' AS "record_type" FROM "state_confirm_records" WHERE "transaction" = ? UNION ALL `+
-			`SELECT "transaction", "state", 'info'      AS "record_type" FROM "state_info_records"    WHERE "transaction" = ? ) AS "records" `+
-			// Resolve state references:
-			//   1) direct state ID match
-			//   2) OR nullifier ID → state ID (only for spent records)
-			`ON ("states"."id" = "records"."state"
-			    OR ("records"."record_type" = 'spent'
-				    AND EXISTS (
-					    SELECT 1
-						  FROM "state_nullifiers"
-					    WHERE "state_nullifiers"."id" = "records"."state"
-              AND "state_nullifiers"."state" = "states"."id"
-					  )
-					)
-				)`,
-			txID, txID, txID, txID).
+			`SELECT "transaction", "state", 'info'      AS "record_type" FROM "state_info_records"    WHERE "transaction" = ? `+
+			`) AS "records" LEFT JOIN "states" ON "states"."id" = "records"."state" `+
+			`UNION ALL `+
+			`SELECT "states".*, "sn"."id" AS "state", "sr"."transaction", 'spent' AS "record_type" `+
+			`FROM "state_spend_records" "sr" `+
+			`JOIN "state_nullifiers" "sn" ON "sn"."id" = "sr"."state" `+
+			`LEFT JOIN "states" ON "states"."id" = "sn"."state" `+
+			`WHERE "sr"."transaction" = ?`,
+			txID, txID, txID, txID, txID).
 		Scan(&records).
 		Error
 	if err != nil {

--- a/core/go/internal/statemgr/statestore.go
+++ b/core/go/internal/statemgr/statestore.go
@@ -181,6 +181,8 @@ func (ss *stateManager) GetTransactionStates(ctx context.Context, dbTX persisten
 	var records []*transactionStateRecord
 	err := dbTX.DB().
 		WithContext(ctx).
+		// This query joins across three tables in a single query - pushing the complexity to the DB.
+		// The reason we have three tables is to make the queries for available states simpler.
 		// Previously we used OR join condition to join the records table with the states table.
 		// This prevented the planner from using the states.id index, forcing a full table scan.
 		// Instead we use union all to join the records table with the states table.


### PR DESCRIPTION
Analysis of `state_nullifier` queries shows that the use of OR conditions was negating the ability to use the existing index on state.id. This change refactors the query in a way that unions multiple queries. It's a non breaking change, and testing has shown that it dramatically improves DB performance.