### PR TITLE
Stop using fmt to stringify hex

### DIFF
--- a/sdk/go/pkg/pldtypes/bytes32.go
+++ b/sdk/go/pkg/pldtypes/bytes32.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/hex"
-	"fmt"
 	"strings"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
@@ -119,7 +118,10 @@ func (id *Bytes32) UnmarshalText(text []byte) error {
 
 // Get string with 0x prefix - nil is all zeros
 func (id Bytes32) HexString0xPrefix() string {
-	return fmt.Sprintf("0x%s", hex.EncodeToString(id[:]))
+	var buf [66]byte
+	buf[0], buf[1] = '0', 'x'
+	hex.Encode(buf[2:], id[:])
+	return string(buf[:])
 }
 
 // Get string (without 0x prefix) - nil is all zeros

--- a/sdk/go/pkg/pldtypes/eth_address.go
+++ b/sdk/go/pkg/pldtypes/eth_address.go
@@ -78,7 +78,10 @@ func (a *EthAddress) IsZero() bool {
 }
 
 func (a EthAddress) String() string {
-	return a.Address0xHex().String()
+	var buf [42]byte
+	buf[0], buf[1] = '0', 'x'
+	hex.Encode(buf[2:], a[:])
+	return string(buf[:])
 }
 
 func (a EthAddress) HexString() string {

--- a/sdk/go/pkg/pldtypes/eth_address_test.go
+++ b/sdk/go/pkg/pldtypes/eth_address_test.go
@@ -42,6 +42,7 @@ func TestEthAddress(t *testing.T) {
 
 	a = MustEthAddress("0xacA6D8Ba6BFf0fa5c8a06A58368CB6097285d5c5")
 	assert.Equal(t, "0xaca6d8ba6bff0fa5c8a06a58368cb6097285d5c5", (*a).String())
+	assert.Equal(t, "0xaca6d8ba6bff0fa5c8a06a58368cb6097285d5c5", a.Address0xHex().String())
 
 	assert.True(t, (*EthAddress)(nil).Equals(nil))
 	assert.False(t, a.Equals(nil))

--- a/sdk/go/pkg/pldtypes/hex_bytes.go
+++ b/sdk/go/pkg/pldtypes/hex_bytes.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/hex"
-	"fmt"
 	"strings"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
@@ -80,7 +79,10 @@ func (id HexBytes) HexString0xPrefix() string {
 	if id == nil {
 		return (&HexBytes{}).HexString0xPrefix()
 	}
-	return fmt.Sprintf("0x%s", hex.EncodeToString(id[:]))
+	buf := make([]byte, 2+hex.EncodedLen(len(id)))
+	buf[0], buf[1] = '0', 'x'
+	hex.Encode(buf[2:], id)
+	return string(buf)
 }
 
 // Get string (without 0x prefix) - nil is all zeros

--- a/sdk/go/pkg/pldtypes/hex_uint256.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/json"
-	"fmt"
 	"math/big"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
@@ -101,12 +100,16 @@ func (hi *HexUint256) NilOrZero() bool {
 
 // Get string with 0x prefix - nil is all zeros
 func (hi *HexUint256) HexString0xPrefix() string {
-	absHi := new(big.Int).Abs(hi.Int())
-	str := absHi.Text(16)
-	if len(str)%2 != 0 {
-		str = "0" + str
+	i := hi.Int()
+	// Avoid allocating a new big.Int for Abs in the common non-negative case
+	str := i.Text(16)
+	if i.Sign() < 0 {
+		str = new(big.Int).Abs(i).Text(16)
 	}
-	return fmt.Sprintf("0x%s", str)
+	if len(str)%2 != 0 {
+		return "0x0" + str
+	}
+	return "0x" + str
 }
 
 // Get string (without 0x prefix) - nil is all zeros

--- a/sdk/go/pkg/pldtypes/hex_uint256_test.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256_test.go
@@ -107,6 +107,10 @@ func TestHexUint256(t *testing.T) {
 	err = v.Scan("wrong000000000000000000000000000000000000000000007fffffffffffffff")
 	assert.Regexp(t, "PD020013", err)
 
+	// Negative values are serialized using their absolute value
+	assert.Equal(t, "0x01", MustParseHexUint256("-1").HexString0xPrefix())
+	assert.Equal(t, "0xff", MustParseHexUint256("-255").HexString0xPrefix())
+
 	assert.True(t, ((*HexUint256)(nil)).NilOrZero())
 
 	dbv, err = ((*HexUint256)(nil)).Value()


### PR DESCRIPTION
The old functions resulted in ~5-6 allocs per call, which is driving a lot of GC