### PR TITLE
More debug server options

### DIFF
--- a/common/go/pkg/pldmsgs/en_descriptions.go
+++ b/common/go/pkg/pldmsgs/en_descriptions.go
@@ -620,7 +620,9 @@ var (
 	StaticServerConfigBaseRedirect = pdm("StaticServerConfig.baseRedirect", "Redirect URL when hitting base path")
 
 	// DebugServerConfig field descriptions
-	DebugServerConfigEnabled = pdm("DebugServerConfig.enabled", "Whether debug server is enabled")
+	DebugServerConfigEnabled              = pdm("DebugServerConfig.enabled", "Whether debug server is enabled")
+	DebugServerConfigBlockProfileRate     = pdm("DebugServerConfig.blockProfileRate", "Rate for runtime block profiling exposed at /debug/pprof/block: 0 disables it, 1 records every blocking event, N samples one event in N")
+	DebugServerConfigMutexProfileFraction = pdm("DebugServerConfig.mutexProfileFraction", "Fraction for runtime mutex profiling exposed at /debug/pprof/mutex: 0 disables it, 1 records every contention event, N samples one event in N")
 
 	// MetricsServerConfig field descriptions
 	MetricsServerConfigEnabled = pdm("MetricsServerConfig.enabled", "Whether metrics server is enabled")

--- a/config/pkg/pldconf/httpserver.go
+++ b/config/pkg/pldconf/httpserver.go
@@ -56,13 +56,17 @@ type StaticServerConfig struct {
 }
 
 type DebugServerConfig struct {
-	Enabled *bool `json:"enabled"`
+	Enabled              *bool `json:"enabled"`
+	BlockProfileRate     *int  `json:"blockProfileRate"`     // BlockProfileRate sets runtime.SetBlockProfileRate; 0 disables block profiling, 1 records every event, N samples 1/N.
+	MutexProfileFraction *int  `json:"mutexProfileFraction"` // MutexProfileFraction sets runtime.SetMutexProfileFraction; 0 disables mutex profiling, 1 records every event, N samples 1/N.
 	HTTPServerConfig
 }
 
 var DebugServerDefaults = DebugServerConfig{
-	Enabled:          confutil.P(false),
-	HTTPServerConfig: HTTPDefaults,
+	Enabled:              confutil.P(false),
+	BlockProfileRate:     confutil.P(0),
+	MutexProfileFraction: confutil.P(0),
+	HTTPServerConfig:     HTTPDefaults,
 }
 
 type MetricsServerConfig struct {

--- a/core/go/internal/componentmgr/manager.go
+++ b/core/go/internal/componentmgr/manager.go
@@ -18,6 +18,7 @@ package componentmgr
 import (
 	"context"
 	"net/http"
+	"runtime"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -134,6 +135,10 @@ func (cm *componentManager) javaDump(res http.ResponseWriter, req *http.Request)
 }
 
 func (cm *componentManager) startDebugServer() (httpserver.Server, error) {
+	// Enable block and mutex profiling so /debug/pprof/block and /debug/pprof/mutex return data.
+	// Both default to 0 (disabled); a positive rate records every event (1) or samples 1/N.
+	runtime.SetBlockProfileRate(confutil.Int(cm.conf.DebugServer.BlockProfileRate, *pldconf.DebugServerDefaults.BlockProfileRate))
+	runtime.SetMutexProfileFraction(confutil.Int(cm.conf.DebugServer.MutexProfileFraction, *pldconf.DebugServerDefaults.MutexProfileFraction))
 	cm.conf.DebugServer.Port = confutil.P(confutil.Int(cm.conf.DebugServer.Port, 0)) // if enabled with no port, we allocate one
 	server, err := httpserver.NewDebugServer(cm.bgCtx, &cm.conf.DebugServer.HTTPServerConfig)
 	if err == nil {

--- a/doc-site/docs/administration/configuration.md
+++ b/doc-site/docs/administration/configuration.md
@@ -235,10 +235,12 @@
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
 | address | Server address | `string` | `"127.0.0.1"` |
+| blockProfileRate | Rate for runtime block profiling exposed at /debug/pprof/block: 0 disables it, 1 records every blocking event, N samples one event in N | `int` | `0` |
 | cors | CORS configuration | [`CORSConfig`](#debugservercors) | - |
 | defaultRequestTimeout | Default request timeout | `string` | `"2m"` |
 | enabled | Whether debug server is enabled | `bool` | `false` |
 | maxRequestTimeout | Maximum request timeout | `string` | `"10m"` |
+| mutexProfileFraction | Fraction for runtime mutex profiling exposed at /debug/pprof/mutex: 0 disables it, 1 records every contention event, N samples one event in N | `int` | `0` |
 | port | Server port | `int` | - |
 | readTimeout | Read timeout | `string` | - |
 | shutdownTimeout | Shutdown timeout | `string` | `"10s"` |


### PR DESCRIPTION
Allow more types of profile to be collected from the debug server- off by default