### PR TITLE
fix(java-sdk): type keymgr_wallets as WalletInfo objects

### DIFF
--- a/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/keymgr/KeyManagerClient.java
+++ b/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/keymgr/KeyManagerClient.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import org.lfdt.paladin.sdk.client.rpc.RpcClient;
 import org.lfdt.paladin.sdk.core.key.KeyMappingAndVerifier;
 import org.lfdt.paladin.sdk.core.key.KeyQueryEntry;
+import org.lfdt.paladin.sdk.core.key.WalletInfo;
 import org.lfdt.paladin.sdk.core.query.QueryJSON;
 import org.lfdt.paladin.sdk.core.types.EthAddress;
 import org.lfdt.paladin.sdk.core.types.HexBytes;
@@ -46,12 +47,12 @@ public final class KeyManagerClient {
   }
 
   /**
-   * Lists the available wallets ({@code keymgr_wallets}).
+   * Lists the wallets configured on the node ({@code keymgr_wallets}).
    *
-   * @return a future completing with the wallet names
+   * @return a future completing with the wallets, each with its name and key selector
    */
-  public CompletableFuture<List<String>> wallets() {
-    return rpc.callRpc(new TypeReference<List<String>>() {}, "keymgr_wallets");
+  public CompletableFuture<List<WalletInfo>> wallets() {
+    return rpc.callRpc(new TypeReference<List<WalletInfo>>() {}, "keymgr_wallets");
   }
 
   /**

--- a/sdk/java/client/src/test/java/org/lfdt/paladin/sdk/client/keymgr/KeyManagerClientTest.java
+++ b/sdk/java/client/src/test/java/org/lfdt/paladin/sdk/client/keymgr/KeyManagerClientTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
@@ -32,11 +33,17 @@ import org.lfdt.paladin.sdk.client.rpc.HttpRpcClient;
 import org.lfdt.paladin.sdk.client.rpc.MockJsonRpcServer;
 import org.lfdt.paladin.sdk.core.key.KeyMappingAndVerifier;
 import org.lfdt.paladin.sdk.core.key.KeyQueryEntry;
+import org.lfdt.paladin.sdk.core.key.WalletInfo;
 import org.lfdt.paladin.sdk.core.query.QueryJSON;
 import org.lfdt.paladin.sdk.core.types.EthAddress;
 import org.lfdt.paladin.sdk.core.types.HexBytes;
 
 class KeyManagerClientTest {
+
+  // The shape a node actually returns from keymgr_wallets — objects, not bare names.
+  private static final String WALLETS_JSON =
+      "[{\"name\":\"signer-1\",\"keySelector\":\".*\",\"keySelectorMustNotMatch\":false},"
+          + "{\"name\":\"hsm-1\",\"keySelector\":\"^hsm\\\\.\",\"keySelectorMustNotMatch\":true}]";
 
   private static final String MAPPING_JSON =
       "{\"identifier\":\"key1\",\"wallet\":\"w1\",\"keyHandle\":\"h1\","
@@ -64,10 +71,15 @@ class KeyManagerClientTest {
   void wallets() throws IOException {
     try (MockJsonRpcServer server =
             new MockJsonRpcServer(
-                (n, req) -> MockJsonRpcServer.Response.of(200, success("[\"w-a\",\"w-b\"]")));
+                (n, req) -> MockJsonRpcServer.Response.of(200, success(WALLETS_JSON)));
         HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
-      final List<String> wallets = new KeyManagerClient(rpc).wallets().join();
-      assertEquals(List.of("w-a", "w-b"), wallets);
+      final List<WalletInfo> wallets = new KeyManagerClient(rpc).wallets().join();
+      assertEquals(2, wallets.size());
+      assertEquals("signer-1", wallets.get(0).name());
+      assertEquals(".*", wallets.get(0).keySelector());
+      assertFalse(wallets.get(0).keySelectorMustNotMatch());
+      assertEquals("hsm-1", wallets.get(1).name());
+      assertTrue(wallets.get(1).keySelectorMustNotMatch());
       final JsonNode req = server.requests().get(0);
       assertEquals("keymgr_wallets", req.get("method").asText());
       // No-arg calls omit the params array (JSON-RPC envelope uses NON_EMPTY inclusion).

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/key/WalletInfo.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/key/WalletInfo.java
@@ -25,6 +25,11 @@ import java.util.Objects;
  * <p>A wallet claims key identifiers by matching them against its key selector, a regular
  * expression. When {@link #keySelectorMustNotMatch()} is set the sense is inverted: the wallet
  * claims identifiers that do <em>not</em> match. Immutable.
+ *
+ * <p>Selectors are evaluated on the node against <a href="https://golang.org/s/re2syntax">RE2
+ * syntax</a>, not {@link java.util.regex}. RE2 has no backreferences ({@code \1}) and no lookahead
+ * or lookbehind ({@code (?=...)}, {@code (?<!...)}), so a selector using them is rejected by the
+ * node even though it would compile as a Java pattern.
  */
 @JsonPropertyOrder({"name", "keySelector", "keySelectorMustNotMatch"})
 public final class WalletInfo {
@@ -54,7 +59,8 @@ public final class WalletInfo {
   }
 
   /**
-   * The regular expression used to select which key identifiers this wallet holds.
+   * The regular expression used to select which key identifiers this wallet holds, in <a
+   * href="https://golang.org/s/re2syntax">RE2 syntax</a>.
    *
    * @return the key selector expression
    */

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/key/WalletInfo.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/key/WalletInfo.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.key;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+
+/**
+ * One wallet configured on the node, as returned by {@code keymgr_wallets}.
+ *
+ * <p>A wallet claims key identifiers by matching them against its key selector, a regular
+ * expression. When {@link #keySelectorMustNotMatch()} is set the sense is inverted: the wallet
+ * claims identifiers that do <em>not</em> match. Immutable.
+ */
+@JsonPropertyOrder({"name", "keySelector", "keySelectorMustNotMatch"})
+public final class WalletInfo {
+
+  private final String name;
+  private final String keySelector;
+  private final boolean keySelectorMustNotMatch;
+
+  @JsonCreator
+  WalletInfo(
+      @JsonProperty("name") final String name,
+      @JsonProperty("keySelector") final String keySelector,
+      @JsonProperty("keySelectorMustNotMatch") final boolean keySelectorMustNotMatch) {
+    this.name = name;
+    this.keySelector = keySelector;
+    this.keySelectorMustNotMatch = keySelectorMustNotMatch;
+  }
+
+  /**
+   * The name of the wallet.
+   *
+   * @return the wallet name
+   */
+  @JsonProperty("name")
+  public String name() {
+    return name;
+  }
+
+  /**
+   * The regular expression used to select which key identifiers this wallet holds.
+   *
+   * @return the key selector expression
+   */
+  @JsonProperty("keySelector")
+  public String keySelector() {
+    return keySelector;
+  }
+
+  /**
+   * Whether the key selector is applied in non-matching mode, so that the wallet claims key
+   * identifiers that do not match {@link #keySelector()}.
+   *
+   * @return {@code true} if the selector match is inverted
+   */
+  @JsonProperty("keySelectorMustNotMatch")
+  public boolean keySelectorMustNotMatch() {
+    return keySelectorMustNotMatch;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof WalletInfo other
+        && keySelectorMustNotMatch == other.keySelectorMustNotMatch
+        && Objects.equals(name, other.name)
+        && Objects.equals(keySelector, other.keySelector);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, keySelector, keySelectorMustNotMatch);
+  }
+
+  @Override
+  public String toString() {
+    return "WalletInfo{name=" + name + ", keySelector=" + keySelector + "}";
+  }
+}

--- a/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/key/WalletInfoTest.java
+++ b/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/key/WalletInfoTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.key;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class WalletInfoTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void roundTrips() throws Exception {
+    final WalletInfo wallet = new WalletInfo("signer-1", ".*", false);
+    final String json = MAPPER.writeValueAsString(wallet);
+
+    final WalletInfo parsed = MAPPER.readValue(json, WalletInfo.class);
+    assertEquals(wallet, parsed);
+    assertEquals("signer-1", parsed.name());
+    assertEquals(".*", parsed.keySelector());
+    assertFalse(parsed.keySelectorMustNotMatch());
+  }
+
+  /** The exact shape a node returns from {@code keymgr_wallets} for a default devnet wallet. */
+  @Test
+  void parsesNodeResponseShape() throws Exception {
+    final String json =
+        "{\"name\":\"signer-1\",\"keySelector\":\".*\",\"keySelectorMustNotMatch\":false}";
+
+    final WalletInfo parsed = MAPPER.readValue(json, WalletInfo.class);
+    assertEquals("signer-1", parsed.name());
+    assertEquals(".*", parsed.keySelector());
+    assertFalse(parsed.keySelectorMustNotMatch());
+  }
+
+  @Test
+  void parsesInvertedSelector() throws Exception {
+    final String json =
+        "{\"name\":\"fallback\",\"keySelector\":\"^hsm\\\\.\",\"keySelectorMustNotMatch\":true}";
+
+    final WalletInfo parsed = MAPPER.readValue(json, WalletInfo.class);
+    assertEquals("fallback", parsed.name());
+    assertTrue(parsed.keySelectorMustNotMatch());
+  }
+
+  @Test
+  void equalsAndHashCode() {
+    final WalletInfo a = new WalletInfo("w", ".*", false);
+    final WalletInfo b = new WalletInfo("w", ".*", false);
+    final WalletInfo differentName = new WalletInfo("other", ".*", false);
+    final WalletInfo differentSense = new WalletInfo("w", ".*", true);
+
+    assertEquals(a, a);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, differentName);
+    assertNotEquals(a, differentSense);
+    assertNotEquals(a, "not a wallet");
+    assertTrue(a.toString().contains("name=w"));
+  }
+}


