### PR TITLE
Only delegate unacknowledged transactions

### DIFF
--- a/core/go/internal/sequencer/coordinator/coordinating.go
+++ b/core/go/internal/sequencer/coordinator/coordinating.go
@@ -33,16 +33,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// Enum for delegation acknowledgement errors
-type DelegationAcknowledgementError int64
-
-const (
-	DelegationAcknowledgementError_None DelegationAcknowledgementError = iota
-	DelegationAcknowledgementError_MaxInflightTransactions
-	DelegationAcknowledgementError_CoordinatorError
-	DelegationAcknowledgementError_PreviousTransactionError
-)
-
 // action_SendHandoverRequest sends a CoordinatorHandoverRequest to the current active coordinator,
 // asking it to step down so this node can take over. Creates an IdempotentRequest on first call
 // and arms the request-timeout timer. Mirrors the pattern of sendAssembleRequest.
@@ -151,14 +141,14 @@ func action_ImportStatesAndLocks(ctx context.Context, c *coordinator, event comm
 	return nil
 }
 
-// Originators send only the delegated transactions that they believe the coordinator needs to know/be reminded about. Which transactions are
-// included in this list depends on whether it is an intitial attempt or a scheduled retry, and whether individual delegation timeouts have
-// been exceeded. This means that the coordinator cannot infer any dependency or ordering between transactions based on the list of transactions
-// in the request.
+// Originators send only the delegated transactions that they believe the coordinator needs to know/be reminded about — a full
+// delegation carries every in-flight transaction, a partial one only those awaiting acknowledgement. Transactions within a
+// request are in the originator's creation order, and the request may name the originator's most recent acknowledged
+// transaction so this request can be ordered after it.
 func action_ProcessDelegatedTransactions(ctx context.Context, c *coordinator, event common.Event) error {
 	e := event.(*TransactionsDelegatedEvent)
 	c.recordOriginatorActivity(e.FromNode)
-	return c.addToDelegatedTransactions(ctx, e.Originator, e.Transactions, e.DelegationID, c.newCoordinatorTransaction)
+	return c.addToDelegatedTransactions(ctx, e.Originator, e.Transactions, e.DelegationID, e.LastDelegatedTransactionID, c.newCoordinatorTransaction)
 }
 
 // recordOriginatorActivity records that an originator node has sent a delegation request,
@@ -294,6 +284,7 @@ func (c *coordinator) addToDelegatedTransactions(
 	originator string,
 	transactions []*components.PrivateTransaction,
 	delegationID string,
+	lastDelegatedTransactionID string,
 	createTransaction func(
 		ctx context.Context,
 		originator string,
@@ -304,7 +295,7 @@ func (c *coordinator) addToDelegatedTransactions(
 	var previousTransaction transaction.CoordinatorTransaction
 
 	delegateAcknowledgementIDs := make([]string, 0, len(transactions))
-	delegateAcknowledgementErrors := make([]int64, len(transactions))
+	delegateAcknowledgementResults := make([]engineProto.DelegationAcknowledgementResult, len(transactions))
 	rejectedMaxInFlight := 0
 	acceptedTransactions := 0
 	inProgressTransactions := 0
@@ -318,13 +309,34 @@ func (c *coordinator) addToDelegatedTransactions(
 		return err
 	}
 
+	// The request may name the originator's most recent acknowledged transaction so that this
+	// request's transactions can be ordered after it without it being resent. Seed the previous
+	// transaction from it; the pre-assembly state check in the loop below then decides whether a
+	// dependency is still needed. If we do not hold that transaction we cannot guarantee FIFO
+	// ordering for anything in this request, so every transaction is refused and the originator
+	// falls back to a full delegation.
+	if lastDelegatedTransactionID != "" {
+		lastDelegatedID, err := uuid.Parse(lastDelegatedTransactionID)
+		if err == nil && c.transactionsByID[lastDelegatedID] != nil {
+			previousTransaction = c.transactionsByID[lastDelegatedID]
+		} else {
+			log.L(ctx).Warnf("last delegated transaction %s from originator %s is not known to this coordinator; refusing %d transactions",
+				lastDelegatedTransactionID, originatorNode, len(transactions))
+			for i, txn := range transactions {
+				delegateAcknowledgementIDs = append(delegateAcknowledgementIDs, txn.ID.String())
+				delegateAcknowledgementResults[i] = engineProto.DelegationAcknowledgementResult_UNKNOWN_LAST_DELEGATED_TRANSACTION
+			}
+			return c.sendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementResults)
+		}
+	}
+
 	for i, txn := range transactions {
 		// Acknowledge every delegation
 		delegateAcknowledgementIDs = append(delegateAcknowledgementIDs, txn.ID.String())
 
 		if txnHandlingError != nil {
 			// Any previous errors, don't handle this or subsequent TXNs to maintain FIFO ordering
-			delegateAcknowledgementErrors[i] = int64(DelegationAcknowledgementError_PreviousTransactionError)
+			delegateAcknowledgementResults[i] = engineProto.DelegationAcknowledgementResult_PREVIOUS_TRANSACTION_ERROR
 			continue
 		}
 
@@ -339,7 +351,7 @@ func (c *coordinator) addToDelegatedTransactions(
 		if len(c.transactionsByID) >= c.maxInflightTransactions {
 			rejectedMaxInFlight++
 			log.L(ctx).Tracef("transaction %s being rejected - reached max in-flight limit", txn.ID.String())
-			delegateAcknowledgementErrors[i] = int64(DelegationAcknowledgementError_MaxInflightTransactions)
+			delegateAcknowledgementResults[i] = engineProto.DelegationAcknowledgementResult_MAX_INFLIGHT_TRANSACTIONS
 			// Since all subsequent transactions will be rejected for the same reason, go through them all recording
 			// an error for the delegation acknowledgement response. The originator may choose to do nothing but log
 			// and retry later.
@@ -349,9 +361,9 @@ func (c *coordinator) addToDelegatedTransactions(
 		// We use the order in which transaction are delegated to establish preassembly dependencies, which is what allows us to
 		// ensure FIFO ordering within an originator up until first assembly.
 		//
-		// An originator sends all of its known transactions (i.e. all that have not yet been confirmed) with every delegation request.
-		// If an originator believes a transaction has been assembled for the first time, it definitely has been, so we can
-		// trust that we have all the information we need in this request to ensure the ordering.
+		// Within a request the transactions arrive in the originator's creation order, and the request's
+		// last_delegated_transaction_id (seeded into previousTransaction above) links its first transaction
+		// to the originator's most recent acknowledged transaction from earlier requests.
 		// We cannot rely on an originator to know that that a transaction has never been assembled, so we need to check our
 		// own records of transactions states, and only establish dependencies when we know a prereq transaction is definitely
 		// going to be selected for assembly again.
@@ -393,7 +405,7 @@ func (c *coordinator) addToDelegatedTransactions(
 			c.metrics.DecCoordinatingTransactions()
 			acceptedTransactions--
 			txnHandlingError = err
-			delegateAcknowledgementErrors[i] = int64(DelegationAcknowledgementError_CoordinatorError)
+			delegateAcknowledgementResults[i] = engineProto.DelegationAcknowledgementResult_COORDINATOR_ERROR
 			// All subsequent transactions will be skipped
 			continue
 		}
@@ -401,13 +413,7 @@ func (c *coordinator) addToDelegatedTransactions(
 	}
 
 	// Acknowledge the delegate request. Optionally errors can be returned which the originator may use to base re-delegate decisions on
-	err = c.transportWriter.SendDelegationResponse(ctx, originatorNode, &engineProto.DelegationResponse{
-		DelegationId:    delegationID,
-		TransactionIds:  delegateAcknowledgementIDs,
-		DelegateNodeId:  originatorNode,
-		ContractAddress: c.contractAddress.HexString(),
-		Errors:          delegateAcknowledgementErrors,
-	})
+	err = c.sendDelegationResponse(ctx, originatorNode, delegationID, delegateAcknowledgementIDs, delegateAcknowledgementResults)
 	if err != nil {
 		return err
 	}
@@ -422,6 +428,18 @@ func (c *coordinator) addToDelegatedTransactions(
 		return txnHandlingError
 	}
 	return nil
+}
+
+// sendDelegationResponse acknowledges a delegation request back to the originating node, carrying
+// one result entry per transaction in the request. DelegateNodeId carries this coordinator's node name.
+func (c *coordinator) sendDelegationResponse(ctx context.Context, originatorNode string, delegationID string, transactionIDs []string, acknowledgementResults []engineProto.DelegationAcknowledgementResult) error {
+	return c.transportWriter.SendDelegationResponse(ctx, originatorNode, &engineProto.DelegationResponse{
+		DelegationId:    delegationID,
+		TransactionIds:  transactionIDs,
+		DelegateNodeId:  c.nodeName,
+		ContractAddress: c.contractAddress.HexString(),
+		Results:         acknowledgementResults,
+	})
 }
 
 func action_NewSigningIdentity(ctx context.Context, c *coordinator, _ common.Event) error {

--- a/core/go/internal/sequencer/coordinator/coordinating_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinating_test.go
@@ -57,7 +57,7 @@ func Test_addToDelegatedTransactions_NewTransactionError_ReturnsError(t *testing
 	txn := transactionBuilder.BuildSparse()
 
 	invalidOriginator := "sender@node1@node2"
-	err := c.addToDelegatedTransactions(ctx, invalidOriginator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, invalidOriginator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 
 	require.Error(t, err, "should return error when NewTransaction fails")
 	assert.Equal(t, 0, len(c.transactionsByID), "transaction should not be added when NewTransaction fails")
@@ -75,7 +75,7 @@ func Test_addToDelegatedTransactions_AddsTransactionInPreDispatchFlowState(t *te
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err, "should add delegated transaction")
 	require.Equal(t, 1, len(c.transactionsByID), "transaction should be added to transactionsByID")
@@ -100,7 +100,7 @@ func Test_addToDelegatedTransactions_AddsTransactionInPooledFlowState(t *testing
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err, "should add delegated transaction")
 	require.Equal(t, 1, len(c.transactionsByID), "transaction should be added to transactionsByID")
@@ -122,13 +122,13 @@ func Test_addToDelegatedTransactions_DuplicateTransaction_SkipsAndReturnsNoError
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 	require.NoError(t, err, "should not return error on first add")
 	require.Equal(t, 1, len(c.transactionsByID), "transaction should be added to transactionsByID")
 	firstCoordinatedTxn := c.transactionsByID[txn.ID]
 	require.NotNil(t, firstCoordinatedTxn, "transaction should exist in transactionsByID")
 
-	err = c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+	err = c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 	require.NoError(t, err, "should not return error when adding duplicate transaction")
 	assert.Equal(t, 1, len(c.transactionsByID), "duplicate transaction should be skipped, count should remain 1")
 	secondCoordinatedTxn := c.transactionsByID[txn.ID]
@@ -439,11 +439,11 @@ func Test_addToDelegatedTransactions_WhenMaxInflightReached_ReturnsError(t *test
 	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn1}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn1}, "", "", c.newCoordinatorTransaction)
 	require.NoError(t, err)
 	require.Len(t, c.transactionsByID, 1)
 
-	err = c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn2}, "", c.newCoordinatorTransaction)
+	err = c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn2}, "", "", c.newCoordinatorTransaction)
 	require.Error(t, err, "should return error when max inflight reached")
 	assert.Len(t, c.transactionsByID, 1, "second transaction should not be added")
 }
@@ -508,7 +508,7 @@ func Test_addToDelegatedTransactions_MaxInflightThree_SlidingWindowKeepsOrder(t 
 		wantLen := min(3, 10-round)
 		delegationID := fmt.Sprintf("delegation-round-%d", round)
 
-		err := c.addToDelegatedTransactions(ctx, originator, txns[round:], delegationID, c.newCoordinatorTransaction)
+		err := c.addToDelegatedTransactions(ctx, originator, txns[round:], delegationID, "", c.newCoordinatorTransaction)
 
 		if round <= 6 {
 			require.Error(t, err, "round %d: should return max inflight error when tail transactions are rejected", round)
@@ -540,7 +540,7 @@ func Test_addToDelegatedTransactions_HandleEventError_ContinuesAndReturnsNoError
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn.PreAssembly = nil // Triggers error in action_InitializeForNewAssembly when transitioning to Pooled
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err)
 	require.Len(t, c.transactionsByID, 1)
@@ -559,7 +559,7 @@ func Test_addToDelegatedTransactions_SendDelegationResponseError_ReturnsError(t 
 
 	txn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", "", c.newCoordinatorTransaction)
 
 	require.Error(t, err)
 	assert.Equal(t, "send ack failed", err.Error())
@@ -683,15 +683,15 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_Estab
 
 	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err)
 }
 
-// A partial delegation request from an originator carries only the un-assembled (Pending/Delegated)
-// FIFO suffix; already-assembled predecessors are omitted. This test confirms that such a partial
-// batch still establishes the new transaction's preassembly dependency on its immediate predecessor,
-// because the predecessor is the first element of the suffix and is already coordinated (Pooled).
+// A request can contain a transaction the coordinator already holds ahead of a new one — e.g. a
+// retried request whose original acknowledgement was lost. This test confirms that such a batch
+// still establishes the new transaction's preassembly dependency on its immediate in-request
+// predecessor, because the predecessor is already coordinated (Pooled).
 func Test_addToDelegatedTransactions_PartialSuffixBatch_EstablishesDependencyOnKnownPredecessor(t *testing.T) {
 	ctx := t.Context()
 	originator := "sender@senderNode"
@@ -715,7 +715,7 @@ func Test_addToDelegatedTransactions_PartialSuffixBatch_EstablishesDependencyOnK
 	existingTxn.ID = previousTxnID
 	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", "", c.newCoordinatorTransaction)
 	require.NoError(t, err)
 
 	prereq, ok := c.dependencyTracker.GetPreassemblyDeps().GetPrerequisite(ctx, newTxn.ID)
@@ -747,7 +747,7 @@ func Test_addToDelegatedTransactions_PreviousTransactionInPreAssemblyState_DoesN
 
 	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err)
 }
@@ -771,7 +771,7 @@ func Test_addToDelegatedTransactions_MockTransactionHandleEventReturnsError(t *t
 		return mockTxn
 	}
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", createTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "delegation-1", "", createTransaction)
 
 	require.Error(t, err)
 	assert.Equal(t, expectedError, err)
@@ -797,25 +797,25 @@ func Test_addToDelegatedTransactions_SubsequentTransactionGetsPreviousTransactio
 		return mockTxn
 	}
 
-	var capturedErrors []int64
+	var capturedResults []engineProto.DelegationAcknowledgementResult
 	c, mocks := builder.WithMockTransportWriter().Build()
 	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, mock.Anything, mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
-		capturedErrors = msg.Errors
+		capturedResults = msg.Results
 		return true
 	})).Return(nil)
 
 	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn1, txn2}, "delegation-1", createTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn1, txn2}, "delegation-1", "", createTransaction)
 
 	require.Error(t, err)
 	assert.Equal(t, firstTxnError, err)
 	assert.Len(t, c.transactionsByID, 0, "first transaction removed after HandleEvent failure; second was skipped due to previous error")
 	// Second transaction should get PreviousTransactionError in the acknowledgement (covers lines 94-95)
-	require.Len(t, capturedErrors, 2, "ack should have one entry per transaction")
-	assert.Equal(t, int64(DelegationAcknowledgementError_CoordinatorError), capturedErrors[0], "first txn gets CoordinatorError from HandleEvent failure")
-	assert.Equal(t, int64(DelegationAcknowledgementError_PreviousTransactionError), capturedErrors[1], "second txn gets PreviousTransactionError when a previous txn failed")
+	require.Len(t, capturedResults, 2, "ack should have one entry per transaction")
+	assert.Equal(t, engineProto.DelegationAcknowledgementResult_COORDINATOR_ERROR, capturedResults[0], "first txn gets CoordinatorError from HandleEvent failure")
+	assert.Equal(t, engineProto.DelegationAcknowledgementResult_PREVIOUS_TRANSACTION_ERROR, capturedResults[1], "second txn gets PreviousTransactionError when a previous txn failed")
 }
 
 func Test_addToDelegatedTransactions_ErrorStopsSubsequentTransactionsBeingAccepted(t *testing.T) {
@@ -861,7 +861,7 @@ func Test_addToDelegatedTransactions_ErrorStopsSubsequentTransactionsBeingAccept
 		return m
 	}
 
