### PR TITLE
Pente return revert result for endorse

### DIFF
--- a/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
+++ b/domains/pente/src/main/java/io/kaleido/paladin/pente/domain/PenteDomain.java
@@ -439,12 +439,37 @@ import com.fasterxml.jackson.core.JsonProcessingException;
                      setPayload(ByteString.copyFrom(endorsementPayload)).
                      build());
          } catch (PenteEVMTransaction.EVMExecutionException e) {
+             // Either the EVM reverted, or the account state supplied with the request did not match
+             // what the transaction expects (e.g. a stale nonce): Both are REVERT results.
              LOGGER.error("EVM execution failed during endorsement", e);
              return CompletableFuture.completedFuture(EndorseTransactionResponse.newBuilder().
-                     setEndorsementResult(EndorseTransactionResponse.Result.SIGN).
+                     setEndorsementResult(EndorseTransactionResponse.Result.REVERT).
                      setRevertReason(e.getMessage()).
                      build());
+         } catch (JsonProcessingException | IllegalArgumentException | IllegalStateException e) {
+             // The request was malformed, the info state carrying the transaction would not parse, or
+             // re-executing it did not reproduce the proposed inputs and outputs. Deterministic in every
+             // case: asking us again with the same assembly gets the same answer, so the result is revert.
+             LOGGER.error("Transaction not endorsed", e);
+             return CompletableFuture.completedFuture(EndorseTransactionResponse.newBuilder().
+                     setEndorsementResult(EndorseTransactionResponse.Result.REVERT).
+                     setRevertReason(e.getMessage()).
+                     build());
+         } catch (ExecutionException e) {
+             if (e.getCause() instanceof ErrorResponseException && isPermanentFailure((ErrorResponseException) e.getCause())) {
+                 // As during assembly, an INVALID_INPUT response from a plugin is a deterministic failure of
+                 // the transaction (e.g. an undecodable raw transaction, an invalid ABI), so the result must
+                 // be revert.
+                 LOGGER.error("Error response from plugin during endorsement", e);
+                 return CompletableFuture.completedFuture(EndorseTransactionResponse.newBuilder().
+                         setEndorsementResult(EndorseTransactionResponse.Result.REVERT).
+                         setRevertReason(e.getMessage()).
+                         build());
+             }
+             return CompletableFuture.failedFuture(e);
          } catch (Exception e) {
+             // Anything else (IO, interrupt, class loading) may be transient, so it is reported as an
+             // error and the coordinator is free to retry rather than finalizing the transaction.
              return CompletableFuture.failedFuture(e);
          } finally {
              ThreadContext.clearAll();

--- a/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/PenteDomainEndorseRevertTest.java
+++ b/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/PenteDomainEndorseRevertTest.java
@@ -1,0 +1,83 @@
+// Copyright contributors to Paladin, an LFDT project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.kaleido.paladin.pente.domain;
+
+import com.google.protobuf.ByteString;
+import io.kaleido.paladin.toolkit.EndorsableState;
+import io.kaleido.paladin.toolkit.EndorseTransactionRequest;
+import io.kaleido.paladin.toolkit.EndorseTransactionResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PenteDomainEndorseRevertTest {
+
+    @Test
+    void missingTransactionInputInfoStateReverts() throws ExecutionException, InterruptedException {
+        var pente = new PenteDomain("", "");
+
+        // Endorsement recovers the transaction from exactly one info state. Without it there is
+        // nothing to re-execute, and no retry can change that — so this must revert, not error.
+        var res = pente.endorseTransaction(EndorseTransactionRequest.newBuilder().build()).get();
+
+        assertEquals(EndorseTransactionResponse.Result.REVERT, res.getEndorsementResult());
+        assertTrue(res.getRevertReason().contains("Expected exactly one info state"),
+                "revert reason should say what was wrong, got: " + res.getRevertReason());
+    }
+
+    @Test
+    void tooManyTransactionInputInfoStatesReverts() throws ExecutionException, InterruptedException {
+        var pente = new PenteDomain("", "");
+
+        // The count check is an equality, not a lower bound: more than one info state is just as
+        // ambiguous as none, and equally unfixable by re-asking.
+        var res = pente.endorseTransaction(EndorseTransactionRequest.newBuilder()
+                .addInfo(infoState("{}"))
+                .addInfo(infoState("{}"))
+                .build()).get();
+
+        assertEquals(EndorseTransactionResponse.Result.REVERT, res.getEndorsementResult());
+        assertTrue(res.getRevertReason().contains("Expected exactly one info state"),
+                "revert reason should say what was wrong, got: " + res.getRevertReason());
+    }
+
+    @Test
+    void unparseableTransactionInputInfoStateReverts() throws ExecutionException, InterruptedException {
+        var pente = new PenteDomain("", "");
+
+        // The info state carries the signed transaction we are being asked to re-execute. The same
+        // bytes fail to parse the same way every time, so this reverts rather than erroring.
+        var res = pente.endorseTransaction(EndorseTransactionRequest.newBuilder()
+                .addInfo(infoState("not valid json"))
+                .build()).get();
+
+        assertEquals(EndorseTransactionResponse.Result.REVERT, res.getEndorsementResult());
+        assertNotNull(res.getRevertReason());
+    }
+
+    private static EndorsableState infoState(String stateDataJson) {
+        return EndorsableState.newBuilder()
+                .setId(ByteString.copyFrom(new byte[32]).toString())
+                .setSchemaId("schema1")
+                .setStateDataJson(stateDataJson)
+                .build();
+    }
+}


### PR DESCRIPTION
Update the errors returned during in endorsement to distinguish between
* A revert result- the domain does not endorse this transaction
* Error - an unexpected error occurred during endorsement, this does not tell us anything about the validity of the transaction being endorsed

#1328 updates the sequencer to handle these reverts correctly

This PR also makes three changes to the endorse error handling to support being more specific in the return type.

1. A reverting EVM execution was returning `SIGN` - this would result in a failed sign request later as there is no attestation to sign
2 `JsonProcessingException` was falling into the generic catch but this is a deterministic failure to parse the info state and should not be retried.
3. A plugin error is marked by assembly as permanent. Endorse now checks for this and returns such errors as a revert.
