### PR TITLE
avoid state query anti join

### DIFF
--- a/core/go/db/migrations/postgres/000037_states_availability_flags.down.sql
+++ b/core/go/db/migrations/postgres/000037_states_availability_flags.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS states_available;
+ALTER TABLE states DROP COLUMN "confirmed";
+ALTER TABLE states DROP COLUMN "spent";
+
+COMMIT;

--- a/core/go/db/migrations/postgres/000037_states_availability_flags.up.sql
+++ b/core/go/db/migrations/postgres/000037_states_availability_flags.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- Denormalize spent-ness and confirmed-ness onto states so the "available" query can
+-- seek a partial index instead of anti-joining the ever-growing state_spend_records.
+ALTER TABLE states ADD COLUMN "spent"     BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE states ADD COLUMN "confirmed" BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- One-time backfill from the authoritative record tables.
+UPDATE states s SET "confirmed" = TRUE
+  FROM state_confirm_records c
+ WHERE c.domain_name = s.domain_name AND c.state = s.id;
+
+UPDATE states s SET "spent" = TRUE
+  FROM state_spend_records sp
+ WHERE sp.domain_name = s.domain_name AND sp.state = s.id;
+
+-- The access path the "available" query seeks: only available rows, created-ordered,
+-- scoped the same way as states_by_domain. A row enters on confirm and leaves on spend.
+CREATE INDEX states_available
+  ON states ("domain_name", "schema", "contract_address", "created")
+  WHERE "confirmed" AND NOT "spent";
+
+COMMIT;

--- a/core/go/db/migrations/sqlite/000037_states_availability_flags.down.sql
+++ b/core/go/db/migrations/sqlite/000037_states_availability_flags.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS states_available;
+ALTER TABLE states DROP COLUMN "confirmed";
+ALTER TABLE states DROP COLUMN "spent";

--- a/core/go/db/migrations/sqlite/000037_states_availability_flags.up.sql
+++ b/core/go/db/migrations/sqlite/000037_states_availability_flags.up.sql
@@ -1,0 +1,17 @@
+-- Denormalize spent-ness and confirmed-ness onto states so the "available" query can
+-- seek a partial index instead of anti-joining the ever-growing state_spend_records.
+ALTER TABLE states ADD COLUMN "spent"     BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE states ADD COLUMN "confirmed" BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- One-time backfill from the authoritative record tables.
+UPDATE states SET "confirmed" = TRUE
+ WHERE ("domain_name", "id") IN (SELECT "domain_name", "state" FROM state_confirm_records);
+
+UPDATE states SET "spent" = TRUE
+ WHERE ("domain_name", "id") IN (SELECT "domain_name", "state" FROM state_spend_records);
+
+-- The access path the "available" query seeks: only available rows, created-ordered,
+-- scoped the same way as states_by_domain. A row enters on confirm and leaves on spend.
+CREATE INDEX states_available
+  ON states ("domain_name", "schema", "contract_address", "created")
+  WHERE "confirmed" AND NOT "spent";

