### PR TITLE
Format signer nonce once

### DIFF
--- a/core/go/internal/publictxmgr/in_memory_tx_state.go
+++ b/core/go/internal/publictxmgr/in_memory_tx_state.go
@@ -17,7 +17,6 @@ package publictxmgr
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -47,6 +46,9 @@ type inMemoryTxState struct {
 
 	managedTxMux sync.Mutex
 	mtx          *managedTx
+
+	// "<from>:<nonce>" string, computed once at construction; the nonce is always allocated before an in-flight tx is constructed
+	signerNonce string
 }
 
 func gasPricingSet(gasPricing pldapi.PublicTxGasPricing) bool {
@@ -74,6 +76,10 @@ func NewInMemoryTxStateManager(ctx context.Context, ptx *DBPublicTxn, ift *inFli
 		imtxs.mtx.FirstSubmit = &firstSub.Created
 		imtxs.mtx.LastSubmittedGasPrice = recoverGasPriceOptions(lastSub.GasPricing)
 	}
+
+	// A nonce is always allocated before an in-flight transaction is constructed
+	imtxs.signerNonce = ptx.From.String() + ":" + strconv.FormatUint(*ptx.Nonce, 10)
+
 	return imtxs
 }
 
@@ -166,11 +172,7 @@ func (imtxs *inMemoryTxState) GetContractAddress() string {
 }
 
 func (imtxs *inMemoryTxState) GetSignerNonce() string {
-	nonceStr := "unassigned"
-	if imtxs.mtx.ptx.Nonce != nil {
-		nonceStr = strconv.FormatUint(*imtxs.mtx.ptx.Nonce, 10)
-	}
-	return fmt.Sprintf("%s:%s", imtxs.mtx.ptx.From, nonceStr)
+	return imtxs.signerNonce
 }
 
 func (imtxs *inMemoryTxState) GetCreatedTime() *pldtypes.Timestamp {

--- a/core/go/internal/publictxmgr/in_memory_tx_state_test.go
+++ b/core/go/internal/publictxmgr/in_memory_tx_state_test.go
@@ -67,6 +67,15 @@ func NewTestInMemoryTxState(t *testing.T) InMemoryTxStateManager {
 
 }
 
+func TestGetSignerNonce(t *testing.T) {
+	from := pldtypes.MustEthAddress("0x4e598f6e918321dd47c86e7a077b4ab0e7414846")
+
+	nonce := uint64(42)
+	imtxs := NewInMemoryTxStateManager(context.Background(), &DBPublicTxn{From: *from, Nonce: &nonce}, nil).(*inMemoryTxState)
+	assert.Equal(t, from.String()+":42", imtxs.GetSignerNonce())
+	assert.Equal(t, fmt.Sprintf("%s:%d", from, nonce), imtxs.GetSignerNonce())
+}
+
 func TestSettersAndGetters(t *testing.T) {
 	oldTime := pldtypes.TimestampNow()
 	oldFrom := pldtypes.MustEthAddress("0xb3d9cf8e163bbc840195a97e81f8a34e295b8f39")


### PR DESCRIPTION
Formatting this string in a log line which is hit repeatedly in public tx processing was driving high allocations and GC. There's a bigger piece of work to remove our whole code base for this, but this picks off a log line that is individually driving a lot of allocations.