-	err := c.addToDelegatedTransactions(ctx, originator, txns, "delegation-10", createTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, txns, "delegation-10", "", createTransaction)
 
 	require.Error(t, err)
 	assert.Equal(t, fifthErr, err)
@@ -972,7 +972,7 @@ func Test_addToDelegatedTransactions_FifthFailsThenFullRetry_PreservesFirstFourA
 		}
 	}
 
-	err := c.addToDelegatedTransactions(ctx, originator, txns, "delegation-pass1", createTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, txns, "delegation-pass1", "", createTransaction)
 	require.Error(t, err)
 	assert.Equal(t, fifthErr, err)
 	require.Len(t, c.transactionsByID, 4)
@@ -985,7 +985,7 @@ func Test_addToDelegatedTransactions_FifthFailsThenFullRetry_PreservesFirstFourA
 	}
 
 	attempt = 1
-	err = c.addToDelegatedTransactions(ctx, originator, txns, "delegation-pass2", createTransaction)
+	err = c.addToDelegatedTransactions(ctx, originator, txns, "delegation-pass2", "", createTransaction)
 	require.NoError(t, err)
 
 	require.Len(t, c.transactionsByID, 10)
@@ -1027,7 +1027,7 @@ func Test_addToDelegatedTransactions_PreviousTransactionNotInPreAssemblyState_No
 
 	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
 
-	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", c.newCoordinatorTransaction)
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{existingTxn, newTxn}, "", "", c.newCoordinatorTransaction)
 
 	require.NoError(t, err)
 }
@@ -1524,4 +1524,111 @@ func Test_getCoordinatorSigningIdentity_ConcurrentWithRotation(t *testing.T) {
 	wg.Wait()
 
 	assert.False(t, malformed.Load(), "every returned signing identity must be a well-formed non-empty domains.* value")
+}
+
+// A partial request that names a last delegated transaction the coordinator holds in a pre-assembly
+// state chains the request's first transaction to it, preserving FIFO ordering without the
+// predecessor being resent.
+func Test_addToDelegatedTransactions_LastDelegatedKnownAndPooled_EstablishesDependency(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@senderNode"
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	c, mocks := builder.Build()
+	mocks.Domain.On("FixedSigningIdentity").Return("")
+	mocks.DomainAPI.On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
+	})
+
+	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
+	previousTxnID := uuid.New()
+	mockPreviousTxn.EXPECT().GetCurrentState().Return(transaction.State_Pooled)
+	mockPreviousTxn.EXPECT().GetID().Return(previousTxnID)
+	c.transactionsByID[previousTxnID] = mockPreviousTxn
+
+	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
+
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{newTxn}, "delegation-1", previousTxnID.String(), c.newCoordinatorTransaction)
+	require.NoError(t, err)
+
+	prereq, ok := c.dependencyTracker.GetPreassemblyDeps().GetPrerequisite(ctx, newTxn.ID)
+	require.True(t, ok, "new transaction must depend on the named last delegated transaction")
+	assert.Equal(t, previousTxnID, prereq)
+}
+
+// A named last delegated transaction that has already progressed past pre-assembly needs no
+// dependency: it can never be re-selected for first assembly, so ordering is already locked in.
+func Test_addToDelegatedTransactions_LastDelegatedPastPreAssembly_NoDependency(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@senderNode"
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	c, mocks := builder.Build()
+	mocks.Domain.On("FixedSigningIdentity").Return("")
+	mocks.DomainAPI.On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
+	})
+
+	mockPreviousTxn := coordinatortransactionmocks.NewCoordinatorTransaction(t)
+	previousTxnID := uuid.New()
+	mockPreviousTxn.EXPECT().GetCurrentState().Return(transaction.State_Endorsement_Gathering)
+	c.transactionsByID[previousTxnID] = mockPreviousTxn
+
+	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
+
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{newTxn}, "delegation-1", previousTxnID.String(), c.newCoordinatorTransaction)
+	require.NoError(t, err)
+
+	_, ok := c.dependencyTracker.GetPreassemblyDeps().GetPrerequisite(ctx, newTxn.ID)
+	assert.False(t, ok, "no dependency is needed on a predecessor already past pre-assembly")
+}
+
+// When the coordinator does not hold the named last delegated transaction it cannot guarantee FIFO
+// ordering, so every transaction in the request is refused with UnknownLastDelegatedTransaction and
+// none is accepted. The response's DelegateNodeId carries the coordinator's node name.
+func Test_addToDelegatedTransactions_UnknownLastDelegated_RefusesAllTransactions(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@senderNode"
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+
+	var capturedResponse *engineProto.DelegationResponse
+	c, mocks := builder.WithMockTransportWriter().Build()
+	mocks.TransportWriter.On("SendDelegationResponse", mock.Anything, "senderNode", mock.MatchedBy(func(msg *engineProto.DelegationResponse) bool {
+		capturedResponse = msg
+		return true
+	})).Return(nil)
+
+	txn1 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
+	txn2 := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
+
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn1, txn2}, "delegation-1", uuid.New().String(), c.newCoordinatorTransaction)
+	require.NoError(t, err)
+
+	assert.Empty(t, c.transactionsByID, "no transaction may be accepted when the predecessor is unknown")
+	require.NotNil(t, capturedResponse)
+	assert.Equal(t, "delegation-1", capturedResponse.DelegationId)
+	assert.Equal(t, c.nodeName, capturedResponse.DelegateNodeId, "the response must carry the coordinator's node name")
+	require.Len(t, capturedResponse.Results, 2)
+	for _, result := range capturedResponse.Results {
+		assert.Equal(t, engineProto.DelegationAcknowledgementResult_UNKNOWN_LAST_DELEGATED_TRANSACTION, result)
+	}
+}
+
+// An empty last delegated transaction ID means there is no external predecessor: the request's first
+// transaction gets no prerequisite.
+func Test_addToDelegatedTransactions_EmptyLastDelegated_NoExternalPredecessor(t *testing.T) {
+	ctx := t.Context()
+	originator := "sender@senderNode"
+	builder := NewCoordinatorBuilderForTesting(t, State_Idle)
+	c, mocks := builder.Build()
+	mocks.Domain.On("FixedSigningIdentity").Return("")
+	mocks.DomainAPI.On("ContractConfig").Return(&prototk.ContractConfig{
+		CoordinatorSelection: prototk.ContractConfig_COORDINATOR_SENDER,
+	})
+
+	newTxn := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1).BuildSparse()
+
+	err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{newTxn}, "delegation-1", "", c.newCoordinatorTransaction)
+	require.NoError(t, err)
+
+	_, ok := c.dependencyTracker.GetPreassemblyDeps().GetPrerequisite(ctx, newTxn.ID)
+	assert.False(t, ok)
 }