--- a/core/go/internal/statemgr/domain_state_writer_test.go
+++ b/core/go/internal/statemgr/domain_state_writer_test.go
@@ -515,6 +515,8 @@ func TestDSWFlushErrorCapture(t *testing.T) {
 	db.ExpectBegin()
 	db.ExpectExec("INSERT.*states").WillReturnResult(driver.ResultNoRows)
 	db.ExpectExec("INSERT.*state_labels").WillReturnResult(driver.ResultNoRows)
+	db.ExpectExec("UPDATE.*states").WillReturnResult(driver.ResultNoRows)
+	db.ExpectExec("UPDATE.*states").WillReturnResult(driver.ResultNoRows)
 	db.ExpectExec("DELETE.*pending_private_state_data").WillReturnResult(driver.ResultNoRows)
 	db.ExpectCommit()
 	err = ss.p.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) error {

--- a/core/go/internal/statemgr/state.go
+++ b/core/go/internal/statemgr/state.go
@@ -192,14 +192,19 @@ func (ss *stateManager) writeStates(ctx context.Context, dbTX persistence.DBTX, 
 			Error
 	}
 
-	// Update the completion index for any opted-in domain transactions that were
-	// waiting for one of the just-written states
+	// Reconcile availability flags for the just-written states, then update the
+	// completion index. A confirm/spend record may have been written before the state row
+	// existed; setStateAvailableFromSpendConfirmRecords sets the flags now from the
+	// authoritative record tables.
 	if err == nil && len(states) > 0 {
-		arrivedIDs := make([]pldtypes.HexBytes, len(states))
-		for i, s := range states {
-			arrivedIDs[i] = s.ID
+		err = ss.setStateAvailableFromSpendConfirmRecords(ctx, dbTX, states)
+		if err == nil {
+			arrivedIDs := make([]pldtypes.HexBytes, len(states))
+			for i, s := range states {
+				arrivedIDs[i] = s.ID
+			}
+			err = ss.updatePendingPrivateStateData(ctx, dbTX, arrivedIDs)
 		}
-		err = ss.updatePendingPrivateStateData(ctx, dbTX, arrivedIDs)
 	}
 	return err
 }
@@ -329,11 +334,23 @@ func (ss *stateManager) findStates(
 	if options.StatusQualifier == "" {
 		options.StatusQualifier = pldapi.StateStatusAll
 	}
-	whereClause, isPlainDB := whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Spent")
+	// Available is served from the maintained confirmed/spent flags and the states_available
+	// partial index, so it needs neither the Confirmed/Spent joins nor whereClauseForQual. Every
+	// other plain-DB qualifier still expresses status via those joins.
+	var whereClause *gorm.DB
+	needsStatusJoins, isPlainDB := true, true
+	if options.StatusQualifier == pldapi.StateStatusAvailable {
+		whereClause = dbTX.DB(ctx).Where(`"states"."confirmed" AND NOT "states"."spent"`)
+		needsStatusJoins = false
+	} else {
+		whereClause, isPlainDB = whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Spent")
+	}
 	if isPlainDB {
 		return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
-			q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
-				Joins("Spent", dbTX.DB(ctx).Select("transaction"))
+			if needsStatusJoins {
+				q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
+					Joins("Spent", dbTX.DB(ctx).Select("transaction"))
+			}
 
 			if len(options.ExcludedIDs) > 0 {
 				q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)

--- a/core/go/internal/statemgr/state_availability.go
+++ b/core/go/internal/statemgr/state_availability.go
@@ -1,0 +1,131 @@
+// Copyright contributors to Paladin, an LFDT project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statemgr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+)
+
+// The confirmed/spent columns on the states table are denormalized from state_confirm_records/state_spend_records
+// so the "available" query can use the states_available partial index instead of anti-joining the
+// ever-growing record tables.
+//
+// Private state data are distibuted off chain via reliable messaging, whereas confirm/spend records
+// are created as result of indexing the base ledger. This means that:
+//
+// - confirm/spend records may arrive before the private state data
+// - confirm/spend records may arrive after the private state data
+// - confirm/spend records may arrive for states for which this node will never receive the private state data
+// - confirm/spend records may arrive concurrently with the private state data (different goroutines are responsible
+//   for persisting to each of the tables)
+//
+// As a result, to ensure consistency we
+// - check for confirm/spend records when persisting a newly received private state and set the
+//   confirmed/spent columns accordingly
+// - check for matching private states when indexing a confirm/spend record and again set the
+//   confirmed/spent columns accordingly
+// - use a named DB lock to synchronise between goroutines writing private state data and confirm/spend locks
+//
+// Auto vacuum will keep the size of partial index small over time, compared to the full set of spent states.
+// There is a cost to auto vacuum but this should be outweighed by the benefit of avoiding the full antijoin.
+// The partial index should stay proportional to usage. It will only grow if a large number of states are
+// confirmed but never spent.
+
+const (
+	availabilityFlagConfirmed = "confirmed"
+	availabilityFlagSpent     = "spent"
+)
+
+const availabilityFlagLock = "state_availability_flags"
+
+func setStatesConfirmed(ctx context.Context, dbTX persistence.DBTX, confirms []*pldapi.StateConfirmRecord) error {
+	idsByDomain := make(map[string][]pldtypes.HexBytes, 1)
+	for _, c := range confirms {
+		idsByDomain[c.DomainName] = append(idsByDomain[c.DomainName], c.State)
+	}
+	for domainName, ids := range idsByDomain {
+		if err := dbTX.DB(ctx).
+			Table("states").
+			Where("domain_name = ?", domainName).
+			Where("id IN ?", ids).
+			Where(`"confirmed" = FALSE`).
+			Update(availabilityFlagConfirmed, true).
+			Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setStatesSpent(ctx context.Context, dbTX persistence.DBTX, spends []*pldapi.StateSpendRecord) error {
+	idsByDomain := make(map[string][]pldtypes.HexBytes, 1)
+	for _, s := range spends {
+		idsByDomain[s.DomainName] = append(idsByDomain[s.DomainName], s.State)
+	}
+	for domainName, ids := range idsByDomain {
+		if err := dbTX.DB(ctx).
+			Table("states").
+			Where("domain_name = ?", domainName).
+			Where("id IN ?", ids).
+			Where(`"spent" = FALSE`).
+			Update(availabilityFlagSpent, true).
+			Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ss *stateManager) setStateAvailableFromSpendConfirmRecords(ctx context.Context, dbTX persistence.DBTX, states []*pldapi.State) error {
+	if len(states) == 0 {
+		return nil
+	}
+	if err := ss.p.TakeNamedLock(ctx, dbTX, availabilityFlagLock); err != nil {
+		return err
+	}
+
+	idsByDomain := make(map[string][]pldtypes.HexBytes, 1)
+	for _, s := range states {
+		idsByDomain[s.DomainName] = append(idsByDomain[s.DomainName], s.ID)
+	}
+
+	for domainName, ids := range idsByDomain {
+		if err := reconcileAvailabilityFlag(ctx, dbTX, domainName, ids, availabilityFlagConfirmed, "state_confirm_records"); err != nil {
+			return err
+		}
+		if err := reconcileAvailabilityFlag(ctx, dbTX, domainName, ids, availabilityFlagSpent, "state_spend_records"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func reconcileAvailabilityFlag(ctx context.Context, dbTX persistence.DBTX, domainName string, ids []pldtypes.HexBytes, column, recordTable string) error {
+	return dbTX.DB(ctx).
+		Table("states").
+		Where("domain_name = ?", domainName).
+		Where("id IN ?", ids).
+		Where(fmt.Sprintf(`"%s" = FALSE`, column)).
+		Where(fmt.Sprintf(`EXISTS (SELECT 1 FROM %s r WHERE r.domain_name = states.domain_name AND r.state = states.id)`, recordTable)).
+		Update(column, true).
+		Error
+}

--- a/core/go/internal/statemgr/state_availability_test.go
+++ b/core/go/internal/statemgr/state_availability_test.go
@@ -1,0 +1,118 @@
+// Copyright contributors to Paladin, an LFDT project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statemgr
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"testing"
+
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetStatesConfirmedUpdateFail(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	db.ExpectExec("UPDATE.*states").WillReturnError(fmt.Errorf("pop"))
+
+	err := setStatesConfirmed(ctx, ss.p.NOTX(), []*pldapi.StateConfirmRecord{
+		{DomainName: "domain1", State: pldtypes.HexBytes(pldtypes.RandBytes(32))},
+	})
+	assert.Regexp(t, "pop", err)
+}
+
+func TestSetStatesSpentUpdateFail(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	db.ExpectExec("UPDATE.*states").WillReturnError(fmt.Errorf("pop"))
+
+	err := setStatesSpent(ctx, ss.p.NOTX(), []*pldapi.StateSpendRecord{
+		{DomainName: "domain1", State: pldtypes.HexBytes(pldtypes.RandBytes(32))},
+	})
+	assert.Regexp(t, "pop", err)
+}
+
+func TestSetStateAvailableFromSpendConfirmRecordsNoStates(t *testing.T) {
+	ctx, ss, _, _, done := newDBMockStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p}
+	ss.p = wrapper
+
+	err := ss.setStateAvailableFromSpendConfirmRecords(ctx, ss.p.NOTX(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, wrapper.lockCalls)
+}
+
+func TestSetStateAvailableFromSpendConfirmRecordsLockFail(t *testing.T) {
+	ctx, ss, _, _, done := newDBMockStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p, lockErr: fmt.Errorf("lock error")}
+	ss.p = wrapper
+
+	err := ss.setStateAvailableFromSpendConfirmRecords(ctx, ss.p.NOTX(), []*pldapi.State{
+		{StateBase: pldapi.StateBase{DomainName: "domain1", ID: pldtypes.HexBytes(pldtypes.RandBytes(32))}},
+	})
+	require.ErrorContains(t, err, "lock error")
+	assert.Equal(t, 1, wrapper.lockCalls)
+}
+
+func TestSetStateAvailableFromSpendConfirmRecordsConfirmedUpdateFail(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	db.ExpectExec("UPDATE.*states").WillReturnError(fmt.Errorf("pop"))
+
+	err := ss.setStateAvailableFromSpendConfirmRecords(ctx, ss.p.NOTX(), []*pldapi.State{
+		{StateBase: pldapi.StateBase{DomainName: "domain1", ID: pldtypes.HexBytes(pldtypes.RandBytes(32))}},
+	})
+	assert.Regexp(t, "pop", err)
+}
+
+func TestSetStateAvailableFromSpendConfirmRecordsSpentUpdateFail(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	db.ExpectExec("UPDATE.*states").WillReturnResult(driver.ResultNoRows) // confirmed flag
+	db.ExpectExec("UPDATE.*states").WillReturnError(fmt.Errorf("pop"))    // spent flag
+
+	err := ss.setStateAvailableFromSpendConfirmRecords(ctx, ss.p.NOTX(), []*pldapi.State{
+		{StateBase: pldapi.StateBase{DomainName: "domain1", ID: pldtypes.HexBytes(pldtypes.RandBytes(32))}},
+	})
+	assert.Regexp(t, "pop", err)
+}
+
+func TestWriteStateFinalizationsLockFail(t *testing.T) {
+	ctx, ss, _, _, done := newDBMockStateManager(t)
+	defer done()
+
+	wrapper := &lockControlledPersistence{Persistence: ss.p, lockErr: fmt.Errorf("lock error")}
+	ss.p = wrapper
+
+	err := ss.WriteStateFinalizations(ctx, ss.p.NOTX(),
+		[]*pldapi.StateSpendRecord{{DomainName: "domain1", State: pldtypes.HexBytes(pldtypes.RandBytes(32)), Transaction: uuid.New()}},
+		nil, nil, nil)
+	require.ErrorContains(t, err, "lock error")
+	assert.Equal(t, 1, wrapper.lockCalls)
+}

--- a/core/go/internal/statemgr/state_status_test.go
+++ b/core/go/internal/statemgr/state_status_test.go
@@ -335,3 +335,69 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), pldapi.StateStatusAvailable)
 
 }
+
+// TestAvailabilityFlagsReconcileOnLateArrival covers the received-state ordering where the
+// confirm/spend records are indexed from the chain before the private data arrives. The
+// WriteStateFinalizations flag UPDATE matches no row at that point; the flags must be reconciled
+// from the record tables when writeStates later inserts the row, so availability matches the
+// record tables regardless of arrival order.
+func TestAvailabilityFlagsReconcileOnLateArrival(t *testing.T) {
+	ctx, ss, m, done := newDBTestStateManager(t)
+	defer done()
+
+	_ = mockDomain(t, m, "domain1", false)
+	mockStateCallback(m)
+
+	schema, err := newABISchema(ctx, "domain1", testABIParam(t, widgetABI))
+	require.NoError(t, err)
+	err = ss.persistSchemas(ctx, ss.p.NOTX(), []*pldapi.Schema{schema.Schema})
+	require.NoError(t, err)
+	schemaID := schema.ID()
+
+	contractAddress := pldtypes.RandAddress()
+
+	confirmWidget := genWidget(t, schemaID, `{"size": 1, "color": "red", "price": 10}`)
+	spentWidget := genWidget(t, schemaID, `{"size": 2, "color": "blue", "price": 20}`)
+
+	// Compute the IDs the sending node would, so the records can be written before the rows exist.
+	confirmState, err := schema.ProcessState(ctx, contractAddress, pldtypes.RawJSON(confirmWidget.StateDataJson), nil, false)
+	require.NoError(t, err)
+	spentState, err := schema.ProcessState(ctx, contractAddress, pldtypes.RawJSON(spentWidget.StateDataJson), nil, false)
+	require.NoError(t, err)
+	confirmID := confirmState.ID
+	spentID := spentState.ID
+
+	// Records land first — no state rows exist yet, so the WriteStateFinalizations UPDATE is a no-op.
+	err = ss.WriteStateFinalizations(ctx, ss.p.NOTX(),
+		[]*pldapi.StateSpendRecord{{DomainName: "domain1", State: spentID, Transaction: uuid.New()}},
+		nil,
+		[]*pldapi.StateConfirmRecord{
+			{DomainName: "domain1", State: confirmID, Transaction: uuid.New()},
+			{DomainName: "domain1", State: spentID, Transaction: uuid.New()},
+		}, nil)
+	require.NoError(t, err)
+
+	findAvailable := func() []*pldapi.State {
+		s, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", schemaID,
+			query.NewQueryBuilder().Query(),
+			&components.StateQueryOptions{StatusQualifier: pldapi.StateStatusAvailable})
+		require.NoError(t, err)
+		return s
+	}
+	require.Empty(t, findAvailable()) // no rows yet, nothing available
+
+	// Private data arrives — setStateAvailableFromSpendConfirmRecords sets the flags from the record tables.
+	err = ss.p.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) error {
+		_, err := ss.WriteReceivedStates(ctx, dbTX, "domain1", []*components.StateUpsertOutsideContext{
+			{ContractAddress: contractAddress, SchemaID: schemaID, Data: pldtypes.RawJSON(confirmWidget.StateDataJson)},
+			{ContractAddress: contractAddress, SchemaID: schemaID, Data: pldtypes.RawJSON(spentWidget.StateDataJson)},
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	// confirmID: confirmed and not spent -> available. spentID: confirmed but spent -> not available.
+	avail := findAvailable()
+	require.Len(t, avail, 1)
+	assert.Equal(t, confirmID, avail[0].ID)
+}

--- a/core/go/internal/statemgr/statestore.go
+++ b/core/go/internal/statemgr/statestore.go
@@ -138,6 +138,17 @@ func (ss *stateManager) Stop() {
 // become fully unavailable.
 func (ss *stateManager) WriteStateFinalizations(ctx context.Context, dbTX persistence.DBTX, spends []*pldapi.StateSpendRecord, reads []*pldapi.StateReadRecord, confirms []*pldapi.StateConfirmRecord, infoRecords []*pldapi.StateInfoRecord) (err error) {
 	ctx = log.WithComponent(ctx, "statemanager")
+	// The spent/confirmed flags on states are denormalized from these records via setStatesSpent/
+	// setStatesConfirmed. A record can be written before its state row exists (private data not yet
+	// received), in which case the flag UPDATE matches nothing and setStateAvailableFromSpendConfirmRecords sets it
+	// on arrival. availabilityFlagLock serializes this flag maintenance against that arrival-path
+	// reconciliation, so whichever transaction commits second sees the other's rows/records and the
+	// flag ends up set exactly once.
+	if len(spends) > 0 || len(confirms) > 0 {
+		if err = ss.p.TakeNamedLock(ctx, dbTX, availabilityFlagLock); err != nil {
+			return err
+		}
+	}
 	if len(spends) > 0 {
 		log.L(ctx).Debugf("Finalizing spends: %s", logStateSpendRecords(spends))
 		err = dbTX.DB(ctx).
@@ -145,6 +156,9 @@ func (ss *stateManager) WriteStateFinalizations(ctx context.Context, dbTX persis
 			Clauses(clause.OnConflict{DoNothing: true}).
 			Create(spends).
 			Error
+		if err == nil {
+			err = setStatesSpent(ctx, dbTX, spends)
+		}
 	}
 	if err == nil && len(reads) > 0 {
 		log.L(ctx).Debugf("Finalizing reads: %s", logStateReadRecords(reads))
@@ -161,6 +175,9 @@ func (ss *stateManager) WriteStateFinalizations(ctx context.Context, dbTX persis
 			Clauses(clause.OnConflict{DoNothing: true}).
 			Create(confirms).
 			Error
+		if err == nil {
+			err = setStatesConfirmed(ctx, dbTX, confirms)
+		}
 	}
 	if err == nil && len(infoRecords) > 0 {
 		log.L(ctx).Debugf("Finalizing info: %s", logStateInfoRecords(infoRecords))


### PR DESCRIPTION
Adds `confirmed` and `spent` boolean columns to the `states` table, with a partial index on states which are confirmed but not spent (i.e. available) as an query optimisation. Available states are queried at assembly time, where DB query performance is critical. The previous approach of establishing which states are available by performing an anti-join over all confirmed/spent state records, causes the query to grow proportional to how many states the node has indexed.

The optimisation only applies to available states since:
- this is the most heavily queried path
- the other state status types are only queried via an external JSONRPC call- it does not make sense to maintain partial indexes to service ad hoc calls
- additionally a spent state partial index would grow indefinitely and proportionally to the anti-join