### PR TITLE
API changes for UI

### DIFF
--- a/core/go/internal/filters/field_bytes32.go
+++ b/core/go/internal/filters/field_bytes32.go
@@ -35,7 +35,7 @@ func (sf Bytes32Field) SQLColumn() string {
 }
 
 func (sf Bytes32Field) SupportsLIKE() bool {
-	return true
+	return false
 }
 
 func (sf Bytes32Field) SQLValue(ctx context.Context, jsonValue pldtypes.RawJSON) (driver.Value, error) {

--- a/core/go/internal/filters/field_bytes32_test.go
+++ b/core/go/internal/filters/field_bytes32_test.go
@@ -50,10 +50,6 @@ func TestBytes32Field(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, nv)
 
-	assert.True(t, Bytes32Field("test").SupportsLIKE())
-
-	v, err = resolveLikeValue(ctx, "test", (pldtypes.RawJSON)(`"a%"`))
-	require.NoError(t, err)
-	assert.Equal(t, "a%", v)
+	assert.False(t, Bytes32Field("test").SupportsLIKE())
 
 }

--- a/core/go/internal/filters/field_hexbytes.go
+++ b/core/go/internal/filters/field_hexbytes.go
@@ -35,7 +35,7 @@ func (sf HexBytesField) SQLColumn() string {
 }
 
 func (sf HexBytesField) SupportsLIKE() bool {
-	return true
+	return false
 }
 
 func (sf HexBytesField) SQLValue(ctx context.Context, jsonValue pldtypes.RawJSON) (driver.Value, error) {

--- a/core/go/internal/filters/field_hexbytes_test.go
+++ b/core/go/internal/filters/field_hexbytes_test.go
@@ -47,10 +47,6 @@ func TestHexBytesField(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, nv)
 
-	assert.True(t, HexBytesField("test").SupportsLIKE())
-
-	v, err = resolveLikeValue(ctx, "test", (pldtypes.RawJSON)(`"a%"`))
-	require.NoError(t, err)
-	assert.Equal(t, "a%", v)
+	assert.False(t, HexBytesField("test").SupportsLIKE())
 
 }

--- a/core/go/internal/filters/field_uuid.go
+++ b/core/go/internal/filters/field_uuid.go
@@ -34,7 +34,7 @@ func (sf UUIDField) SQLColumn() string {
 }
 
 func (sf UUIDField) SupportsLIKE() bool {
-	return true
+	return false
 }
 
 func (sf UUIDField) SQLValue(ctx context.Context, jsonValue pldtypes.RawJSON) (driver.Value, error) {

--- a/core/go/internal/filters/field_uuid_test.go
+++ b/core/go/internal/filters/field_uuid_test.go
@@ -48,10 +48,6 @@ func TestUUIDField(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, nv)
 
-	assert.True(t, UUIDField("test").SupportsLIKE())
-
-	v, err = resolveLikeValue(ctx, "test", (pldtypes.RawJSON)(`"%2ef2-4b91-8f73%"`))
-	require.NoError(t, err)
-	assert.Equal(t, "%2ef2-4b91-8f73%", v)
+	assert.False(t, UUIDField("test").SupportsLIKE())
 
 }

--- a/core/go/internal/filters/query_traverser.go
+++ b/core/go/internal/filters/query_traverser.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"context"
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -147,21 +146,6 @@ func resolveValue(ctx context.Context, fieldName string, field FieldResolver, js
 	return value, nil
 }
 