--- a/core/go/internal/sequencer/coordinator/coordinator_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_test.go
@@ -296,7 +296,7 @@ func TestCoordinator_MaxInflightTransactions(t *testing.T) {
 	for i := range 100 {
 		transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originator).NumberOfRequiredEndorsers(1)
 		txn := transactionBuilder.BuildSparse()
-		err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", c.newCoordinatorTransaction)
+		err := c.addToDelegatedTransactions(ctx, originator, []*components.PrivateTransaction{txn}, "", "", c.newCoordinatorTransaction)
 
 		if i < 5 {
 			require.NoError(t, err)

--- a/core/go/internal/sequencer/coordinator/events.go
+++ b/core/go/internal/sequencer/coordinator/events.go
@@ -41,11 +41,12 @@ func (*CoordinatorCreatedEvent) TypeString() string {
 
 type TransactionsDelegatedEvent struct {
 	common.BaseEvent
-	FromNode               string // Node name that sent the delegation request
-	Originator             string // Fully qualified identity locator for the originator
-	Transactions           []*components.PrivateTransaction
-	OriginatorsBlockHeight uint64
-	DelegationID           string
+	FromNode                   string // Node name that sent the delegation request
+	Originator                 string // Fully qualified identity locator for the originator
+	Transactions               []*components.PrivateTransaction
+	OriginatorsBlockHeight     uint64
+	DelegationID               string
+	LastDelegatedTransactionID string // most recent acknowledged transaction from earlier requests; this request's transactions are ordered after it. empty when there is no predecessor
 }
 
 func (*TransactionsDelegatedEvent) Type() EventType {

--- a/core/go/internal/sequencer/originator/delegation.go
+++ b/core/go/internal/sequencer/originator/delegation.go
@@ -28,7 +28,18 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/originator/transaction"
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
+	"github.com/google/uuid"
 )
+
+// inFlightDelegation tracks a delegation request that has been sent but whose acknowledgement has not
+// yet arrived. It lives in the full or partial in-flight slot, and its one-shot timer signals a request
+// timeout: when it fires it notifies for a new delegaation so the batching loop re-delegates the
+// still-outstanding transactions from live state under a fresh delegation ID. The transactions it carried
+// are not recorded here because that rebuild reads live state rather than replaying this request.
+type inFlightDelegation struct {
+	delegationID string
+	cancelTimer  func()
+}
 
 // startDelegationLoop creates the notification channels and starts the batching goroutine. Called from the
 // State_Sending entry hook on the event-loop goroutine. No-op if the originator has not started yet
@@ -41,6 +52,7 @@ func (o *originator) startDelegationLoop() {
 	o.notifyPartialDelegation = make(chan struct{}, 1)
 	loopCtx, cancel := context.WithCancel(o.ctx)
 	done := make(chan struct{})
+	o.delegationLoopCtx = loopCtx
 	o.delegationLoopCancel = cancel
 	o.delegationLoopDone = done
 	// Capture the channels as locals so stopDelegationLoop nil-ing the struct fields never races the goroutine.
@@ -54,12 +66,16 @@ func (o *originator) startDelegationLoop() {
 // stopDelegationLoop cancels the batching goroutine and waits for it to exit. Called from the
 // State_Sending exit hook on the event-loop goroutine. cancel() is called before the join so a
 // goroutine blocked queueing a flush event is released via the queue's ctx.Done() branch.
+// Any in-flight delegation requests are discarded along with their timers: outside State_Sending
+// there is nothing left to delegate.
 func (o *originator) stopDelegationLoop() {
 	if o.delegationLoopCancel == nil {
 		return
 	}
 	o.delegationLoopCancel()
 	<-o.delegationLoopDone
+	o.cancelAllInFlightDelegations()
+	o.delegationLoopCtx = nil
 	o.delegationLoopCancel = nil
 	o.delegationLoopDone = nil
 	o.notifyFullDelegation = nil
@@ -67,9 +83,9 @@ func (o *originator) stopDelegationLoop() {
 }
 
 // delegationLoop coalesces delegation requests. On each batch tick it drains both dirty-flag
-// channels and, if anything was requested, queues a single DelegateSendBatchEvent onto the event loop.
-// full takes priority over partial (a full resend is a superset of a partial one). Both channels are
-// drained every tick so a stale partial notification cannot linger behind a full one.
+// channels and, if either was set, queues a single DelegateSendBatchEvent onto the event loop. full
+// takes priority over partial (a full send is a superset of a partial one). Both channels are drained
+// every tick so a stale partial notification cannot linger behind a full one.
 func (o *originator) delegationLoop(ctx context.Context, interval time.Duration, full, partial chan struct{}) {
 	log.L(ctx).Debugf("delegation batching loop started for %s (interval %s)", o.contractAddress, interval)
 	ticker := time.NewTicker(interval)
@@ -107,14 +123,18 @@ func (o *originator) delegationLoop(ctx context.Context, interval time.Duration,
 // delegation-rejected redirect) where the coordinator may be missing state, so we bias toward
 // over-sending.
 //
-// When full is false only transactions whose state is State_Pending or State_Delegated are included,
-// i.e. the minimal set required to ensure FIFO ordering until first assembly
+// When full is false only transactions whose state is State_Pending — sent but not yet acknowledged
+// by the coordinator, or not yet sent at all — are included. FIFO ordering with transactions the
+// coordinator has already acknowledged is preserved by naming the most recent State_Delegated
+// transaction in the request's last_delegated_transaction_id rather than resending it.
 func sendDelegationRequest(ctx context.Context, o *originator, full bool) error {
 	// Delegate resolved transactions in the order they were created on the originating node.
 	// A still-resolving transaction blocks all later transactions so the coordinator
 	// receives them in creation order and never sees a transaction whose verifiers are unresolved.
 	inFlight := 0
 	transactionsToDelegate := make([]*components.PrivateTransaction, 0)
+	var lastDelegatedTransactionID string
+	var lastDelegatedTxn transaction.OriginatorTransaction
 	for _, txn := range o.transactionsOrdered {
 		// A transaction has advanced past verifier resolution, and so is eligible for delegation, only
 		// once it has left State_Initial and State_Resolving.
@@ -123,12 +143,21 @@ func sendDelegationRequest(ctx context.Context, o *originator, full bool) error 
 			break
 		}
 		inFlight++
-		// On the golden path skip any transaction the coordinator already knows about (it has been
-		// assembled at least once, so its ordering is locked in). We skip both the DelegatedEvent and
-		// the protobuf entry.
-		if !full && state != transaction.State_Pending && state != transaction.State_Delegated {
-			continue
+		if !full {
+			// Acknowledged (Delegated) transactions are not resent; the most recent one seen before the
+			// first included transaction is named as the predecessor the coordinator orders this
+			// request after. Acceptance is prefix-ordered, so Delegated transactions precede Pending ones.
+			if state == transaction.State_Delegated && len(transactionsToDelegate) == 0 {
+				lastDelegatedTxn = txn
+			}
+			if state != transaction.State_Pending {
+				continue
+			}
 		}
+		if lastDelegatedTxn != nil {
+			lastDelegatedTransactionID = lastDelegatedTxn.GetID().String()
+		}
+
 		transactionsToDelegate = append(transactionsToDelegate, txn.GetPrivateTransaction())
 		err := txn.HandleEvent(ctx, &transaction.DelegatedEvent{
 			BaseEvent: transaction.BaseEvent{
@@ -159,41 +188,124 @@ func sendDelegationRequest(ctx context.Context, o *originator, full bool) error 
 			PreAssembly: tx.PreAssembly,
 		})
 	}
+
+	// Record the request before sending so that even a request which fails to send times out and is
+	// re-delegated. recordInFlightDelegation mints the delegation ID, supersedes the requests this send
+	// replaces, and arms a fresh one-shot timer; the request below is sent under ifd.delegationID.
+	ifd := o.recordInFlightDelegation(full)
+
 	return o.transportWriter.SendDelegationRequest(ctx, o.currentActiveCoordinator, &engineProto.DelegationRequest{
-		DelegateNodeId:        o.currentActiveCoordinator,
-		OriginatorBlockHeight: int64(o.currentBlockHeight),
-		ContractAddress:       o.contractAddress.HexString(),
-		Transactions:          delegations,
+		DelegationId:               ifd.delegationID,
+		DelegateNodeId:             o.currentActiveCoordinator,
+		OriginatorBlockHeight:      int64(o.currentBlockHeight),
+		ContractAddress:            o.contractAddress.HexString(),
+		Transactions:               delegations,
+		LastDelegatedTransactionId: lastDelegatedTransactionID,
 	})
 }
 
+// recordInFlightDelegation mints a fresh delegation ID, supersedes the in-flight requests this send
+// replaces, then records the new request in its slot and arms its timer, returning the entry so the caller
+// sends under its delegation ID. A full send supersedes every in-flight request (it re-delegates a superset);
+// a partial send supersedes only a prior partial — a full carries transactions a partial would not resend, so
+// its recovery timer is left running. This keeps at most one full and one partial in flight at once, each to
+// the current coordinator.
+func (o *originator) recordInFlightDelegation(full bool) *inFlightDelegation {
+	ifd := &inFlightDelegation{delegationID: uuid.New().String()}
+	if full {
+		o.cancelAllInFlightDelegations()
+		o.fullInFlight = ifd
+		o.startInFlightDelegationTimer(ifd, o.notifyFullDelegation)
+	} else {
+		stopInFlightDelegationTimer(o.partialInFlight)
+		o.partialInFlight = ifd
+		o.startInFlightDelegationTimer(ifd, o.notifyPartialDelegation)
+	}
+	return ifd
+}
+
+func (o *originator) startInFlightDelegationTimer(ifd *inFlightDelegation, notify chan struct{}) {
+	loopCtx := o.delegationLoopCtx
+	if loopCtx == nil {
+		return
+	}
+	ifd.cancelTimer = o.clock.ScheduleTimer(loopCtx, o.requestTimeout, func() {
+		select {
+		case notify <- struct{}{}:
+		default:
+		}
+	})
+}
+
+// stopInFlightDelegationTimer stops an in-flight request's one-shot timer, if it has one. Safe on a nil entry.
+func stopInFlightDelegationTimer(ifd *inFlightDelegation) {
+	if ifd != nil && ifd.cancelTimer != nil {
+		ifd.cancelTimer()
+	}
+}
+
+// cancelInFlightByID stops and clears whichever in-flight slot holds the given delegation ID. Called when
+// its acknowledgement arrives (whatever the per-transaction outcomes were: a response means the request
+// landed). A response for a request already superseded matches neither slot and is a no-op; its
+// transactions are still applied by the caller from the response itself.
+func (o *originator) cancelInFlightByID(delegationID string) {
+	switch {
+	case o.fullInFlight != nil && o.fullInFlight.delegationID == delegationID:
+		stopInFlightDelegationTimer(o.fullInFlight)
+		o.fullInFlight = nil
+	case o.partialInFlight != nil && o.partialInFlight.delegationID == delegationID:
+		stopInFlightDelegationTimer(o.partialInFlight)
+		o.partialInFlight = nil
+	}
+}
+
+// cancelAllInFlightDelegations discards both in-flight delegation requests. Called when the active
+// coordinator changes — the full delegation to the new coordinator supersedes them — and when the
+// delegation loop stops.
+func (o *originator) cancelAllInFlightDelegations() {
+	stopInFlightDelegationTimer(o.fullInFlight)
+	stopInFlightDelegationTimer(o.partialInFlight)
+	o.fullInFlight = nil
+	o.partialInFlight = nil
+}
+
 // action_NotifyPartialDelegation indicates to the delegation batching loop that a partial delegation
-// (only transactions State_Pending / State_Delegated) will be required on its next tick. Sending all
-// transactions in these states is required to preserve FIFO ordering from this originator until first
-// assembly. o.notifyPartialDelegation has length 1, so that multiple notfications result in a single
-// delegation request.
+// (only State_Pending transactions, i.e. those not yet acknowledged by the coordinator) will be
+// required on its next tick. Every partial request carries all Pending transactions, so a lost
+// request or acknowledgement is repaired by the next partial send. o.notifyPartialDelegation has
+// length 1, so that multiple notfications result in a single delegation request.
 func action_NotifyPartialDelegation(_ context.Context, o *originator, _ common.Event) error {
+	o.partialDelegationNotification()
+	return nil
+}
+
+func (o *originator) partialDelegationNotification() {
 	select {
 	case o.notifyPartialDelegation <- struct{}{}:
 	default:
 	}
-	return nil
 }
 
 // action_NotifyFullDelegation indicates to the delegation batching loop that a full delegation
 // (all resolved but unconfirmed transactions) will be required on its next tick. o.notifyFullDelegation
 // has length 1, so that multiple notfications result in a single delegation request.
 func action_NotifyFullDelegation(_ context.Context, o *originator, _ common.Event) error {
+	o.fullDelegationNotification()
+	return nil
+}
+
+func (o *originator) fullDelegationNotification() {
 	select {
 	case o.notifyFullDelegation <- struct{}{}:
 	default:
 	}
-	return nil
 }
 
 // action_SendDelegation is the sole handler of Event_DelegateSendBatch, queued by the batching goroutine.
 // It refreshes the block height once per flush (rather than once per trigger) and sends the coalesced
-// delegation request.
+// delegation request. The trigger is the same whether a fresh notification or an in-flight request's
+// timeout set the flag: sendDelegationRequest rebuilds from live state, re-delegating any still-Pending
+// transactions under a fresh delegation ID.
 func action_SendDelegation(ctx context.Context, o *originator, event common.Event) error {
 	e := event.(*DelegateSendBatchEvent)
 	o.refreshBlockHeight(ctx)
@@ -237,6 +349,74 @@ func action_HandleDelegationRejected(_ context.Context, o *originator, event com
 	if common.IsHigherPriority(o.coordinatorPriorityList, e.ActiveCoordinator, o.currentActiveCoordinator) {
 		o.currentActiveCoordinator = e.ActiveCoordinator
 		o.resetFailoverIndex()
+		o.cancelAllInFlightDelegations()
+	}
+	return nil
+}
+
+// validator_IsDelegationAckFromCurrentCoordinator returns true when the acknowledgement's sender is
+// the currently tracked active coordinator. An acknowledgement from any other node is stale (e.g.
+// sent by a coordinator we have since failed away from) and is dropped.
+func validator_IsDelegationAckFromCurrentCoordinator(_ context.Context, o *originator, event common.Event) (bool, error) {
+	return event.(*DelegationRequestAcknowledgedEvent).FromNode == o.currentActiveCoordinator, nil
+}
+
+// action_HandleDelegationAcknowledged processes a DelegationResponse from the current active
+// coordinator. The response means the request landed, so its in-flight request timer is stopped
+// regardless of the per-transaction outcomes. The coordinator acknowledges transactions in the order
+// they were sent, accepting each one until it reaches one it could not take on. Each accepted
+// transaction is moved Pending → Delegated; the first transaction the coordinator did not accept, and
+// every transaction after it, stays Pending and is re-delegated. That re-delegation is full when the
+// coordinator did not recognise our last delegated transaction (it cannot then guarantee FIFO
+// ordering), and partial otherwise.
+func action_HandleDelegationAcknowledged(ctx context.Context, o *originator, event common.Event) error {
+	e := event.(*DelegationRequestAcknowledgedEvent)
+	o.cancelInFlightByID(e.DelegationID)
+
+	for i, transactionIDString := range e.TransactionIDs {
+		if i >= len(e.Results) {
+			// A response with fewer acknowledgements than transactions is malformed; treat this
+			// transaction and everything after it as un-acknowledged and re-delegate them.
+			log.L(ctx).Warnf("coordinator %s returned fewer acknowledgements than transactions; requesting partial delegation", e.FromNode)
+			o.partialDelegationNotification()
+			return nil
+		}
+		if e.Results[i] == engineProto.DelegationAcknowledgementResult_UNKNOWN_LAST_DELEGATED_TRANSACTION {
+			// The coordinator does not recognise our last delegated transaction and so cannot guarantee
+			// FIFO ordering. Re-delegate everything with a full delegation.
+			log.L(ctx).Warnf("coordinator %s does not recognise our last delegated transaction; requesting full delegation", e.FromNode)
+			o.fullDelegationNotification()
+			return nil
+		}
+		if e.Results[i] != engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED {
+			// The coordinator did not accept this transaction, so it and every transaction after it stays
+			// Pending. Re-delegate them with a partial delegation.
+			log.L(ctx).Debugf("coordinator %s did not accept transaction %s; requesting partial delegation", e.FromNode, transactionIDString)
+			o.partialDelegationNotification()
+			return nil
+		}
+
+		// The coordinator accepted this transaction: move it Pending → Delegated.
+		transactionID, err := uuid.Parse(transactionIDString)
+		if err != nil {
+			log.L(ctx).Warnf("delegation acknowledgement from %s contains invalid transaction ID %s: %v", e.FromNode, transactionIDString, err)
+			continue
+		}
+		txn := o.transactionsByID[transactionID]
+		if txn == nil {
+			// The transaction completed and was cleaned up while the acknowledgement was in flight.
+			continue
+		}
+		err = txn.HandleEvent(ctx, &transaction.DelegationAcknowledgedEvent{
+			BaseEvent: transaction.BaseEvent{
+				TransactionID: transactionID,
+			},
+			Coordinator: e.FromNode,
+		})
+		if err != nil {
+			msg := fmt.Errorf("error handling delegation acknowledged event for transaction %s: %v", transactionIDString, err)
+			return i18n.NewError(ctx, msgs.MsgSequencerInternalError, msg)
+		}
 	}
 	return nil
 }

--- a/core/go/internal/sequencer/originator/delegation_test.go
+++ b/core/go/internal/sequencer/originator/delegation_test.go
@@ -22,9 +22,11 @@ import (
 	"time"
 
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/originator/transaction"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/testutil"
 	"github.com/LFDT-Paladin/paladin/core/mocks/originatortransactionmocks"
+	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
@@ -98,13 +100,14 @@ func Test_sendDelegationRequest_HandleEventError_ReturnsWrappedError(t *testing.
 	assert.Contains(t, err.Error(), expectedErr.Error())
 }
 
-// On the golden (partial) path, transactions that the coordinator already knows about (Assembling or
-// beyond) are skipped: they get neither a DelegatedEvent nor a protobuf entry. Only Pending/Delegated
-// transactions are (re)sent.
-func Test_sendDelegationRequest_Partial_ExcludesAssembledTransactions(t *testing.T) {
+// On the golden (partial) path only Pending transactions are sent: transactions the coordinator
+// already holds — acknowledged (Delegated) or assembled and beyond — get neither a DelegatedEvent
+// nor a protobuf entry. The most recent Delegated transaction is named as the request's
+// last_delegated_transaction_id instead of being resent.
+func Test_sendDelegationRequest_Partial_SendsPendingOnlyWithLastDelegated(t *testing.T) {
 	ctx := context.Background()
 	assembledTxn, assembledID := newExcludedMockTxn(t, transaction.State_Assembling)
-	delegatedTxn, delegatedID := newDelegatableMockTxn(t, transaction.State_Delegated)
+	delegatedTxn, delegatedID := newExcludedMockTxn(t, transaction.State_Delegated)
 	pendingTxn, pendingID := newDelegatableMockTxn(t, transaction.State_Pending)
 
 	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
@@ -116,13 +119,39 @@ func Test_sendDelegationRequest_Partial_ExcludesAssembledTransactions(t *testing
 	require.NoError(t, err)
 
 	assert.True(t, mocks.SentMessageRecorder.HasSentDelegationRequest())
-	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(delegatedID), "Delegated txn must be included")
 	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(pendingID), "Pending txn must be included")
+	assert.False(t, mocks.SentMessageRecorder.HasDelegatedTransaction(delegatedID), "Delegated txn must not be resent on the partial path")
 	assert.False(t, mocks.SentMessageRecorder.HasDelegatedTransaction(assembledID), "Assembling txn must be excluded on the partial path")
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, delegatedID.String(), requests[0].LastDelegatedTransactionId, "the most recent Delegated txn must be named as the predecessor")
+	assert.NotEmpty(t, requests[0].DelegationId, "every request must carry a delegation ID for its acknowledgement")
+}
+
+// A partial send with no Delegated predecessor (all earlier transactions have moved past
+// pre-assembly) leaves last_delegated_transaction_id empty.
+func Test_sendDelegationRequest_Partial_NoDelegatedPredecessor_EmptyLastDelegated(t *testing.T) {
+	ctx := context.Background()
+	assembledTxn, _ := newExcludedMockTxn(t, transaction.State_Assembling)
+	pendingTxn, pendingID := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(assembledTxn, pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	require.NoError(t, sendDelegationRequest(ctx, o, false))
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	require.Len(t, requests, 1)
+	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(pendingID))
+	assert.Empty(t, requests[0].LastDelegatedTransactionId)
 }
 
 // The full (recovery) path re-delegates everything in the resolved prefix, including already-assembled
-// transactions, because the coordinator may be missing state.
+// transactions, because the coordinator may be missing state. A full request carries the complete
+// order itself, so it names no predecessor.
 func Test_sendDelegationRequest_Full_IncludesAssembledTransactions(t *testing.T) {
 	ctx := context.Background()
 	assembledTxn, assembledID := newDelegatableMockTxn(t, transaction.State_Assembling)
@@ -141,6 +170,10 @@ func Test_sendDelegationRequest_Full_IncludesAssembledTransactions(t *testing.T)
 	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(assembledID), "full resend must include the assembled txn")
 	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(delegatedID))
 	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(pendingID))
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	require.Len(t, requests, 1)
+	assert.Empty(t, requests[0].LastDelegatedTransactionId, "a full request must not name a predecessor")
 }
 
 // A partial delegation with nothing left to send (every resolved transaction is already assembled)
@@ -398,7 +431,7 @@ func Test_action_SendDelegation_Partial_ExcludesAssembled(t *testing.T) {
 		Build()
 	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(100))
 
-	err := action_SendDelegation(ctx, o, &DelegateSendBatchEvent{Full: false})
+	err := action_SendDelegation(ctx, o, &DelegateSendBatchEvent{})
 	require.NoError(t, err)
 
 	assert.True(t, mocks.SentMessageRecorder.HasDelegatedTransaction(pendingID))
@@ -442,4 +475,450 @@ func Test_sendDelegationRequest_TransportError_ReturnsError(t *testing.T) {
 	err := sendDelegationRequest(ctx, o, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transport error")
+}
+
+// A delegation response with every transaction acknowledged moves each one Pending -> Delegated
+// (via a DelegationAcknowledgedEvent) and cancels the request's in-flight entry, and no follow-up
+// delegation is raised.
+func Test_action_HandleDelegationAcknowledged_AllAcked(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newAckExpectingMockTxn(t)
+	txn2, txnID2 := newAckExpectingMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1, txn2).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String(), txnID2.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED, engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, o.partialInFlight, "the response must cancel the request's in-flight entry")
+	assert.Nil(t, o.fullInFlight)
+	assert.Len(t, o.notifyPartialDelegation, 0)
+	assert.Len(t, o.notifyFullDelegation, 0)
+}
+
+// The coordinator applies prefix-acceptance, so error entries are the un-acknowledged remainder:
+// the acknowledged prefix moves to Delegated and a partial delegation is raised to re-send exactly
+// the transactions still Pending.
+func Test_action_HandleDelegationAcknowledged_PrefixAck_RaisesPartialDelegation(t *testing.T) {
+	ctx := context.Background()
+	ackedTxn, ackedID := newAckExpectingMockTxn(t)
+	rejectedTxn, rejectedID := newInertMockTxn(t)
+	skippedTxn, skippedID := newInertMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(ackedTxn, rejectedTxn, skippedTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{ackedID.String(), rejectedID.String(), skippedID.String()},
+		Results: []engineProto.DelegationAcknowledgementResult{
+			engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED,
+			engineProto.DelegationAcknowledgementResult_MAX_INFLIGHT_TRANSACTIONS,
+			engineProto.DelegationAcknowledgementResult_PREVIOUS_TRANSACTION_ERROR,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, o.notifyPartialDelegation, 1, "the un-acknowledged remainder must trigger a partial delegation")
+	assert.Len(t, o.notifyFullDelegation, 0)
+	assert.Nil(t, o.partialInFlight, "a response with per-transaction errors still proves the request landed, so the in-flight entry is cancelled")
+	assert.Nil(t, o.fullInFlight)
+}
+
+// When the coordinator does not recognise the request's last delegated predecessor it cannot
+// guarantee FIFO ordering, so the originator falls back to a full delegation.
+func Test_action_HandleDelegationAcknowledged_UnknownLastDelegated_RaisesFullDelegation(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newInertMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_UNKNOWN_LAST_DELEGATED_TRANSACTION},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, o.notifyFullDelegation, 1, "an unknown predecessor must trigger a full delegation")
+	assert.Len(t, o.notifyPartialDelegation, 0)
+}
+
+// The acknowledged delegation ID can match the full slot rather than the partial one; the response
+// must clear whichever slot holds it.
+func Test_action_HandleDelegationAcknowledged_FullSlotAck_CancelsFullInFlight(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newAckExpectingMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.fullInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, o.fullInFlight, "the response must cancel the full in-flight entry it acknowledges")
+	assert.Nil(t, o.partialInFlight)
+}
+
+// A response carrying fewer acknowledgement results than transactions is malformed: the transaction
+// at the short index and everything after it are treated as un-acknowledged and re-delegated.
+func Test_action_HandleDelegationAcknowledged_FewerResultsThanTransactions_RaisesPartial(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newInertMockTxn(t)
+	txn2, txnID2 := newInertMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1, txn2).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String(), txnID2.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, o.notifyPartialDelegation, 1, "a short results list must re-delegate the un-acknowledged transactions")
+	assert.Len(t, o.notifyFullDelegation, 0)
+}
+
+// An acknowledgement carrying a malformed transaction ID is skipped without failing the whole batch.
+func Test_action_HandleDelegationAcknowledged_InvalidTransactionID_Skips(t *testing.T) {
+	ctx := context.Background()
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{"not-a-uuid"},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, o.notifyPartialDelegation, 0)
+	assert.Len(t, o.notifyFullDelegation, 0)
+}
+
+// An acknowledgement for a transaction that has already completed and been cleaned up is skipped:
+// there is no live transaction left to move to Delegated.
+func Test_action_HandleDelegationAcknowledged_UnknownTransaction_Skips(t *testing.T) {
+	ctx := context.Background()
+	goneID := uuid.New()
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{goneID.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, o.notifyPartialDelegation, 0)
+	assert.Len(t, o.notifyFullDelegation, 0)
+}
+
+// A failure moving an acknowledged transaction Pending → Delegated surfaces as an error from the action.
+func Test_action_HandleDelegationAcknowledged_TransactionHandleEventError_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newAckErroringMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	err := action_HandleDelegationAcknowledged(ctx, o, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "coordinator@node1",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	})
+	require.Error(t, err)
+}
+
+// An acknowledgement from a node that is not the current active coordinator (e.g. one we have since
+// failed away from) is dropped by the state machine: no transaction events, no follow-up delegation,
+// and the in-flight entry for the current coordinator is untouched.
+func Test_stateMachine_Sending_DelegationAckFromStaleCoordinator_Dropped(t *testing.T) {
+	ctx := context.Background()
+	txn1, txnID1 := newInertMockTxn(t)
+
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(txn1).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, &DelegationRequestAcknowledgedEvent{
+		FromNode:       "stale-coordinator@node2",
+		DelegationID:   "d1",
+		TransactionIDs: []string{txnID1.String()},
+		Results:        []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED},
+	}))
+
+	assert.NotNil(t, o.partialInFlight, "a stale acknowledgement must not cancel the in-flight entry")
+	assert.Len(t, o.notifyPartialDelegation, 0)
+	assert.Len(t, o.notifyFullDelegation, 0)
+}
+
+// A partial send is recorded in the partial in-flight slot under the sent delegation ID, so its timeout
+// can re-delegate the transactions if the acknowledgement never arrives.
+func Test_sendDelegationRequest_RecordsInFlightDelegation(t *testing.T) {
+	ctx := context.Background()
+	pendingTxn, _ := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+
+	require.NoError(t, sendDelegationRequest(ctx, o, false))
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	require.Len(t, requests, 1)
+	require.NotNil(t, o.partialInFlight, "the partial send must be recorded in the partial slot")
+	assert.Nil(t, o.fullInFlight, "a partial send must not record a full")
+	assert.Equal(t, requests[0].DelegationId, o.partialInFlight.delegationID, "the in-flight entry must carry the sent delegation ID")
+}
+
+// A send rebuilds from live state, so it supersedes every request already in flight: the prior entry is
+// cancelled and a single fresh one recorded. This is what a request timeout relies on — the timer pokes
+// the notify channel, and the resulting send re-delegates the still-Pending transactions under a fresh
+// delegation ID, with the predecessor computed at send time.
+func Test_action_SendDelegation_SupersedesInFlightUnderFreshDelegationID(t *testing.T) {
+	ctx := context.Background()
+	delegatedTxn, delegatedID := newExcludedMockTxn(t, transaction.State_Delegated)
+	pendingTxn, pendingID := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(delegatedTxn, pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(100))
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+
+	require.NoError(t, action_SendDelegation(ctx, o, &DelegateSendBatchEvent{}))
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	require.Len(t, requests, 1, "the still-outstanding transactions must be re-delegated")
+	assert.NotEqual(t, "d1", requests[0].DelegationId, "the re-delegation must use a fresh delegation ID")
+	require.Len(t, requests[0].Transactions, 1)
+	assert.Equal(t, pendingID.String(), requests[0].Transactions[0].Id, "the still-Pending transaction must be re-delegated")
+	assert.Equal(t, delegatedID.String(), requests[0].LastDelegatedTransactionId, "the predecessor is computed from live state at send time")
+
+	require.NotNil(t, o.partialInFlight, "a fresh in-flight entry replaces the superseded one")
+	assert.NotEqual(t, "d1", o.partialInFlight.delegationID, "the superseded entry must be dropped")
+}
+
+// A partial send supersedes only a prior partial: an in-flight full delegation (a recovery send that
+// re-pushes transactions a partial would not resend) keeps its slot and timer, so its own timeout still
+// fires independently.
+func Test_action_SendDelegation_Partial_PreservesInFlightFull(t *testing.T) {
+	ctx := context.Background()
+	pendingTxn, _ := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(100))
+	full := &inFlightDelegation{delegationID: "full-1"}
+	o.fullInFlight = full
+
+	require.NoError(t, action_SendDelegation(ctx, o, &DelegateSendBatchEvent{}))
+
+	assert.Same(t, full, o.fullInFlight, "a partial send must not disturb an in-flight full delegation")
+	require.NotNil(t, o.partialInFlight, "the partial send is recorded in the partial slot")
+}
+
+// A full send supersedes everything in flight (it re-delegates a superset): both slots collapse to the
+// single new full request.
+func Test_action_SendDelegation_Full_SupersedesBoth(t *testing.T) {
+	ctx := context.Background()
+	pendingTxn, _ := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(100))
+	o.fullInFlight = &inFlightDelegation{delegationID: "full-old"}
+	o.partialInFlight = &inFlightDelegation{delegationID: "partial-old"}
+
+	require.NoError(t, action_SendDelegation(ctx, o, &DelegateSendBatchEvent{Full: true}))
+
+	require.NotNil(t, o.fullInFlight, "the full send is recorded in the full slot")
+	assert.NotEqual(t, "full-old", o.fullInFlight.delegationID, "the prior full is superseded")
+	assert.Nil(t, o.partialInFlight, "a full send supersedes any in-flight partial")
+}
+
+// Switching the active coordinator discards every in-flight delegation request: the full delegation
+// to the new coordinator supersedes them all.
+func Test_action_SwitchActiveCoordinator_CancelsInFlightDelegations(t *testing.T) {
+	ctx := context.Background()
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.partialInFlight = &inFlightDelegation{delegationID: "d1"}
+	o.fullInFlight = &inFlightDelegation{delegationID: "d2"}
+
+	err := action_SwitchActiveCoordinator(ctx, o, &common.HeartbeatReceivedEvent{
+		FromNode: "new-coordinator@node2",
+		CoordinatorSnapshot: &common.CoordinatorSnapshot{
+			CoordinatorState: common.CoordinatorState_Active,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, o.partialInFlight)
+	assert.Nil(t, o.fullInFlight)
+}
+
+// The request timer pokes the notify channel it was armed with when it fires: the partial channel for a
+// partial delegation's timer, the full channel for a full one, so the batching loop re-delegates at the
+// same scope.
+func Test_armInFlightDelegationTimer_PokesNotifyChannelForScope(t *testing.T) {
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	o.delegationLoopCtx = context.Background()
+	o.requestTimeout = time.Millisecond
+
+	o.startInFlightDelegationTimer(&inFlightDelegation{delegationID: "d1"}, o.notifyPartialDelegation)
+	<-o.notifyPartialDelegation
+	assert.Len(t, o.notifyFullDelegation, 0, "a partial request's timeout must not poke the full channel")
+
+	o.startInFlightDelegationTimer(&inFlightDelegation{delegationID: "d2"}, o.notifyFullDelegation)
+	<-o.notifyFullDelegation
+}
+
+// End to end through the batching goroutine: a request whose acknowledgement never arrives is
+// re-delegated under a fresh delegation ID once its request timeout fires.
+func Test_delegationLoop_Timeout_ReDelegatesRequest(t *testing.T) {
+	pendingTxn, _ := newDelegatableMockTxn(t, transaction.State_Pending)
+
+	o, mocks := NewOriginatorBuilderForTesting(t, State_Sending).
+		Transactions(pendingTxn).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	mocks.EngineIntegration.On("GetBlockHeight", mock.Anything).Return(int64(100)).Maybe()
+	o.ctx = context.Background()
+	o.requestTimeout = time.Millisecond
+
+	// startDelegationLoop replaces the builder's channels and runs the real goroutine; entry to
+	// Sending raises nothing here, so raise the partial flag to drive the first send.
+	o.startDelegationLoop()
+	defer o.stopDelegationLoop()
+	o.notifyPartialDelegation <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		if err := o.stateMachineEventLoop.DrainPendingEvents(context.Background()); err != nil {
+			return false
+		}
+		return len(mocks.SentMessageRecorder.SentDelegationRequests()) >= 2
+	}, 5*time.Second, time.Millisecond, "the un-acknowledged request must be re-delegated")
+
+	requests := mocks.SentMessageRecorder.SentDelegationRequests()
+	assert.NotEqual(t, requests[0].DelegationId, requests[1].DelegationId, "the re-delegation must use a fresh delegation ID")
+}
+
+// When a request's timeout fires but a wake is already queued on the notify channel, the redundant
+// wake is dropped rather than blocking the timer goroutine.
+func Test_startInFlightDelegationTimer_ChannelFull_CoalescesTimeout(t *testing.T) {
+	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
+		CurrentActiveCoordinator("coordinator@node1").
+		Build()
+	clk := &captureClock{Clock: common.RealClock()}
+	o.clock = clk
+	o.delegationLoopCtx = context.Background()
+	o.requestTimeout = time.Millisecond
+
+	// Fill the single-slot buffer so a wake is already pending when the timeout fires.
+	o.notifyPartialDelegation <- struct{}{}
+
+	o.startInFlightDelegationTimer(&inFlightDelegation{delegationID: "d1"}, o.notifyPartialDelegation)
+	require.NotNil(t, clk.scheduled, "the timer must have been scheduled")
+
+	clk.scheduled()
+
+	assert.Len(t, o.notifyPartialDelegation, 1, "the redundant timeout wake must be coalesced, not queued")
+}
+
+// captureClock records the function passed to ScheduleTimer so a test can fire the timeout
+// synchronously, deferring every other clock method to the embedded real clock.
+type captureClock struct {
+	common.Clock
+	scheduled func()
+}
+
+func (c *captureClock) ScheduleTimer(_ context.Context, _ time.Duration, f func()) func() {
+	c.scheduled = f
+	return func() {}
+}
+
+// newInertMockTxn builds a mock transaction that must receive no events at all; read-only
+// accessors are permitted but not required.
+func newInertMockTxn(t *testing.T) (*originatortransactionmocks.OriginatorTransaction, uuid.UUID) {
+	txID := uuid.New()
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID).Maybe()
+	mockTxn.On("GetCurrentState").Return(transaction.State_Pending).Maybe()
+	return mockTxn, txID
+}
+
+// newAckExpectingMockTxn builds a mock Pending transaction that must receive exactly one
+// DelegationAcknowledgedEvent.
+func newAckExpectingMockTxn(t *testing.T) (*originatortransactionmocks.OriginatorTransaction, uuid.UUID) {
+	txID := uuid.New()
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID).Maybe()
+	mockTxn.On("GetCurrentState").Return(transaction.State_Pending).Maybe()
+	mockTxn.On("HandleEvent", mock.Anything, mock.AnythingOfType("*transaction.DelegationAcknowledgedEvent")).Return(nil).Once()
+	return mockTxn, txID
+}
+
+// newAckErroringMockTxn builds a mock Pending transaction whose DelegationAcknowledgedEvent handling
+// fails, so the action's error path can be exercised.
+func newAckErroringMockTxn(t *testing.T) (*originatortransactionmocks.OriginatorTransaction, uuid.UUID) {
+	txID := uuid.New()
+	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
+	mockTxn.On("GetID").Return(txID).Maybe()
+	mockTxn.On("GetCurrentState").Return(transaction.State_Pending).Maybe()
+	mockTxn.On("HandleEvent", mock.Anything, mock.AnythingOfType("*transaction.DelegationAcknowledgedEvent")).Return(fmt.Errorf("pop")).Once()
+	return mockTxn, txID
 }

