### PR TITLE
Fix in-memory listener state bug

### DIFF
--- a/core/go/internal/txmgr/rpcmodule_test.go
+++ b/core/go/internal/txmgr/rpcmodule_test.go
@@ -804,8 +804,12 @@ func TestRPCBlockchainEventListenersCRUD(t *testing.T) {
 			Return(mockESHandle, nil)
 		mc.blockIndexer.On("QueryEventStreamDefinitions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return([]*blockindexer.EventStreamDefinition{es}, nil)
-		mc.blockIndexer.On("StartEventStream", mock.Anything, id).Return(nil)
-		mc.blockIndexer.On("StopEventStream", mock.Anything, id).Return(nil)
+		mc.blockIndexer.On("StartEventStream", mock.Anything, id).Run(func(args mock.Arguments) {
+			es.Started = confutil.P(true)
+		}).Return(nil)
+		mc.blockIndexer.On("StopEventStream", mock.Anything, id).Run(func(args mock.Arguments) {
+			es.Started = confutil.P(false)
+		}).Return(nil)
 		mc.blockIndexer.On("RemoveEventStream", mock.Anything, id).Return(nil)
 		mc.blockIndexer.On("GetEventStreamStatus", mock.Anything, id).Return(&blockindexer.EventStreamStatus{}, nil)
 	})
@@ -856,10 +860,28 @@ func TestRPCBlockchainEventListenersCRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, *boolRes)
 
+	err = rpcClient.CallRPC(ctx, &l, "ptx_getBlockchainEventListener", "listener1")
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	require.NotNil(t, l.Started)
+	assert.False(t, *l.Started)
+
+	err = rpcClient.CallRPC(ctx, &listeners, "ptx_queryBlockchainEventListeners", query.NewQueryBuilder().Limit(1).Query())
+	require.NoError(t, err)
+	require.Len(t, listeners, 1)
+	require.NotNil(t, listeners[0].Started)
+	assert.False(t, *listeners[0].Started)
+
 	// Start listener
 	err = rpcClient.CallRPC(ctx, &boolRes, "ptx_startBlockchainEventListener", "listener1")
 	require.NoError(t, err)
 	assert.True(t, *boolRes)
+
+	err = rpcClient.CallRPC(ctx, &l, "ptx_getBlockchainEventListener", "listener1")
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	require.NotNil(t, l.Started)
+	assert.True(t, *l.Started)
 
 	// Delete listener
 	err = rpcClient.CallRPC(ctx, &boolRes, "ptx_deleteBlockchainEventListener", "listener1")

--- a/core/go/pkg/blockindexer/event_streams.go
+++ b/core/go/pkg/blockindexer/event_streams.go
@@ -420,6 +420,11 @@ func (es *eventStream) start(updateDB bool) error {
 			if err != nil {
 				return err
 			}
+			// Keep in-memory definition in sync with DB so callers of Definition()
+			// (e.g. ptx_getBlockchainEventListener) see the current started status.
+			// Only update when persisting — temporary runtime stops/starts must not
+			// overwrite the configured/desired started state.
+			es.definition.Started = confutil.P(true)
 		}
 		es.detectorDone = make(chan struct{})
 		es.dispatcherDone = make(chan struct{})
@@ -442,6 +447,11 @@ func (es *eventStream) stop(updateDB bool) error {
 		if err != nil {
 			return err
 		}
+		// Keep in-memory definition in sync with DB so callers of Definition()
+		// (e.g. ptx_getBlockchainEventListener) see the current started status.
+		// Only update when persisting — temporary runtime stops must not
+		// overwrite the configured/desired started state.
+		es.definition.Started = confutil.P(false)
 	}
 	if es.cancelCtx != nil {
 		es.cancelCtx()

--- a/core/go/pkg/blockindexer/event_streams_test.go
+++ b/core/go/pkg/blockindexer/event_streams_test.go
@@ -711,6 +711,8 @@ func TestStartStopEventStream(t *testing.T) {
 	assert.NotNil(t, eventStream.dispatcherDone)
 	assert.NotNil(t, eventStream.detectorStarted)
 	assert.NotNil(t, eventStream.dispatcherStarted)
+	require.NotNil(t, eventStream.definition.Started)
+	assert.True(t, *eventStream.definition.Started)
 
 	// Wait for goroutines to start
 	<-eventStream.detectorStarted
@@ -724,6 +726,9 @@ func TestStartStopEventStream(t *testing.T) {
 		err = bi.StopEventStream(ctx, esID)
 		assert.ErrorContains(c, err, "pop")
 	}, testTimeout(t), 1*time.Millisecond)
+	// Failed DB update must not flip in-memory started status
+	require.NotNil(t, eventStream.definition.Started)
+	assert.True(t, *eventStream.definition.Started)
 
 	// final StopEventStream
 	err = bi.StopEventStream(ctx, esID)
@@ -731,6 +736,8 @@ func TestStartStopEventStream(t *testing.T) {
 
 	assert.Nil(t, eventStream.detectorDone)
 	assert.Nil(t, eventStream.dispatcherDone)
+	require.NotNil(t, eventStream.definition.Started)
+	assert.False(t, *eventStream.definition.Started)
 }
 
 func TestGetEventStreamStatus(t *testing.T) {


### PR DESCRIPTION
The RPC API method `ptx_getBlockchainEventListener` should return the state of a listener. However, it always returns the same value no matter what the actual state of the listener is. The issue happens because even though the database entry is updated, the in-memory information of the listener is not.