### PR DESCRIPTION
Fixes #1320.

### What

`KeyManagerClient.wallets()` declared `CompletableFuture<List<String>>`, but `keymgr_wallets`
returns a list of wallet objects. Every call against a live node failed with:

```
PaladinRpcException: failed to parse result: Cannot deserialize value of type
`java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
```

This adds the missing `WalletInfo` model and retypes the method.

### Changes

| File | Change |
|------|--------|
| `core/.../key/WalletInfo.java` | New — immutable model for `name` / `keySelector` / `keySelectorMustNotMatch` |
| `core/.../key/WalletInfoTest.java` | New — 4 tests, including one pinned to the literal payload a devnet node returns |
| `client/.../keymgr/KeyManagerClient.java` | `wallets()` retyped to `List<WalletInfo>` |
| `client/.../keymgr/KeyManagerClientTest.java` | Stub corrected to the real wire shape |

### On the test that missed this

The existing `KeyManagerClientTest.wallets()` stubbed the response as `["w-a","w-b"]` — a
fabricated payload matching the client's incorrect assumption rather than the node's actual
output. It passed, which is why the mismatch merged in #1279.

The replacement stubs two wallets in the real shape, including one with
`keySelectorMustNotMatch: true` to cover the inverted-selector case. `WalletInfoTest` also
pins the exact JSON captured from a running devnet node, so a future change to the wire
format fails a test rather than a demo.

### Breaking change

`wallets()` changes return type from `List<String>` to `List<WalletInfo>`. The old signature
never worked against a real node, so nothing functional depends on it — but it is a public
API change, and better landed before `0.1.0`.

### Testing

`./gradlew :sdk:java:core:build :sdk:java:client:build` — green, including Spotless,
Checkstyle, Javadoc doclint and JaCoCo.

- `WalletInfoTest` — 4 tests, 0 failures
- `KeyManagerClientTest` — 7 tests, 0 failures

Verified manually against a local 3-node devnet: `wallets()` now returns
`signer-1 selector=.*`.

### Follow-up

This was found by pointing a client at a real node, not by CI — the SDK has no test that
talks to one. Noted in #1320 as an argument for prioritizing #1242.