--- a/core/go/internal/sequencer/originator/events.go
+++ b/core/go/internal/sequencer/originator/events.go
@@ -68,6 +68,22 @@ func (*DelegationRequestRejectedEvent) TypeString() string {
 	return "Event_DelegationRequestRejected"
 }
 
+type DelegationRequestAcknowledgedEvent struct {
+	common.BaseEvent
+	FromNode       string
+	DelegationID   string
+	TransactionIDs []string
+	Results        []engineProto.DelegationAcknowledgementResult
+}
+
+func (*DelegationRequestAcknowledgedEvent) Type() EventType {
+	return Event_DelegationRequestAcknowledged
+}
+
+func (*DelegationRequestAcknowledgedEvent) TypeString() string {
+	return "Event_DelegationRequestAcknowledged"
+}
+
 type DelegateSendBatchEvent struct {
 	common.BaseEvent
 	Full bool

--- a/core/go/internal/sequencer/originator/observing.go
+++ b/core/go/internal/sequencer/originator/observing.go
@@ -57,6 +57,7 @@ func action_SwitchActiveCoordinator(ctx context.Context, o *originator, event co
 	o.currentActiveCoordinator = e.FromNode
 	o.resetFailoverIndex()
 	o.heartbeatIntervalsSinceLastReceive = 0
+	o.cancelAllInFlightDelegations()
 	return nil
 }
 
@@ -162,15 +163,13 @@ func (o *originator) hasDroppedTransactions(ctx context.Context, snapshot *commo
 		// A freshly-delegated transaction races the coordinator's snapshot: the snapshot we are checking
 		// against may have been generated before the delegation reached the coordinator, so its absence is
 		// expected rather than a drop. Only consider a transaction dropped once at least one full heartbeat
-		// interval has elapsed since it was first delegated to the current coordinator, by which point that
-		// coordinator has had the chance to include it in a snapshot. The first-delegation time is reset if
-		// the transaction is redirected to a different coordinator, so the grace restarts on each handover
-		// but is not extended by the partial FIFO resend to the same coordinator.
+		// interval has elapsed since it was last delegated, by which point the coordinator has had the
+		// chance to include it in a snapshot.
 		//
 		// A 10% buffer is added to the heartbeat interval to allow for network delays where the delegation has
 		// arrived at the coordinator the instant after a heartbeat has been sent.
-		firstDelegated := txn.GetFirstDelegatedTime()
-		if firstDelegated == nil || o.clock.Now().Sub(*firstDelegated) < o.heartbeatInterval*11/10 {
+		lastDelegated := txn.GetLastDelegatedTime()
+		if lastDelegated == nil || o.clock.Now().Sub(*lastDelegated) < o.heartbeatInterval*11/10 {
 			continue
 		}
 		if !transactionFoundInSnapshot(snapshot, txn) {

--- a/core/go/internal/sequencer/originator/observing_test.go
+++ b/core/go/internal/sequencer/originator/observing_test.go
@@ -82,7 +82,7 @@ func Test_validator_HasDroppedTransactions_TrueWhenInFlightTransactionAbsentFrom
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		NodeName("member1@node1").
 		CurrentActiveCoordinator("coordinator@node1").
@@ -103,7 +103,7 @@ func Test_validator_HasDroppedTransactions_FalseWhenAllTransactionsPresentInSnap
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		NodeName("member1@node1").
 		CurrentActiveCoordinator("coordinator@node1").
@@ -128,7 +128,7 @@ func Test_validator_HasDroppedTransactions_FalseWhenTransactionPresentInReverted
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		NodeName("member1@node1").
 		CurrentActiveCoordinator("coordinator@node1").

--- a/core/go/internal/sequencer/originator/originating.go
+++ b/core/go/internal/sequencer/originator/originating.go
@@ -121,6 +121,7 @@ func action_FailoverToNextCoordinator(ctx context.Context, o *originator, _ comm
 		o.currentActiveCoordinator = o.coordinatorPriorityList[o.failoverIndex]
 		o.failoverIndex = (o.failoverIndex + 1) % len(o.coordinatorPriorityList)
 		o.heartbeatIntervalsSinceLastReceive = 0
+		o.cancelAllInFlightDelegations()
 		log.L(ctx).Debugf("originator failing over from %s to %s (failoverIndex now %d)",
 			prev, o.currentActiveCoordinator, o.failoverIndex)
 	}

--- a/core/go/internal/sequencer/originator/originating_test.go
+++ b/core/go/internal/sequencer/originator/originating_test.go
@@ -144,7 +144,7 @@ func Test_hasDroppedTransactions_TrueWhenDelegatedTxnNotInSnapshot(t *testing.T)
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		Transactions(mockTxn).
 		Build()
@@ -163,7 +163,7 @@ func Test_hasDroppedTransactions_FalseWhenDelegatedTxnWithinGracePeriod(t *testi
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID).Maybe()
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(ptrTo(time.Now()))
+	mockTxn.On("GetLastDelegatedTime").Return(ptrTo(time.Now()))
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		Transactions(mockTxn).
 		Build()
@@ -178,7 +178,7 @@ func Test_hasDroppedTransactions_FalseWhenDelegatedTxnInSnapshot(t *testing.T) {
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	o, _ := NewOriginatorBuilderForTesting(t, State_Sending).
 		Transactions(mockTxn).
 		Build()
@@ -271,7 +271,7 @@ func newDelegatableMockTxn(t *testing.T, state transaction.State) (*originatortr
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(state)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime()).Maybe()
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime()).Maybe()
 	mockTxn.On("GetPrivateTransaction").Return(&components.PrivateTransaction{ID: txID})
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	return mockTxn, txID
@@ -293,7 +293,7 @@ func newExcludedMockTxn(t *testing.T, state transaction.State) (*originatortrans
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID).Maybe()
 	mockTxn.On("GetCurrentState").Return(state)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime()).Maybe()
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime()).Maybe()
 	return mockTxn, txID
 }
 

--- a/core/go/internal/sequencer/originator/originator.go
+++ b/core/go/internal/sequencer/originator/originator.go
@@ -79,8 +79,16 @@ type originator struct {
 	   enqueues a DelegateSendBatchEvent. All fields are owned by the event-loop goroutine. */
 	notifyFullDelegation    chan struct{}
 	notifyPartialDelegation chan struct{}
+	delegationLoopCtx       context.Context
 	delegationLoopCancel    context.CancelFunc
 	delegationLoopDone      chan struct{} // per-run done channel; nil = never started / already stopped+waited
+
+	/* In-flight delegation requests awaiting acknowledgement: at most one full and one partial, both to the
+	   current active coordinator (a coordinator change cancels them). Each holds a one-shot request timer;
+	   if it fires before the acknowledgement arrives it notifiers again so the batching goroutine's next tick
+	   re-delegates the still-outstanding transactions from live state under a fresh delegation ID. */
+	fullInFlight    *inFlightDelegation
+	partialInFlight *inFlightDelegation
 
 	/* Config */
 	nodeName                string
@@ -88,6 +96,7 @@ type originator struct {
 	contractAddress         *pldtypes.EthAddress
 	inactiveGracePeriod     int // expressed as a multiple of heartbeat intervals
 	resolveRetryBackoff     time.Duration
+	requestTimeout          time.Duration
 	delegationBatchInterval time.Duration
 	heartbeatInterval       time.Duration // grace before a delegated-but-unsnapshotted transaction counts as dropped
 
@@ -117,6 +126,7 @@ func NewOriginator(
 		metrics:                 metrics,
 		inactiveGracePeriod:     confutil.IntMin(configuration.InactiveGracePeriod, pldconf.SequencerMinimum.InactiveGracePeriod, *pldconf.SequencerDefaults.InactiveGracePeriod),
 		resolveRetryBackoff:     confutil.DurationMin(configuration.RequestTimeout, pldconf.SequencerMinimum.RequestTimeout, *pldconf.SequencerDefaults.RequestTimeout),
+		requestTimeout:          confutil.DurationMin(configuration.RequestTimeout, pldconf.SequencerMinimum.RequestTimeout, *pldconf.SequencerDefaults.RequestTimeout),
 		delegationBatchInterval: confutil.DurationMin(configuration.DelegationBatchInterval, pldconf.SequencerMinimum.DelegationBatchInterval, *pldconf.SequencerDefaults.DelegationBatchInterval),
 		heartbeatInterval:       confutil.DurationMin(configuration.HeartbeatInterval, pldconf.SequencerMinimum.HeartbeatInterval, *pldconf.SequencerDefaults.HeartbeatInterval),
 		clock:                   common.RealClock(),

--- a/core/go/internal/sequencer/originator/state_machine.go
+++ b/core/go/internal/sequencer/originator/state_machine.go
@@ -38,10 +38,11 @@ const (
 )
 
 const (
-	Event_OriginatorCreated         EventType = iota + 300 // fired once by Start to drive the initial coordinator selection
-	Event_TransactionCreated                               // a new transaction has been created and is ready to be sent to the coordinator TODO maybe name something like Intent created?
-	Event_DelegationRequestRejected                        // pushed by transport_client when a DelegationResponse arrives with Accepted == false
+	Event_OriginatorCreated             EventType = iota + 300 // fired once by Start to drive the initial coordinator selection
+	Event_TransactionCreated                                   // a new transaction has been created and is ready to be sent to the coordinator TODO maybe name something like Intent created?
+	Event_DelegationRequestRejected                            // pushed by transport_client when a DelegationRejection message arrives
 	Event_DelegateSendBatch                                    // fired by the delegation batching goroutine when the batch timer coalesces one or more delegation requests
+	Event_DelegationRequestAcknowledged                        // pushed by transport_client when a DelegationResponse arrives from a coordinator
 )
 
 // Type aliases for the generic statemachine types, specialized for originator
@@ -277,6 +278,15 @@ var stateDefinitionsMap = StateDefinitions{
 							Action: action_FailoverToNextCoordinator,
 						},
 					},
+				}},
+			},
+			Event_DelegationRequestAcknowledged: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					// An acknowledgement is only meaningful from the current active coordinator; one from
+					// any other node (e.g. a coordinator we have since failed away from) is dropped.
+					Validator: validator_IsDelegationAckFromCurrentCoordinator,
+					Actions:   []ActionRule{{Action: action_HandleDelegationAcknowledged}},
 				}},
 			},
 			Event_DelegationRequestRejected: {

--- a/core/go/internal/sequencer/originator/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/state_machine_test.go
@@ -666,7 +666,7 @@ func TestStateMachine_Sending_HeartbeatReceived_DroppedTransaction_Redelegates(t
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	mockTxn.On("GetPrivateTransaction").Return(&components.PrivateTransaction{ID: txID})
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	builder := NewOriginatorBuilderForTesting(t, State_Sending).
@@ -701,7 +701,7 @@ func TestStateMachine_Sending_HeartbeatReceived_NoDroppedTransactions_NoRedelega
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	builder := NewOriginatorBuilderForTesting(t, State_Sending).
 		CurrentActiveCoordinator("coordinator@node1").
 		Transactions(mockTxn)
@@ -731,7 +731,7 @@ func TestStateMachine_Sending_HeartbeatReceived_HigherPriorityActiveNode_Redirec
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated) // called by validator_HasDroppedTransactions (step 5)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	mockTxn.On("GetPrivateTransaction").Return(&components.PrivateTransaction{ID: txID})
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	builder := NewOriginatorBuilderForTesting(t, State_Sending).
@@ -1073,7 +1073,7 @@ func TestStateMachine_Sending_HeartbeatReceived_Step3_GraceExceeded_SwitchesCoor
 	mockTxn := originatortransactionmocks.NewOriginatorTransaction(t)
 	mockTxn.On("GetID").Return(txID)
 	mockTxn.On("GetCurrentState").Return(transaction.State_Delegated)
-	mockTxn.On("GetFirstDelegatedTime").Return(staleDelegatedTime())
+	mockTxn.On("GetLastDelegatedTime").Return(staleDelegatedTime())
 	mockTxn.On("GetPrivateTransaction").Return(&components.PrivateTransaction{ID: txID})
 	mockTxn.On("HandleEvent", mock.Anything, mock.Anything).Return(nil)
 	builder := NewOriginatorBuilderForTesting(t, State_Sending).

--- a/core/go/internal/sequencer/originator/transaction/delegated.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated.go
@@ -25,18 +25,13 @@ import (
 	"github.com/google/uuid"
 )
 
-func action_Delegated(ctx context.Context, t *originatorTransaction, event common.Event) error {
+// action_DelegationSent records the coordinator a delegation request was sent to and the time it was
+// sent. The dropped-transaction grace runs from this time, so it restarts whenever the transaction
+// is genuinely (re)delegated.
+func action_DelegationSent(ctx context.Context, t *originatorTransaction, event common.Event) error {
 	e := event.(*DelegatedEvent)
 	if e.Coordinator == "" {
 		return i18n.NewError(ctx, msgs.MsgSequencerInternalError, "transaction delegate cannot be set to an empty node identity")
-	}
-	// Reset the first-delegation timestamp whenever the transaction is delegated to a different
-	// coordinator: the dropped-transaction grace must restart so the new coordinator has a chance to
-	// report the transaction in a snapshot before it can be considered dropped. Re-delegations to the
-	// same coordinator (e.g. the partial FIFO resend) leave it untouched so the grace reflects how long
-	// the transaction has genuinely been in flight there.
-	if t.firstDelegatedTime == nil || e.Coordinator != t.currentDelegate {
-		t.firstDelegatedTime = ptrTo(t.clock.Now())
 	}
 	t.currentDelegate = e.Coordinator
 	t.updateLastDelegatedTime()
@@ -44,7 +39,7 @@ func action_Delegated(ctx context.Context, t *originatorTransaction, event commo
 }
 
 // action_ResetDelegationState clears all assembly and dispatch state accumulated for the previous
-// coordinator. Called alongside action_Delegated when a transaction is re-delegated to a new coordinator.
+// coordinator. Called alongside action_DelegationSent when a transaction is re-delegated to a new coordinator.
 func action_ResetDelegationState(_ context.Context, t *originatorTransaction, _ common.Event) error {
 	t.latestAssembleRequest = nil
 	t.latestFulfilledAssembleRequestID = uuid.Nil
@@ -66,7 +61,7 @@ func validator_CoordinatorIsCurrentDelegate(ctx context.Context, t *originatorTr
 }
 
 func (t *originatorTransaction) updateLastDelegatedTime() {
-	t.lastDelegatedTime = ptrTo(common.RealClock().Now())
+	t.lastDelegatedTime = ptrTo(t.clock.Now())
 }
 
 func action_SendPreDispatchResponse(ctx context.Context, txn *originatorTransaction, _ common.Event) error {

--- a/core/go/internal/sequencer/originator/transaction/delegated_test.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_action_Delegated_EmptyCoordinator_ReturnsError(t *testing.T) {
+func Test_action_DelegationSent_EmptyCoordinator_ReturnsError(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn, _ := builder.BuildWithMocks()
@@ -37,12 +37,12 @@ func Test_action_Delegated_EmptyCoordinator_ReturnsError(t *testing.T) {
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: "",
 	}
-	err := action_Delegated(ctx, txn, event)
+	err := action_DelegationSent(ctx, txn, event)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "transaction delegate cannot be set to an empty node identity")
 }
 
-func Test_action_Delegated_SetsDelegateAndUpdatesTime(t *testing.T) {
+func Test_action_DelegationSent_SetsDelegateAndUpdatesTime(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn, _ := builder.BuildWithMocks()
@@ -51,39 +51,40 @@ func Test_action_Delegated_SetsDelegateAndUpdatesTime(t *testing.T) {
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: coordinator,
 	}
-	err := action_Delegated(ctx, txn, event)
+	err := action_DelegationSent(ctx, txn, event)
 	require.NoError(t, err)
 	assert.Equal(t, coordinator, txn.currentDelegate)
 	assert.NotNil(t, txn.lastDelegatedTime)
 }
 
-func Test_action_Delegated_FirstDelegatedTime_ResetOnlyOnCoordinatorChange(t *testing.T) {
+func Test_action_DelegationSent_LastDelegatedTime_AdvancesOnEveryDelegation(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn, _ := builder.BuildWithMocks()
 
-	// First delegation records the first-delegation timestamp for the coordinator.
-	require.NoError(t, action_Delegated(ctx, txn, &DelegatedEvent{
+	// Each delegation records the time it was sent; the dropped-transaction grace runs from here.
+	require.NoError(t, action_DelegationSent(ctx, txn, &DelegatedEvent{
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: "coord@node1",
 	}))
-	require.NotNil(t, txn.firstDelegatedTime)
-	first := txn.firstDelegatedTime
+	require.NotNil(t, txn.lastDelegatedTime)
+	first := txn.lastDelegatedTime
 
-	// Re-delegation to the same coordinator (the partial FIFO resend) must not move it, so the
-	// dropped-transaction grace reflects how long the transaction has genuinely been in flight there.
-	require.NoError(t, action_Delegated(ctx, txn, &DelegatedEvent{
+	// A re-delegation to the same coordinator restarts the grace.
+	require.NoError(t, action_DelegationSent(ctx, txn, &DelegatedEvent{
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: "coord@node1",
 	}))
-	assert.Same(t, first, txn.firstDelegatedTime, "re-delegation to the same coordinator must not reset the first-delegation time")
+	assert.NotSame(t, first, txn.lastDelegatedTime, "re-delegation must record a new last-delegated time")
 
-	// Delegation to a different coordinator restarts the grace against the new coordinator's snapshots.
-	require.NoError(t, action_Delegated(ctx, txn, &DelegatedEvent{
+	// So does a delegation to a different coordinator, which also records the new delegate.
+	second := txn.lastDelegatedTime
+	require.NoError(t, action_DelegationSent(ctx, txn, &DelegatedEvent{
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: "coord@node2",
 	}))
-	assert.NotSame(t, first, txn.firstDelegatedTime, "delegation to a new coordinator must reset the first-delegation time")
+	assert.NotSame(t, second, txn.lastDelegatedTime, "delegation to a new coordinator must record a new last-delegated time")
+	assert.Equal(t, "coord@node2", txn.currentDelegate)
 }
 
 func TestAction_SendPreDispatchResponse_Success(t *testing.T) {
@@ -409,7 +410,7 @@ func TestValidator_PreDispatchRequestMatchesAssembledDelegation_HashError(t *tes
 
 func Test_action_ResetDelegationState_ClearsAssemblyAndDispatchState(t *testing.T) {
 	ctx := context.Background()
-	// Start in State_Assembling — state machine has a top-level validator for Event_Delegated in
+	// Start in State_Assembling — state machine has a top-level validator for Event_DelegationSent in
 	// this state that checks ValidatorNot(validator_CoordinatorIsCurrentDelegate), so a re-delegation
 	// from a DIFFERENT coordinator triggers action_ResetDelegationState.
 	builder := NewTransactionBuilderForTesting(t, State_Assembling)
@@ -433,8 +434,8 @@ func Test_action_ResetDelegationState_ClearsAssemblyAndDispatchState(t *testing.
 	})
 	require.NoError(t, err)
 
-	// State should transition back to Delegated.
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	// State should drop back to Pending to await the new coordinator's acknowledgement.
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 
 	// action_ResetDelegationState should have cleared all assembly/dispatch state.
 	assert.Nil(t, txn.latestAssembleRequest)
@@ -443,7 +444,7 @@ func Test_action_ResetDelegationState_ClearsAssemblyAndDispatchState(t *testing.
 	assert.Nil(t, txn.signerAddress)
 	assert.Nil(t, txn.latestSubmissionHash)
 	assert.Nil(t, txn.nonce)
-	// currentDelegate should now be the new coordinator (set by action_Delegated).
+	// currentDelegate should now be the new coordinator (set by action_DelegationSent).
 	assert.Equal(t, newCoordinator, txn.currentDelegate)
 }
 

--- a/core/go/internal/sequencer/originator/transaction/events.go
+++ b/core/go/internal/sequencer/originator/transaction/events.go
@@ -122,14 +122,31 @@ type DelegatedEvent struct {
 }
 
 func (*DelegatedEvent) Type() EventType {
-	return Event_Delegated
+	return Event_DelegationSent
 }
 
 func (*DelegatedEvent) TypeString() string {
-	return "Event_Delegated"
+	return "Event_DelegationSent"
 }
 
 func (e *DelegatedEvent) GetCoordinator() string {
+	return e.Coordinator
+}
+
+type DelegationAcknowledgedEvent struct {
+	BaseEvent
+	Coordinator string
+}
+
+func (*DelegationAcknowledgedEvent) Type() EventType {
+	return Event_DelegationAcknowledged
+}
+
+func (*DelegationAcknowledgedEvent) TypeString() string {
+	return "Event_DelegationAcknowledged"
+}
+
+func (e *DelegationAcknowledgedEvent) GetCoordinator() string {
 	return e.Coordinator
 }
 

--- a/core/go/internal/sequencer/originator/transaction/events_test.go
+++ b/core/go/internal/sequencer/originator/transaction/events_test.go
@@ -115,12 +115,12 @@ func TestCreatedEvent_Fields(t *testing.T) {
 
 func TestDelegatedEvent_Type(t *testing.T) {
 	event := &DelegatedEvent{}
-	assert.Equal(t, Event_Delegated, event.Type())
+	assert.Equal(t, Event_DelegationSent, event.Type())
 }
 
 func TestDelegatedEvent_TypeString(t *testing.T) {
 	event := &DelegatedEvent{}
-	assert.Equal(t, "Event_Delegated", event.TypeString())
+	assert.Equal(t, "Event_DelegationSent", event.TypeString())
 }
 
 func TestDelegatedEvent_Fields(t *testing.T) {

--- a/core/go/internal/sequencer/originator/transaction/state_machine.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine.go
@@ -51,7 +51,7 @@ const (
 	Event_Created                    EventType = iota // Transaction initially received by the originator or has been loaded from the database after a restart / swap-in
 	Event_ConfirmedSuccess                            // confirmation received from the blockchain of base ledge transaction successful completion
 	Event_ConfirmedReverted                           // confirmation received from the blockchain of base ledge transaction failure
-	Event_Delegated                                   // transaction has been delegated to a coordinator
+	Event_DelegationSent                              // a delegation request has been sent to a coordinator
 	Event_AssembleRequestReceived                     // coordinator has requested that we assemble the transaction
 	Event_AssembleSuccess                             // we have successfully assembled the transaction (signing, if required, happens separately in State_Signing)
 	Event_SignSuccess                                 // the background sign goroutine has signed all local SIGN attestations of the assembled plan
@@ -68,6 +68,7 @@ const (
 	Event_VerifiersResolved                           // background resolution of the required verifiers completed successfully
 	Event_VerifierResolutionFailed                    // background resolution of the required verifiers failed; a retry will be scheduled
 	Event_VerifierResolutionRetry                     // scheduled retry timer fired; re-attempt verifier resolution
+	Event_DelegationAcknowledged                      // the coordinator has acknowledged receipt of this transaction's delegation
 )
 
 // Type aliases for the generic statemachine types, specialized for Transaction
@@ -83,6 +84,44 @@ type (
 	StateDefinitions = statemachine.StateDefinitions[State, *originatorTransaction]
 	StateMachine     = statemachine.StateMachine[State, *originatorTransaction]
 )
+
+// State_Pending and State_Delegated share the handlers for coordinator-driven progress events
+// (assemble request, dispatch notification). A valid event from the current delegate is proof that
+// the coordinator holds the transaction, so a transaction still Pending (its delegation
+// acknowledgement has not yet been processed) proceeds exactly as if the acknowledgement had
+// arrived first.
+var preAssemblyAssembleRequestReceivedHandlers = EventHandlers{
+	Match: statemachine.MatchAll,
+	Handlers: []EventHandler{{
+		// Always runs first: refresh the cached block height before any validator reads it.
+		Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
+	}, {
+		// Assemble request is not from the current delegate; reject without entering the assembly flow.
+		Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
+		Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
+	}, {
+		// Block height tolerance exceeded: reject without entering the assembly flow.
+		Validator: validator_AssembleBlockHeightToleranceExceeded,
+		Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
+	}, {
+		// Private state incomplete: reject so the coordinator retries once states have arrived.
+		Validator: validator_IsPrivateStateDataPendingForAssembly,
+		Actions:   []ActionRule{{Action: action_RejectAssemblyPrivateStateDataPending}},
+	}, {
+		// All checks pass: assemble and transition.
+		Validator: statemachine.ValidatorAnd(
+			validator_AssembleRequestFromCurrentDelegate,
+			statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
+			statemachine.ValidatorNot(validator_IsPrivateStateDataPendingForAssembly),
+		),
+		Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
+		Transitions: []Transition{
+			{
+				To: State_Assembling,
+			},
+		},
+	}},
+}
 
 var stateDefinitionsMap = StateDefinitions{
 	State_Initial: {
@@ -168,13 +207,36 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
+				// Sending a delegation request records the delegate and the delegation time, but the
+				// transaction stays Pending until the coordinator's acknowledgement arrives.
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
-					Actions: []ActionRule{{Action: action_Delegated}},
+					Actions: []ActionRule{{Action: action_DelegationSent}},
+				}},
+			},
+			Event_DelegationAcknowledged: {
+				// The current delegate has acknowledged receipt of the delegation: the transaction is
+				// now known to be held by the coordinator.
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Validator: validator_CoordinatorIsCurrentDelegate,
 					Transitions: []Transition{
 						{
 							To: State_Delegated,
+						},
+					},
+				}},
+			},
+			Event_AssembleRequestReceived: preAssemblyAssembleRequestReceivedHandlers,
+			Event_Dispatched: {
+				Match: statemachine.MatchFirst,
+				Handlers: []EventHandler{{
+					Validator: validator_CoordinatorIsCurrentDelegate,
+					Actions:   []ActionRule{{Action: action_Dispatched}},
+					Transitions: []Transition{
+						{
+							To: State_Dispatched,
 						},
 					},
 				}},
@@ -198,47 +260,27 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
-				Match: statemachine.MatchAll,
+			Event_DelegationSent: {
+				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the previous coordinator's acknowledgement no
+					// longer holds, so discard its accumulated state, record the new delegate, and drop back to
+					// Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
-					Actions:   []ActionRule{{Action: action_ResetDelegationState}},
-				}, {
-					Actions: []ActionRule{{Action: action_Delegated}},
-				}},
-			},
-			Event_AssembleRequestReceived: {
-				Match: statemachine.MatchAll,
-				Handlers: []EventHandler{{
-					// Always runs first: refresh the cached block height before any validator reads it.
-					Actions: []ActionRule{{Action: action_RefreshBlockHeight}},
-				}, {
-					// Assemble request is not from the current delegate; reject without entering the assembly flow.
-					Validator: statemachine.ValidatorNot(validator_AssembleRequestFromCurrentDelegate),
-					Actions:   []ActionRule{{Action: action_SendAssembleRejectionNotCurrentDelegate}},
-				}, {
-					// Block height tolerance exceeded: reject without entering the assembly flow.
-					Validator: validator_AssembleBlockHeightToleranceExceeded,
-					Actions:   []ActionRule{{Action: action_SendAssembleBlockHeightRejection}},
-				}, {
-					// Private state incomplete: reject so the coordinator retries once states have arrived.
-					Validator: validator_IsPrivateStateDataPendingForAssembly,
-					Actions:   []ActionRule{{Action: action_RejectAssemblyPrivateStateDataPending}},
-				}, {
-					// All checks pass: assemble and transition.
-					Validator: statemachine.ValidatorAnd(
-						validator_AssembleRequestFromCurrentDelegate,
-						statemachine.ValidatorNot(validator_AssembleBlockHeightToleranceExceeded),
-						statemachine.ValidatorNot(validator_IsPrivateStateDataPendingForAssembly),
-					),
-					Actions: []ActionRule{{Action: action_AssembleRequestReceived}},
-					Transitions: []Transition{
-						{
-							To: State_Assembling,
-						},
+					Actions: []ActionRule{
+						{Action: action_DelegationSent},
+						{Action: action_ResetDelegationState},
 					},
+					Transitions: []Transition{{
+						To: State_Pending,
+					}},
+				}, {
+					// Re-sent to the same coordinator that already acknowledged us: just refresh the delegation
+					// time (restarting the dropped-transaction grace) and stay Delegated.
+					Actions: []ActionRule{{Action: action_DelegationSent}},
 				}},
 			},
+			Event_AssembleRequestReceived: preAssemblyAssembleRequestReceivedHandlers,
 			Event_Dispatched: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
@@ -272,16 +314,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -415,16 +460,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -513,16 +561,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -598,16 +649,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -710,16 +764,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -801,16 +858,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -886,16 +946,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},
@@ -954,16 +1017,19 @@ var stateDefinitionsMap = StateDefinitions{
 					Transitions: []Transition{{To: State_Confirmed}},
 				}},
 			},
-			Event_Delegated: {
+			Event_DelegationSent: {
 				Match: statemachine.MatchFirst,
 				Handlers: []EventHandler{{
+					// Re-delegated to a different coordinator: the acknowledgement we were holding no longer
+					// applies, so discard the state accumulated for the old coordinator, record the new delegate,
+					// and drop back to Pending to await the new coordinator's delegation acknowledgement.
 					Validator: statemachine.ValidatorNot(validator_CoordinatorIsCurrentDelegate),
 					Actions: []ActionRule{
-						{Action: action_Delegated},
+						{Action: action_DelegationSent},
 						{Action: action_ResetDelegationState},
 					},
 					Transitions: []Transition{{
-						To: State_Delegated,
+						To: State_Pending,
 					}},
 				}},
 			},

--- a/core/go/internal/sequencer/originator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine_test.go
@@ -33,13 +33,18 @@ func Test_HandleEvent_ProcessesEvent(t *testing.T) {
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn, mocks := builder.BuildWithMocks()
 	coordinator := "coord@node1"
-	event := &DelegatedEvent{
+	err := txn.HandleEvent(ctx, &DelegatedEvent{
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: coordinator,
-	}
-	err := txn.HandleEvent(ctx, event)
+	})
 	require.NoError(t, err)
 	assert.Equal(t, coordinator, txn.currentDelegate)
+	// The acknowledgement from the delegate transitions Pending -> Delegated
+	err = txn.HandleEvent(ctx, &DelegationAcknowledgedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
+		Coordinator: coordinator,
+	})
+	require.NoError(t, err)
 	// Transition callback should have been invoked
 	<-mocks.Events
 }
@@ -280,13 +285,13 @@ func TestOriginatorTransaction_Resolving_OnRetry_ReResolves(t *testing.T) {
 	assert.True(t, ok, "the retry must re-run resolution")
 }
 
-// An assemble request must be silently dropped in any state before the transaction has been delegated,
-// so verifiers are guaranteed resolved by the time assembly runs. There is no handler for
-// Event_AssembleRequestReceived in State_Initial, State_Resolving or State_Pending: the event is ignored
-// and the transaction does not change state or invoke assembly.
+// An assemble request must be silently dropped in any state before the transaction is eligible for
+// delegation, so verifiers are guaranteed resolved by the time assembly runs. There is no handler
+// for Event_AssembleRequestReceived in State_Initial or State_Resolving: the event is ignored and
+// the transaction does not change state or invoke assembly.
 func TestOriginatorTransaction_AssembleRequestIgnoredBeforeDelegation(t *testing.T) {
 	ctx := context.Background()
-	for _, state := range []State{State_Initial, State_Resolving, State_Pending} {
+	for _, state := range []State{State_Initial, State_Resolving} {
 		t.Run(state.String(), func(t *testing.T) {
 			builder := NewTransactionBuilderForTesting(t, state)
 			txn, mocks := builder.BuildWithMocks()
@@ -303,7 +308,25 @@ func TestOriginatorTransaction_AssembleRequestIgnoredBeforeDelegation(t *testing
 	}
 }
 
-func TestOriginatorTransaction_Pending_ToDelegated_OnDelegated(t *testing.T) {
+// A Pending transaction that has never been sent to a coordinator has no current delegate, so any
+// assemble request is rejected as not-current-delegate and the transaction stays Pending.
+func TestOriginatorTransaction_Pending_AssembleRequestRejectedBeforeSend(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Pending)
+	txn, mocks := builder.BuildWithMocks()
+
+	err := txn.HandleEvent(ctx, &AssembleRequestReceivedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		RequestID:   uuid.New(),
+		Coordinator: builder.GetCoordinator(),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Pending, txn.GetCurrentState(), "assemble request must not change state")
+	assert.True(t, mocks.SentMessageRecorder.HasSentAssembleRejection())
+	mocks.EngineIntegration.AssertNotCalled(t, "Assemble")
+}
+
+func TestOriginatorTransaction_Pending_StaysPending_OnDelegated(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn := builder.Build()
@@ -315,7 +338,161 @@ func TestOriginatorTransaction_Pending_ToDelegated_OnDelegated(t *testing.T) {
 		Coordinator: builder.GetCoordinator(),
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, State_Pending, txn.GetCurrentState(), "sending a delegation request must not change state before the acknowledgement arrives")
+	assert.Equal(t, builder.GetCoordinator(), txn.currentDelegate)
+	assert.NotNil(t, txn.lastDelegatedTime)
+}
+
+func TestOriginatorTransaction_Pending_ToDelegated_OnDelegationAcknowledged(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Pending)
+	txn := builder.Build()
+
+	require.NoError(t, txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	}))
+	require.Equal(t, State_Pending, txn.GetCurrentState())
+
+	err := txn.HandleEvent(ctx, &DelegationAcknowledgedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	})
+	assert.NoError(t, err)
 	assert.Equal(t, State_Delegated, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
+}
+
+func TestOriginatorTransaction_Pending_IgnoresDelegationAcknowledged_FromNonCurrentDelegate(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Pending)
+	txn := builder.Build()
+
+	require.NoError(t, txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	}))
+
+	err := txn.HandleEvent(ctx, &DelegationAcknowledgedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: "other-coordinator@node2",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Pending, txn.GetCurrentState(), "an acknowledgement from a node other than the current delegate must be ignored")
+}
+
+// A late or duplicate acknowledgement must never regress a transaction that has progressed past
+// Pending — including the duplicate acknowledgements a full delegation produces for transactions
+// the coordinator already holds.
+func TestOriginatorTransaction_DelegationAcknowledged_NoOpPastPending(t *testing.T) {
+	ctx := context.Background()
+	states := []State{
+		State_Delegated,
+		State_Assembling,
+		State_Signing,
+		State_Endorsement_Gathering,
+		State_Prepared,
+		State_Dispatched,
+		State_Sequenced,
+		State_Submitted,
+		State_Parked,
+	}
+	for _, state := range states {
+		t.Run(state.String(), func(t *testing.T) {
+			builder := NewTransactionBuilderForTesting(t, state)
+			txn := builder.Build()
+			txn.currentDelegate = builder.GetCoordinator()
+
+			err := txn.HandleEvent(ctx, &DelegationAcknowledgedEvent{
+				BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+				Coordinator: builder.GetCoordinator(),
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, state, txn.GetCurrentState(), "a late acknowledgement must not change state")
+		})
+	}
+}
+
+// A full delegation resend to the same coordinator refreshes the delegation bookkeeping but changes
+// no transaction's state.
+func TestOriginatorTransaction_Delegated_StaysDelegated_OnDelegatedSameCoordinator(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Delegated)
+	txn := builder.Build()
+
+	err := txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, builder.GetCoordinator(), txn.currentDelegate)
+}
+
+func TestOriginatorTransaction_Delegated_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+	// Re-delegating an acknowledged transaction to a different coordinator drops it back to Pending:
+	// the new coordinator has not yet acknowledged it, so State_Delegated (which now means
+	// "acknowledged by the current delegate") no longer applies.
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Delegated)
+	txn := builder.Build()
+
+	newCoordinator := uuid.New().String()
+	err := txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: newCoordinator,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
+	assert.Equal(t, newCoordinator, txn.currentDelegate)
+}
+
+// An assemble request from the current delegate while the transaction is still Pending is proof the
+// coordinator holds the transaction, so it proceeds exactly as it would from State_Delegated.
+func TestOriginatorTransaction_Pending_ToAssembling_OnAssembleRequestFromCurrentDelegate(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Pending)
+	txn, mocks := builder.BuildWithMocks()
+
+	require.NoError(t, txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	}))
+	require.Equal(t, State_Pending, txn.GetCurrentState())
+
+	mocks.MockForAssembleRequestOK().Once()
+	err := txn.HandleEvent(ctx, &AssembleRequestReceivedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		RequestID:   uuid.New(),
+		Coordinator: builder.GetCoordinator(),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Assembling, txn.GetCurrentState())
+	// Wait for the state transition event and the background assembly's success event.
+	<-mocks.Events
+	<-mocks.Events
+	assert.True(t, mocks.EngineIntegration.AssertExpectations(t))
+}
+
+// A dispatch notification from the current delegate while the transaction is still Pending is proof
+// the coordinator holds the transaction, so it proceeds exactly as it would from State_Delegated.
+func TestOriginatorTransaction_Pending_ToDispatched_OnDispatchedFromCurrentDelegate(t *testing.T) {
+	ctx := context.Background()
+	builder := NewTransactionBuilderForTesting(t, State_Pending)
+	txn := builder.Build()
+
+	require.NoError(t, txn.HandleEvent(ctx, &DelegatedEvent{
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: builder.GetCoordinator(),
+	}))
+	require.Equal(t, State_Pending, txn.GetCurrentState())
+
+	err := txn.HandleEvent(ctx, &DispatchedEvent{
+		BaseEvent:     BaseEvent{TransactionID: txn.GetID()},
+		Coordinator:   builder.GetCoordinator(),
+		SignerAddress: *pldtypes.RandAddress(),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, State_Dispatched, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Delegated_ToAssembling_OnAssembleRequestReceived_OK(t *testing.T) {
@@ -503,7 +680,7 @@ func Test_Delegated_PrivateStateComplete_ProceedsToAssembly(t *testing.T) {
 	assert.Equal(t, State_Assembling, txn.GetCurrentState())
 }
 
-func TestOriginatorTransaction_Assembling_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Assembling_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Assembling)
 	txn := builder.Build()
@@ -513,7 +690,7 @@ func TestOriginatorTransaction_Assembling_ToDelegated_OnDelegated_IfDifferentCoo
 		Coordinator: uuid.New().String(), // different from current delegate
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Assembling_ToEndorsement_Gathering_OnAssembleSuccess(t *testing.T) {
@@ -788,7 +965,7 @@ func TestOriginatorTransaction_Delegated_ToDispatched_OnDispatched_IfCurrentDele
 	assert.Equal(t, State_Dispatched, txn.GetCurrentState())
 }
 
-func TestOriginatorTransaction_EndorsementGathering_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_EndorsementGathering_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering)
 	txn := builder.Build()
@@ -798,7 +975,7 @@ func TestOriginatorTransaction_EndorsementGathering_ToDelegated_OnDelegated_IfDi
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Endorsement_Gathering_NoTransition_OnAssembleRequest_IfMatchesPreviousRequest(t *testing.T) {
@@ -941,7 +1118,7 @@ func TestOriginatorTransaction_Reverted_StaysInState_OnAssembleRequestReceived_P
 	assert.Equal(t, State_Reverted, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 
-func TestOriginatorTransaction_Parked_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Parked_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Parked)
 	txn := builder.Build()
@@ -951,7 +1128,7 @@ func TestOriginatorTransaction_Parked_ToDelegated_OnDelegated_IfDifferentCoordin
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Parked_DoResendAssembleResponse_OnAssembleRequest_IfMatchesPreviousRequest(t *testing.T) {
@@ -1193,7 +1370,7 @@ func TestOriginatorTransaction_Endorsement_Gathering_NoTransition_OnDispatchConf
 	assert.Equal(t, State_Endorsement_Gathering, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 
-func TestOriginatorTransaction_Prepared_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Prepared_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Prepared)
 	txn := builder.Build()
@@ -1203,7 +1380,7 @@ func TestOriginatorTransaction_Prepared_ToDelegated_OnDelegated_IfDifferentCoord
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Prepared_NoTransition_OnAssembleRequest_IfMatchesPreviousRequest(t *testing.T) {
@@ -1529,7 +1706,7 @@ func TestOriginatorTransaction_Dispatched_ToDelegated_OnConfirmedReverted(t *tes
 	assert.Equal(t, State_Delegated, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 
-func TestOriginatorTransaction_Dispatched_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Dispatched_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Dispatched)
 	txn := builder.Build()
@@ -1539,7 +1716,7 @@ func TestOriginatorTransaction_Dispatched_ToDelegated_OnDelegated_IfDifferentCoo
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Sequenced_ToConfirmed_OnConfirmedSuccess(t *testing.T) {
@@ -1669,7 +1846,7 @@ func TestOriginatorTransaction_Sequenced_ToDelegated_OnConfirmedReverted(t *test
 	assert.Equal(t, State_Delegated, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 
-func TestOriginatorTransaction_Sequenced_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Sequenced_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Sequenced)
 	txn := builder.Build()
@@ -1679,7 +1856,7 @@ func TestOriginatorTransaction_Sequenced_ToDelegated_OnDelegated_IfDifferentCoor
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Submitted_StaysSubmitted_OnSubmitted_IfCurrentDelegate(t *testing.T) {
@@ -1728,7 +1905,7 @@ func TestOriginatorTransaction_Submitted_ToDelegated_OnConfirmedReverted(t *test
 	assert.Equal(t, State_Delegated, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
 }
 
-func TestOriginatorTransaction_Submitted_ToDelegated_OnDelegated_IfDifferentCoordinator(t *testing.T) {
+func TestOriginatorTransaction_Submitted_ToPending_OnDelegated_IfDifferentCoordinator(t *testing.T) {
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Submitted)
 	txn := builder.Build()
@@ -1738,7 +1915,7 @@ func TestOriginatorTransaction_Submitted_ToDelegated_OnDelegated_IfDifferentCoor
 		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, State_Delegated, txn.GetCurrentState())
+	assert.Equal(t, State_Pending, txn.GetCurrentState())
 }
 
 func TestOriginatorTransaction_Submitted_ToAssembling_OnAssembleRequest(t *testing.T) {

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -45,7 +45,7 @@ type OriginatorTransaction interface {
 	GetCurrentState() State
 	GetPrivateTransaction() *components.PrivateTransaction
 	GetStatus(ctx context.Context) components.PrivateTxStatus
-	GetFirstDelegatedTime() *time.Time
+	GetLastDelegatedTime() *time.Time
 }
 
 // OriginatorTransaction tracks the state of a transaction that is being sent by the local node in originator state.
@@ -62,7 +62,6 @@ type originatorTransaction struct {
 	queueEventForOriginator          func(context.Context, common.Event)
 	currentDelegate                  string
 	lastDelegatedTime                *time.Time
-	firstDelegatedTime               *time.Time // set on first delegation to the current coordinator; reset when the coordinator changes
 	latestAssembleRequest            *assembleRequestFromCoordinator
 	latestFulfilledAssembleRequestID uuid.UUID
 	latestPreDispatchRequestID       uuid.UUID
@@ -263,10 +262,4 @@ func (t *originatorTransaction) GetLastDelegatedTime() *time.Time {
 	t.RLock()
 	defer t.RUnlock()
 	return t.lastDelegatedTime
-}
-
-func (t *originatorTransaction) GetFirstDelegatedTime() *time.Time {
-	t.RLock()
-	defer t.RUnlock()
-	return t.firstDelegatedTime
 }

--- a/core/go/internal/sequencer/originator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_test.go
@@ -171,29 +171,20 @@ func TestTransaction_GetLastDelegatedTime_ReturnsUpdatedTime(t *testing.T) {
 	assert.NotNil(t, time1, "GetLastDelegatedTime should return a non-nil value")
 }
 
-func TestTransaction_GetFirstDelegatedTime_InitiallyNil(t *testing.T) {
-	// Test that GetFirstDelegatedTime returns nil for a newly created transaction
-	builder := NewTransactionBuilderForTesting(t, State_Initial)
-	txn, _ := builder.BuildWithMocks()
-
-	firstDelegatedTime := txn.GetFirstDelegatedTime()
-	assert.Nil(t, firstDelegatedTime, "GetFirstDelegatedTime should return nil for a newly created transaction")
-}
-
-func TestTransaction_GetFirstDelegatedTime_ReturnsSetTime(t *testing.T) {
-	// Test that GetFirstDelegatedTime returns the time recorded on first delegation
+func TestTransaction_GetLastDelegatedTime_ReturnsSetTimeAfterDelegation(t *testing.T) {
+	// Test that GetLastDelegatedTime returns the time recorded on delegation
 	ctx := context.Background()
 	builder := NewTransactionBuilderForTesting(t, State_Pending)
 	txn, _ := builder.BuildWithMocks()
 
-	require.NoError(t, action_Delegated(ctx, txn, &DelegatedEvent{
+	require.NoError(t, action_DelegationSent(ctx, txn, &DelegatedEvent{
 		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
 		Coordinator: "coord@node1",
 	}))
 
-	firstDelegatedTime := txn.GetFirstDelegatedTime()
-	require.NotNil(t, firstDelegatedTime, "GetFirstDelegatedTime should return a non-nil value after delegation")
-	assert.Equal(t, txn.firstDelegatedTime, firstDelegatedTime, "GetFirstDelegatedTime should return the recorded first-delegation time")
+	lastDelegatedTime := txn.GetLastDelegatedTime()
+	require.NotNil(t, lastDelegatedTime, "GetLastDelegatedTime should return a non-nil value after delegation")
+	assert.Equal(t, txn.lastDelegatedTime, lastDelegatedTime, "GetLastDelegatedTime should return the recorded last-delegation time")
 }
 
 func TestTransaction_Hash_ErrorWhenPrivateTransactionIsNil(t *testing.T) {

--- a/core/go/internal/sequencer/testutil/sent_message_recorder.go
+++ b/core/go/internal/sequencer/testutil/sent_message_recorder.go
@@ -60,6 +60,7 @@ type SentMessageRecorder struct {
 	preDispatchRejectionReason     engineProto.RejectionReason
 	hasSentDelegationRequest       bool
 	delegatedTransactionIDs        []uuid.UUID
+	sentDelegationRequests         []*engineProto.DelegationRequest
 	sentSignResponses              []*engineProto.SignResponse
 	hasSentSignError               bool
 }
@@ -100,6 +101,7 @@ func (r *SentMessageRecorder) Reset(ctx context.Context) {
 	r.hasSentSignError = false
 	r.hasSentDelegationRequest = false
 	r.delegatedTransactionIDs = nil
+	r.sentDelegationRequests = nil
 	// per-tx maps are NOT reset — they accumulate across the full test
 }
 
@@ -379,6 +381,7 @@ func (r *SentMessageRecorder) SendDelegationRequest(ctx context.Context, node st
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	r.hasSentDelegationRequest = true
+	r.sentDelegationRequests = append(r.sentDelegationRequests, msg)
 	for _, del := range msg.Transactions {
 		id, err := uuid.Parse(del.GetId())
 		if err != nil {
@@ -387,6 +390,13 @@ func (r *SentMessageRecorder) SendDelegationRequest(ctx context.Context, node st
 		r.delegatedTransactionIDs = append(r.delegatedTransactionIDs, id)
 	}
 	return nil
+}
+
+// SentDelegationRequests returns every delegation request sent so far, in send order.
+func (r *SentMessageRecorder) SentDelegationRequests() []*engineProto.DelegationRequest {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return append([]*engineProto.DelegationRequest{}, r.sentDelegationRequests...)
 }
 
 func (r *SentMessageRecorder) HasSentDelegationRequest() bool {

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -266,13 +266,13 @@ func testDelegationRequestMsg(coordinatorNode string, contractAddress *pldtypes.
 	}, nil
 }
 
-func testDelegationResponseMsg(delegatingNodeName, delegationId string, transactionIDs []string, contractAddress *pldtypes.EthAddress, errors []int64) *engineProto.DelegationResponse {
+func testDelegationResponseMsg(delegatingNodeName, delegationId string, transactionIDs []string, contractAddress *pldtypes.EthAddress, results []engineProto.DelegationAcknowledgementResult) *engineProto.DelegationResponse {
 	return &engineProto.DelegationResponse{
 		DelegationId:    delegationId,
 		TransactionIds:  transactionIDs,
 		DelegateNodeId:  delegatingNodeName,
 		ContractAddress: contractAddress.String(),
-		Errors:          errors,
+		Results:         results,
 	}
 }
 
@@ -873,7 +873,7 @@ func TestSendDelegationResponse_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, transactionIDs, contractAddress, []int64{0}))
+	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, transactionIDs, contractAddress, []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED}))
 	require.NoError(t, err)
 }
 
@@ -897,7 +897,7 @@ func TestSendDelegationResponse_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, []string{transactionID}, contractAddress, []int64{0}))
+	err := tw.SendDelegationResponse(ctx, delegatingNodeName, testDelegationResponseMsg(delegatingNodeName, delegationId, []string{transactionID}, contractAddress, []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED}))
 	require.NoError(t, err)
 }
 

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -471,6 +471,7 @@ func (sMgr *sequencerManager) handleDelegationRequest(ctx context.Context, messa
 	transactionDelegatedEvent.FromNode = message.FromNode
 	transactionDelegatedEvent.OriginatorsBlockHeight = uint64(delegationRequest.OriginatorBlockHeight)
 	transactionDelegatedEvent.DelegationID = delegationRequest.DelegationId
+	transactionDelegatedEvent.LastDelegatedTransactionID = delegationRequest.LastDelegatedTransactionId
 	transactionDelegatedEvent.EventTime = time.Now()
 
 	contractAddress := sMgr.parseContractAddressString(ctx, delegationRequest.ContractAddress, message)
@@ -532,29 +533,20 @@ func (sMgr *sequencerManager) handleDelegationResponse(ctx context.Context, mess
 		return
 	}
 
-	rejectedDelegationIDs := make([]string, 0, len(delegationRequestAcknowledgment.TransactionIds))
-	rejectedDelegationMaxInFlight := 0
-	rejectedDelegationCoordinatorError := 0
-
-	// Currently we don't act on specific errors, but we have the option in the future to treat a specific delegate rejection
-	// differently to just relying on re-delegate on the next heartbeat/timeout. For now log explicit rejections from the coordinator.
-	for i, errorCode := range delegationRequestAcknowledgment.Errors {
-		switch coordinator.DelegationAcknowledgementError(errorCode) {
-		case coordinator.DelegationAcknowledgementError_MaxInflightTransactions:
-			rejectedDelegationIDs = append(rejectedDelegationIDs, delegationRequestAcknowledgment.TransactionIds[i])
-			rejectedDelegationMaxInFlight++
-		case coordinator.DelegationAcknowledgementError_CoordinatorError, coordinator.DelegationAcknowledgementError_PreviousTransactionError:
-			rejectedDelegationCoordinatorError++
-		}
+	// Get rather than load the sequencer - it must already have the originator in memory to process the delegation response
+	seq := sMgr.GetSequencer(ctx, *contractAddress)
+	if seq == nil {
+		log.L(ctx).Warnf("sequencer for contract %s is not loaded: delegation response cannot be processed unless already in memory", contractAddress)
+		return
 	}
 
-	if rejectedDelegationMaxInFlight > 0 {
-		log.L(ctx).Debugf("coordinator rejected %d delegations with max in flight limit", rejectedDelegationMaxInFlight)
-		log.L(ctx).Tracef("rejected delegations: %+v", rejectedDelegationIDs)
-	}
-	if rejectedDelegationCoordinatorError > 0 {
-		log.L(ctx).Warnf("coordinator error processing %d delegations", rejectedDelegationCoordinatorError)
-	}
+	acknowledgedEvent := &originator.DelegationRequestAcknowledgedEvent{}
+	acknowledgedEvent.FromNode = message.FromNode
+	acknowledgedEvent.DelegationID = delegationRequestAcknowledgment.DelegationId
+	acknowledgedEvent.TransactionIDs = delegationRequestAcknowledgment.TransactionIds
+	acknowledgedEvent.Results = delegationRequestAcknowledgment.Results
+	acknowledgedEvent.EventTime = time.Now()
+	seq.GetOriginator().QueueEvent(ctx, acknowledgedEvent)
 }
 
 func (sMgr *sequencerManager) handleDelegationRejection(ctx context.Context, message *components.ReceivedMessage) {

--- a/core/go/internal/sequencer/transport_client_test.go
+++ b/core/go/internal/sequencer/transport_client_test.go
@@ -885,28 +885,6 @@ func TestHandlePreDispatchResponse_Success(t *testing.T) {
 	mocks.coordinator.AssertExpectations(t)
 }
 
-func TestHandleDelegationResponse_Success(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-
-	txID := uuid.New()
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		TransactionIds: []string{txID.String()},
-	}
-	payload, _ := proto.Marshal(delegationRequestAcknowledgment)
-
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationResponse,
-		Payload:     payload,
-	}
-
-	// Should not panic - this handler just logs
-	sm.handleDelegationResponse(ctx, message)
-}
-
 func TestHandleDelegationResponse_UnmarshalError(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
@@ -920,109 +898,6 @@ func TestHandleDelegationResponse_UnmarshalError(t *testing.T) {
 	}
 
 	// Should not panic
-	sm.handleDelegationResponse(ctx, message)
-}
-
-func TestHandleDelegationResponse_MaxInFlightRejection(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-
-	txID1 := uuid.New().String()
-	txID2 := uuid.New().String()
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		TransactionIds: []string{txID1, txID2},
-		Errors: []int64{
-			int64(coordinator.DelegationAcknowledgementError_MaxInflightTransactions),
-			int64(coordinator.DelegationAcknowledgementError_MaxInflightTransactions),
-		},
-	}
-	payload, err := proto.Marshal(delegationRequestAcknowledgment)
-	require.NoError(t, err)
-
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationResponse,
-		Payload:     payload,
-	}
-
-	// Should not panic; handler logs max in flight rejections
-	sm.handleDelegationResponse(ctx, message)
-}
-
-func TestHandleDelegationResponse_UnknownError(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-
-	txID := uuid.New().String()
-	unknownErrorCode := int64(99)
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		TransactionIds: []string{txID},
-		Errors:         []int64{unknownErrorCode},
-	}
-	payload, err := proto.Marshal(delegationRequestAcknowledgment)
-	require.NoError(t, err)
-
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationResponse,
-		Payload:     payload,
-	}
-
-	sm.handleDelegationResponse(ctx, message)
-}
-
-func TestHandleDelegationResponse_MixedErrors(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-
-	txIDAccepted := uuid.New().String()
-	txIDMaxInFlight := uuid.New().String()
-	txIDUnknown := uuid.New().String()
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		TransactionIds: []string{txIDAccepted, txIDMaxInFlight, txIDUnknown},
-		Errors: []int64{
-			int64(coordinator.DelegationAcknowledgementError_None),
-			int64(coordinator.DelegationAcknowledgementError_MaxInflightTransactions),
-			42, // unknown error code
-		},
-	}
-	payload, err := proto.Marshal(delegationRequestAcknowledgment)
-	require.NoError(t, err)
-
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationResponse,
-		Payload:     payload,
-	}
-
-	sm.handleDelegationResponse(ctx, message)
-}
-
-func TestHandleDelegationResponse_Empty(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-
-	delegationRequestAcknowledgment := &engineProto.DelegationResponse{
-		TransactionIds: []string{},
-		Errors:         []int64{},
-	}
-	payload, err := proto.Marshal(delegationRequestAcknowledgment)
-	require.NoError(t, err)
-
-	message := &components.ReceivedMessage{
-		FromNode:    "test-node",
-		MessageID:   uuid.New(),
-		MessageType: transport.MessageType_DelegationResponse,
-		Payload:     payload,
-	}
-
 	sm.handleDelegationResponse(ctx, message)
 }
 
@@ -1782,6 +1657,46 @@ func TestHandleDelegationRejection_Success(t *testing.T) {
 	<-done
 }
 
+func TestHandleDelegationResponse_Success(t *testing.T) {
+	ctx := context.Background()
+	mocks := newTransportClientTestMocks(t)
+	sm := newSequencerManagerForTransportClientTesting(t, mocks)
+	contractAddr := pldtypes.RandAddress()
+
+	transactionIDs := []string{uuid.New().String(), uuid.New().String()}
+	response := &engineProto.DelegationResponse{
+		ContractAddress: contractAddr.String(),
+		DelegationId:    "delegation-1",
+		TransactionIds:  transactionIDs,
+		Results:         []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED, engineProto.DelegationAcknowledgementResult_MAX_INFLIGHT_TRANSACTIONS},
+	}
+	payload, err := proto.Marshal(response)
+	require.NoError(t, err)
+
+	seq := newSequencerForTransportClientTesting(contractAddr, mocks)
+	sm.sequencers[contractAddr.String()] = seq
+	done := make(chan struct{})
+	mocks.originator.EXPECT().QueueEvent(ctx, mock.MatchedBy(func(e interface{}) bool {
+		acknowledgedEvent, ok := e.(*originator.DelegationRequestAcknowledgedEvent)
+		if !ok {
+			return false
+		}
+		ok = acknowledgedEvent.FromNode == "coordinator-node" &&
+			acknowledgedEvent.DelegationID == "delegation-1" &&
+			assert.ObjectsAreEqual(transactionIDs, acknowledgedEvent.TransactionIDs) &&
+			assert.ObjectsAreEqual([]engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_DELEGATION_ACCEPTED, engineProto.DelegationAcknowledgementResult_MAX_INFLIGHT_TRANSACTIONS}, acknowledgedEvent.Results)
+		if ok {
+			close(done)
+		}
+		return ok
+	})).Once()
+
+	sm.handleDelegationResponse(ctx, &components.ReceivedMessage{
+		FromNode: "coordinator-node", MessageType: transport.MessageType_DelegationResponse, Payload: payload,
+	})
+	<-done
+}
+
 func TestHandleHandoverRequest_Success(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
@@ -1921,28 +1836,6 @@ func TestHandleCoordinatorHeartbeatNotification_UnparseableSnapshot(t *testing.T
 	payload, _ := proto.Marshal(heartbeatNotification)
 	sm.handleCoordinatorHeartbeatNotification(ctx, &components.ReceivedMessage{
 		FromNode: "coordinator-node", MessageType: transport.MessageType_CoordinatorHeartbeatNotification, Payload: payload,
-	})
-}
-
-func TestHandleDelegationResponse_CoordinatorErrors(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	contractAddr := pldtypes.RandAddress()
-
-	delegationResponse := &engineProto.DelegationResponse{
-		ContractAddress: contractAddr.String(),
-		TransactionIds:  []string{uuid.New().String(), uuid.New().String()},
-		Errors: []int64{
-			int64(coordinator.DelegationAcknowledgementError_CoordinatorError),
-			int64(coordinator.DelegationAcknowledgementError_PreviousTransactionError),
-		},
-	}
-	payload, err := proto.Marshal(delegationResponse)
-	require.NoError(t, err)
-
-	sm.handleDelegationResponse(ctx, &components.ReceivedMessage{
-		FromNode: "test-node", MessageType: transport.MessageType_DelegationResponse, Payload: payload,
 	})
 }
 
@@ -2441,7 +2334,8 @@ func TestHandleDelegationRequest_NilTransactionSpecification(t *testing.T) {
 	})
 }
 
-func TestHandleDelegationResponse_MaxInFlightWithContractAddress(t *testing.T) {
+// A delegation response for a contract whose sequencer is not loaded is dropped.
+func TestHandleDelegationResponse_SequencerNotLoaded(t *testing.T) {
 	ctx := context.Background()
 	mocks := newTransportClientTestMocks(t)
 	sm := newSequencerManagerForTransportClientTesting(t, mocks)
@@ -2449,20 +2343,7 @@ func TestHandleDelegationResponse_MaxInFlightWithContractAddress(t *testing.T) {
 	payload, _ := proto.Marshal(&engineProto.DelegationResponse{
 		ContractAddress: contractAddr.String(),
 		TransactionIds:  []string{uuid.New().String()},
-		Errors:          []int64{int64(coordinator.DelegationAcknowledgementError_MaxInflightTransactions)},
-	})
-	sm.handleDelegationResponse(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_DelegationResponse, Payload: payload})
-}
-
-func TestHandleDelegationResponse_CoordinatorErrorWithContractAddress(t *testing.T) {
-	ctx := context.Background()
-	mocks := newTransportClientTestMocks(t)
-	sm := newSequencerManagerForTransportClientTesting(t, mocks)
-	contractAddr := pldtypes.RandAddress()
-	payload, _ := proto.Marshal(&engineProto.DelegationResponse{
-		ContractAddress: contractAddr.String(),
-		TransactionIds:  []string{uuid.New().String()},
-		Errors:          []int64{int64(coordinator.DelegationAcknowledgementError_CoordinatorError)},
+		Results:         []engineProto.DelegationAcknowledgementResult{engineProto.DelegationAcknowledgementResult_MAX_INFLIGHT_TRANSACTIONS},
 	})
 	sm.handleDelegationResponse(ctx, &components.ReceivedMessage{MessageType: transport.MessageType_DelegationResponse, Payload: payload})
 }

--- a/core/go/pkg/proto/engine.proto
+++ b/core/go/pkg/proto/engine.proto
@@ -114,6 +114,7 @@ message DelegationRequest {
     int64 originator_block_height = 3; // the originator's block height upon which this delegation was calculated
     repeated PrivateTransactionDelegation transactions = 4; // typed delegation descriptors, one per delegated transaction
     string contract_address = 5; // hex EthAddress — all transactions in this request share the same contract
+    string last_delegated_transaction_id = 6; // ID of the most recent transaction this originator has delegated and had acknowledged
 }
 
 // PrivateTransactionDelegation is the minimal wire descriptor sent when an originator
@@ -125,9 +126,17 @@ message PrivateTransactionDelegation {
     io.kaleido.paladin.toolkit.TransactionPreAssembly pre_assembly = 4;
 }
 
+enum DelegationAcknowledgementResult {
+    DELEGATION_ACCEPTED = 0;                    // the transaction was accepted; no error
+    MAX_INFLIGHT_TRANSACTIONS = 1;              // coordinator is at its in-flight limit and cannot accept the transaction
+    COORDINATOR_ERROR = 2;                      // coordinator failed to handle the delegated transaction
+    PREVIOUS_TRANSACTION_ERROR = 3;             // an earlier transaction in the same request was not accepted, so this one is withheld to preserve FIFO ordering
+    UNKNOWN_LAST_DELEGATED_TRANSACTION = 4;     // coordinator does not hold the request's last_delegated_transaction_id and so cannot guarantee FIFO ordering for the request
+}
+
 message DelegationResponse {
     repeated string transaction_ids = 1;
-    repeated int64 errors = 2; // Every delegate could have a different result. Allow optional enum error per transaction
+    repeated DelegationAcknowledgementResult results = 2; // per-transaction result, parallel to transaction_ids
     string delegate_node_id = 3;
     string delegation_id = 4; // this is used to correlate the acknowledgement back to the delegation. unlike the transport message id / correlation id, this is not unique across retries
     string contract_address = 5;


### PR DESCRIPTION
Previously an originator resent every `Pending` and every `Delegated` transaction on each partial delegation request to preserve FIFO ordering until first assembly with the coordinator. This change aims to minimise the number of transactions that are redelegated when already accepted by the coordinator by using the delegation acknowledgements the coordinator already sent. Instead of sending all unassembled transactions in order, FIFO ordering is instead preserved with a single reference to the last delegated transaction.

#### Pending and Delegated now reflect the coordinator's response

The originator now processes the `DelegationResponse` it always sent but previously only logged. This changes what the two states mean:

- **`Pending`** — a delegation request has been sent, but the coordinator has not yet acknowledged holding the transaction.
- **`Delegated`** — the current coordinator has acknowledged the transaction.

Sending a delegation request no longer moves a transaction to `Delegated`; it records the delegate and stays `Pending` until the acknowledgement arrives. Re-delegating to a **different** coordinator drops the transaction back to `Pending` (its old acknowledgement no longer holds) and it re-enters `Delegated` only when the new coordinator acknowledges — symmetric with a first-time delegation. Re-delegating to the **same** coordinator never demotes an already-acknowledged transaction.

#### FIFO preserved with a last-delegated reference, not a resend

A partial delegation now carries only `Pending` transactions plus `last_delegated_transaction_id` — the ID of the most recent already-acknowledged transaction. The coordinator chains the new batch after that transaction, giving the same FIFO ordering the resend used to provide, without the acknowledged transactions on the wire. If the coordinator no longer knows that transaction, it rejects the request and the originator falls back to a full delegation.

#### Retries for lost requests and acknowledgements

Because a transaction now waits in `Pending` for a response, a lost request or lost acknowledgement is covered by retries:

- Each delegation request is tracked in-flight under a delegation ID with a one-shot timer set to the request timeout. If the response arrives, the timer is cancelled. If it fires, the still-outstanding transactions are re-delegated from live state under a fresh ID.
- A response that acknowledges only some transactions triggers a follow-up partial covering exactly the un-acknowledged remainder (which, after the acks are applied, is precisely the remaining `Pending` set).