-func resolveLikeValue(ctx context.Context, fieldName string, jsonValue pldtypes.RawJSON) (driver.Value, error) {
-	if len(jsonValue) == 0 {
-		return nil, i18n.NewError(ctx, msgs.MsgFiltersValueMissing, fieldName)
-	}
-	var untyped interface{}
-	if err := json.Unmarshal(jsonValue, &untyped); err != nil {
-		return nil, err
-	}
-	s, ok := untyped.(string)
-	if !ok {
-		return nil, i18n.NewError(ctx, msgs.MsgFiltersValueInvalidForString, string(jsonValue))
-	}
-	return s, nil
-}
-
 func resolveFieldAndValue(ctx context.Context, fieldSet FieldSet, fieldName string, jsonValue pldtypes.RawJSON) (FieldResolver, driver.Value, error) {
 	field, err := resolveField(ctx, fieldSet, fieldName)
 	if err != nil {
@@ -197,16 +181,12 @@ func (qt *queryTraverser[T]) addSimpleFilters(t Traverser[T], jf *query.Statemen
 		t = t.IsEqual(e, e.Field, field, testValue)
 	}
 	for _, e := range jf.Like {
-		field, err := resolveField(qt.ctx, qt.fieldSet, e.Field)
+		field, testValue, err := resolveFieldAndValue(qt.ctx, qt.fieldSet, e.Field, e.Value)
 		if err != nil {
 			return t.WithError(err)
 		}
 		if !field.SupportsLIKE() {
 			return t.WithError(i18n.NewError(qt.ctx, msgs.MsgFiltersFieldTypeDoesNotSupportLike, field))
-		}
-		testValue, err := resolveLikeValue(qt.ctx, e.Field, e.Value)
-		if err != nil {
-			return t.WithError(err)
 		}
 		t = t.IsLike(e, e.Field, field, testValue)
 	}

--- a/core/go/internal/filters/query_traverser_gorm.go
+++ b/core/go/internal/filters/query_traverser_gorm.go
@@ -104,27 +104,18 @@ func (t *gormTraverser) IsEqual(e *query.OpSingleVal, fieldName string, field Fi
 	return t
 }
 
-func likeSQLColumn(field FieldResolver) string {
-	col := field.SQLColumn()
-	if _, ok := field.(UUIDField); ok {
-		return fmt.Sprintf("CAST(%s AS TEXT)", col)
-	}
-	return col
-}
-
 func (t *gormTraverser) IsLike(e *query.OpSingleVal, fieldName string, field FieldResolver, testValue driver.Value) Traverser[*gormTraverser] {
-	col := likeSQLColumn(field)
 	if e.CaseInsensitive {
 		if e.Not {
-			t.db = t.db.Where(fmt.Sprintf("%s NOT ILIKE ?", col), testValue)
+			t.db = t.db.Where(fmt.Sprintf("%s NOT ILIKE ?", field.SQLColumn()), testValue)
 		} else {
-			t.db = t.db.Where(fmt.Sprintf("%s ILIKE ?", col), testValue)
+			t.db = t.db.Where(fmt.Sprintf("%s ILIKE ?", field.SQLColumn()), testValue)
 		}
 	} else {
 		if e.Not {
-			t.db = t.db.Where(fmt.Sprintf("%s NOT LIKE ?", col), testValue)
+			t.db = t.db.Where(fmt.Sprintf("%s NOT LIKE ?", field.SQLColumn()), testValue)
 		} else {
-			t.db = t.db.Where(fmt.Sprintf("%s LIKE ?", col), testValue)
+			t.db = t.db.Where(fmt.Sprintf("%s LIKE ?", field.SQLColumn()), testValue)
 		}
 	}
 	return t

--- a/core/go/internal/filters/query_traverser_gorm_test.go
+++ b/core/go/internal/filters/query_traverser_gorm_test.go
@@ -342,65 +342,6 @@ func TestBuildQueryJSONLike(t *testing.T) {
 	assert.Equal(t, "SELECT count(*) FROM \"test\" WHERE tag LIKE '%%stuff%%' AND tag NOT LIKE 'abc' AND tag ILIKE 'ABC' AND tag NOT ILIKE 'abc' LIMIT 10", generatedSQL)
 }
 
-func TestBuildQueryJSONLikeHexFields(t *testing.T) {
-
-	var qf query.QueryJSON
-	err := json.Unmarshal([]byte(`{
-		"like": [
-			{
-				"field": "contractAddress",
-				"value": "a%"
-			},
-			{
-				"field": "schema",
-				"value": "00%"
-			}
-		]
-	}`), &qf)
-	require.NoError(t, err)
-
-	p, err := mockpersistence.NewSQLMockProvider()
-	require.NoError(t, err)
-	generatedSQL := p.P.DB().ToSQL(func(tx *gorm.DB) *gorm.DB {
-		var count int64
-		db := BuildGORM(context.Background(), &qf, tx.Table("test"), FieldMap{
-			"contractAddress": HexBytesField("contract_address"),
-			"schema":          Bytes32Field("schema"),
-		}).Count(&count)
-		require.NoError(t, db.Error)
-		return db
-	})
-
-	assert.Equal(t, "SELECT count(*) FROM \"test\" WHERE contract_address LIKE 'a%' AND schema LIKE '00%'", generatedSQL)
-}
-
-func TestBuildQueryJSONLikeUUIDField(t *testing.T) {
-
-	var qf query.QueryJSON
-	err := json.Unmarshal([]byte(`{
-		"like": [
-			{
-				"field": "id",
-				"value": "%2ef2-4b91-8f73%"
-			}
-		]
-	}`), &qf)
-	require.NoError(t, err)
-
-	p, err := mockpersistence.NewSQLMockProvider()
-	require.NoError(t, err)
-	generatedSQL := p.P.DB().ToSQL(func(tx *gorm.DB) *gorm.DB {
-		var count int64
-		db := BuildGORM(context.Background(), &qf, tx.Table("test"), FieldMap{
-			"id": UUIDField(`"reliable_msgs"."id"`),
-		}).Count(&count)
-		require.NoError(t, db.Error)
-		return db
-	})
-
-	assert.Equal(t, `SELECT count(*) FROM "test" WHERE CAST("reliable_msgs"."id" AS TEXT) LIKE '%2ef2-4b91-8f73%'`, generatedSQL)
-}
-
 func TestBuildQueryJSONGreaterThan(t *testing.T) {
 
 	var qf query.QueryJSON

--- a/core/go/internal/filters/query_traverser_inline_eval.go
+++ b/core/go/internal/filters/query_traverser_inline_eval.go
@@ -26,7 +26,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
-	"github.com/google/uuid"
 )
 
 type ValueSet interface {
@@ -154,7 +153,7 @@ func (t *inlineEval) doCompare(e *query.Op, fieldName string, field FieldResolve
 		// REMEMBER - if you update this function you must update BuildQueryCompareLessFunc() too
 		switch testValueTyped := testValue.(type) {
 		case string:
-			strValue, ok := valueAsString(actualValue)
+			strValue, ok := actualValue.(string)
 			if !ok {
 				return t.withError(i18n.NewError(t.ctx, msgs.MsgFiltersUnexpectedResolvedValueType, actualValue, testValue))
 			}
@@ -177,17 +176,6 @@ func (t *inlineEval) doCompare(e *query.Op, fieldName string, field FieldResolve
 		t.matches = t.matches && valMatches
 	}
 	return t
-}
-
-func valueAsString(actualValue driver.Value) (string, bool) {
-	switch v := actualValue.(type) {
-	case string:
-		return v, true
-	case uuid.UUID:
-		return v.String(), true
-	default:
-		return "", false
-	}
 }
 
 func (t *inlineEval) IsEqual(e *query.OpSingleVal, fieldName string, field FieldResolver, testValue driver.Value) Traverser[*inlineEval] {

--- a/core/go/internal/filters/query_traverser_inline_eval_test.go
+++ b/core/go/internal/filters/query_traverser_inline_eval_test.go
@@ -683,60 +683,6 @@ func TestEvalQueryMatchLike(t *testing.T) {
 	assert.False(t, match)
 }
 
-func TestEvalQueryMatchLikeHexFields(t *testing.T) {
-
-	hexFieldMap := FieldMap{
-		"contractAddress": HexBytesField("contract_address"),
-		"schema":          Bytes32Field("schema"),
-	}
-
-	var qf *query.QueryJSON
-	err := json.Unmarshal([]byte(`{"like": [{"field": "contractAddress", "value": "a%"}]}`), &qf)
-	require.NoError(t, err)
-	match, err := EvalQuery(context.Background(), qf, hexFieldMap, ResolvingValueSet{
-		"contractAddress": pldtypes.RawJSON(`"0xabcdef1234567890"`),
-	})
-	require.NoError(t, err)
-	assert.True(t, match)
-
-	match, err = EvalQuery(context.Background(), qf, hexFieldMap, ResolvingValueSet{
-		"contractAddress": pldtypes.RawJSON(`"0x1234567890abcdef"`),
-	})
-	require.NoError(t, err)
-	assert.False(t, match)
-
-	err = json.Unmarshal([]byte(`{"like": [{"field": "schema", "value": "00%"}]}`), &qf)
-	require.NoError(t, err)
-	match, err = EvalQuery(context.Background(), qf, hexFieldMap, PassthroughValueSet{
-		"schema": "0001020304050607080910111213141516171819202122232425262728293031",
-	})
-	require.NoError(t, err)
-	assert.True(t, match)
-}
-
-func TestEvalQueryLikeUUIDField(t *testing.T) {
-
-	uuidFieldMap := FieldMap{
-		"id": UUIDField("id"),
-	}
-
-	var qf *query.QueryJSON
-	err := json.Unmarshal([]byte(`{"like": [{"field": "id", "value": "%2ef2-4b91-8f73%"}]}`), &qf)
-	require.NoError(t, err)
-
-	match, err := EvalQuery(context.Background(), qf, uuidFieldMap, ResolvingValueSet{
-		"id": pldtypes.RawJSON(`"00002ef2-4b91-8f73-0000-000000000000"`),
-	})
-	require.NoError(t, err)
-	assert.True(t, match)
-
-	match, err = EvalQuery(context.Background(), qf, uuidFieldMap, ResolvingValueSet{
-		"id": pldtypes.RawJSON(`"F9E01529-6551-4C8E-8ACE-F1C4A6A1943F"`),
-	})
-	require.NoError(t, err)
-	assert.False(t, match)
-}
-
 func TestEvalQueryLikeFail(t *testing.T) {
 
 	eval := &inlineEval{

--- a/core/go/internal/transportmgr/manager.go
+++ b/core/go/internal/transportmgr/manager.go
@@ -96,6 +96,10 @@ var reliableMessageAckFilters = filters.FieldMap{
 	"error":     filters.StringField("error"),
 }
 
+var peerInfoFilters = filters.FieldMap{
+	"name": filters.StringField("name"),
+}
+
 func NewTransportManager(bgCtx context.Context, conf *pldconf.TransportManagerInlineConfig) components.TransportManager {
 	tm := &transportManager{
 		conf:                      conf,

--- a/core/go/internal/transportmgr/peer.go
+++ b/core/go/internal/transportmgr/peer.go
@@ -27,10 +27,12 @@ import (
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
+	"github.com/LFDT-Paladin/paladin/core/internal/filters"
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"gorm.io/gorm/clause"
 )
@@ -102,21 +104,69 @@ func (tm *transportManager) listActivePeers() nameSortedPeers {
 	return peers
 }
 
-func (tm *transportManager) listActivePeerInfo() []*pldapi.PeerInfo {
-	peers := tm.listActivePeers()
-	peerInfo := make([]*pldapi.PeerInfo, len(peers))
-	for i, p := range peers {
-		peerInfo[i] = &p.PeerInfo
-	}
-	return peerInfo
-}
-
 func (tm *transportManager) getPeerInfo(nodeName string) *pldapi.PeerInfo {
 	peer := tm.getActivePeer(nodeName)
 	if peer == nil {
 		return nil
 	}
 	return &peer.PeerInfo
+}
+
+type peerWithValueSet struct {
+	info *pldapi.PeerInfo
+	vs   filters.PassthroughValueSet
+}
+
+func (p *peerWithValueSet) ValueSet() filters.ValueSet {
+	return p.vs
+}
+
+func peerInfoValueSet(p *pldapi.PeerInfo) filters.PassthroughValueSet {
+	return filters.PassthroughValueSet{
+		"name": p.Name,
+	}
+}
+
+func (tm *transportManager) QueryPeers(ctx context.Context, jq *query.QueryJSON) ([]*pldapi.PeerInfo, error) {
+	if err := filters.CheckLimitSet(ctx, jq); err != nil {
+		return nil, err
+	}
+
+	sortInstructions := jq.Sort
+	if len(sortInstructions) == 0 {
+		sortInstructions = []string{"name"}
+	}
+
+	peers := tm.listActivePeers()
+	matches := make([]*peerWithValueSet, 0, len(peers))
+	for _, p := range peers {
+		pws := &peerWithValueSet{
+			info: &p.PeerInfo,
+			vs:   peerInfoValueSet(&p.PeerInfo),
+		}
+		match, err := filters.EvalQuery(ctx, jq, peerInfoFilters, pws.vs)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			matches = append(matches, pws)
+		}
+	}
+
+	if err := filters.SortValueSetInPlace(ctx, peerInfoFilters, matches, sortInstructions...); err != nil {
+		return nil, err
+	}
+
+	limit := *jq.Limit
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+
+	result := make([]*pldapi.PeerInfo, len(matches))
+	for i, p := range matches {
+		result[i] = p.info
+	}
+	return result, nil
 }
 
 // efficient read-locked call to get an active peer connection

--- a/core/go/internal/transportmgr/peer_test.go
+++ b/core/go/internal/transportmgr/peer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/retry"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
@@ -336,6 +337,37 @@ func TestNameSortedPeers(t *testing.T) {
 		{PeerInfo: pldapi.PeerInfo{Name: "ddd"}},
 	}, peerList)
 
+}
+
+func TestQueryPeers(t *testing.T) {
+	ctx := context.Background()
+	tm := &transportManager{
+		peers: map[string]*peer{
+			"node1": {PeerInfo: pldapi.PeerInfo{Name: "node1"}},
+			"node2": {PeerInfo: pldapi.PeerInfo{Name: "node2"}},
+			"node3": {PeerInfo: pldapi.PeerInfo{Name: "node3"}},
+		},
+	}
+
+	peers, err := tm.QueryPeers(ctx, query.NewQueryBuilder().
+		In("name", []any{"node1", "node3"}).
+		Limit(10).
+		Query())
+	require.NoError(t, err)
+	require.Len(t, peers, 2)
+	require.Equal(t, "node1", peers[0].Name)
+	require.Equal(t, "node3", peers[1].Name)
+
+	peers, err = tm.QueryPeers(ctx, query.NewQueryBuilder().
+		Equal("name", "node2").
+		Limit(10).
+		Query())
+	require.NoError(t, err)
+	require.Len(t, peers, 1)
+	require.Equal(t, "node2", peers[0].Name)
+
+	_, err = tm.QueryPeers(ctx, query.NewQueryBuilder().Query())
+	require.Regexp(t, "PD010721", err)
 }
 
 func TestConnectionRace(t *testing.T) {

--- a/core/go/internal/transportmgr/transportmgr_rpc.go
+++ b/core/go/internal/transportmgr/transportmgr_rpc.go
@@ -34,7 +34,7 @@ func (tm *transportManager) initRPC() {
 		Add("transport_nodeName", tm.rpcNodeName()).
 		Add("transport_localTransports", tm.rpcLocalTransports()).
 		Add("transport_localTransportDetails", tm.rpcLocalTransportDetails()).
-		Add("transport_peers", tm.rpcPeers()).
+		Add("transport_queryPeers", tm.rpcQueryPeers()).
 		Add("transport_peerInfo", tm.rpcPeerInfo()).
 		Add("transport_queryReliableMessages", tm.rpcQueryReliableMessages()).
 		Add("transport_queryReliableMessageAcks", tm.rpcQueryReliableMessageAcks())
@@ -65,10 +65,10 @@ func (tm *transportManager) rpcLocalTransportDetails() rpcserver.RPCHandler {
 	})
 }
 
-func (tm *transportManager) rpcPeers() rpcserver.RPCHandler {
-	return rpcserver.RPCMethod0(func(ctx context.Context) ([]*pldapi.PeerInfo, error) {
-		// ctx = log.WithComponent(ctx, "transportmanager")
-		return tm.listActivePeerInfo(), nil
+func (tm *transportManager) rpcQueryPeers() rpcserver.RPCHandler {
+	return rpcserver.RPCMethod1(func(ctx context.Context, jq query.QueryJSON) ([]*pldapi.PeerInfo, error) {
+		ctx = log.WithComponent(ctx, "transportmanager")
+		return tm.QueryPeers(ctx, &jq)
 	})
 }
 

--- a/core/go/internal/transportmgr/transportmgr_rpc_test.go
+++ b/core/go/internal/transportmgr/transportmgr_rpc_test.go
@@ -67,7 +67,7 @@ func TestRPCLocalDetails(t *testing.T) {
 	_, err := tm.getPeer(ctx, "node2", false)
 	require.NoError(t, err)
 
-	peers, rpcErr := transportRPC.Peers(ctx)
+	peers, rpcErr := transportRPC.QueryPeers(ctx, query.NewQueryBuilder().Limit(100).Query())
 	require.NoError(t, rpcErr)
 	require.Len(t, peers, 1)
 	require.Equal(t, "node2", peers[0].Name)

--- a/doc-site/docs/reference/apis/transport.md
+++ b/doc-site/docs/reference/apis/transport.md
@@ -33,7 +33,11 @@ title: transport_*
 
 0. `peer`: [`PeerInfo`](../types/peerinfo.md#peerinfo)
 
-## `transport_peers`
+## `transport_queryPeers`
+
+### Parameters
+
+0. `query`: [`QueryJSON`](../types/queryjson.md#queryjson)
 
 ### Returns
 

--- a/sdk/go/pkg/pldclient/transport.go
+++ b/sdk/go/pkg/pldclient/transport.go
@@ -28,7 +28,7 @@ type Transport interface {
 	NodeName(ctx context.Context) (nodeName string, err error)
 	LocalTransports(ctx context.Context) (transportNames []string, err error)
 	LocalTransportDetails(ctx context.Context, transportName string) (transportDetailsStr string, err error)
-	Peers(ctx context.Context) (peers []*pldapi.PeerInfo, err error)
+	QueryPeers(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error)
 	PeerInfo(ctx context.Context, nodeName string) (peer *pldapi.PeerInfo, err error)
 	QueryReliableMessages(ctx context.Context, query *query.QueryJSON) (reliableMessages []*pldapi.ReliableMessage, err error)
 	QueryReliableMessageAcks(ctx context.Context, query *query.QueryJSON) (reliableMessageAcks []*pldapi.ReliableMessageAck, err error)
@@ -50,8 +50,8 @@ var transportInfo = &rpcModuleInfo{
 			Inputs: []string{"transportName"},
 			Output: "transportDetailsStr",
 		},
-		"transport_peers": {
-			Inputs: []string{},
+		"transport_queryPeers": {
+			Inputs: []string{"query"},
 			Output: "peers",
 		},
 		"transport_peerInfo": {
@@ -95,8 +95,8 @@ func (t *transport) LocalTransportDetails(ctx context.Context, transportName str
 	return
 }
 
-func (t *transport) Peers(ctx context.Context) (peers []*pldapi.PeerInfo, err error) {
-	err = t.c.CallRPC(ctx, &peers, "transport_peers")
+func (t *transport) QueryPeers(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error) {
+	err = t.c.CallRPC(ctx, &peers, "transport_queryPeers", query)
 	return
 }
 

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -1109,8 +1109,11 @@ export default class PaladinClient {
       return res.data.result;
     },
 
-    peers: async () => {
-      const res = await this.post<JsonRpcResult<any[]>>("transport_peers", []);
+    queryPeers: async (query: IQuery) => {
+      const res = await this.post<JsonRpcResult<any[]>>(
+        "transport_queryPeers",
+        [query]
+      );
       return res.data.result;
     },
 


### PR DESCRIPTION
The main change introduced in this PR is the modification to the JSON RPC API method `transport_peers`. It currently does not accept any arguments so there is no control of how many results it returns or which ones. In this PR the method is renamed to `transport_queryPeers` to follow the same naming convention used in other methods within Paladin. It now accepts one JSON Query argument.
Other changes in this PR: revert changes introduced in PR 1214. Specifically, in that PR `SupportsLIKE` was switched from `false` to `true` for certain fields in order to allow for queries where the user may know how a value starts, ends or what characters it may contain. This could have an impact on performance so the `SupportsLIKE` was restored to return `false`. Instead, the UI has been updated so that when applying a filter to a field that does not support `LIKE`, the comparisons `starts with`, `ends with`, `contains`, `does not contain`, `does not start with` and `does not end with` are removed.
