### PR TITLE
Statemgr cleanup

### DIFF
--- a/common/go/pkg/pldmsgs/en_errors.go
+++ b/common/go/pkg/pldmsgs/en_errors.go
@@ -43,7 +43,7 @@ var (
 	MsgTypesInvalidDBUint256                 = pde("PD020013", "Integer incorrectly serialized to the database for a uint256: %s")
 	MsgTypesInvalidJSONFormatOptions         = pde("PD020014", "The JSON formatting options must be a valid set of key=value pairs in URL query string format '%s'")
 	MsgTypesUnknownJSONFormatOptions         = pde("PD020015", "JSON formatting option unknown %s=%s")
-	MsgTypesInvalidStateQualifier            = pde("PD020016", "Status must be one of 'available','confirmed','unconfirmed','spent','locked','all' or the UUID of a transaction")
+	MsgTypesInvalidStateQualifier            = pde("PD020016", "Status must be one of 'available','confirmed','unconfirmed','spent','all'")
 	MsgTypesPrivateIdentityReqFullyQualified = pde("PD020017", "Locator string %s must be fully qualified with a node name")
 	MsgTypesRestoreFailed                    = pde("PD020018", "Failed to restore type '%T' into '%T'")
 	MsgTypesTimeParseFail                    = pde("PD020019", "Cannot parse time as RFC3339, Unix, or UnixNano: '%s'", 400)

--- a/common/go/pkg/pldmsgs/en_errors.go
+++ b/common/go/pkg/pldmsgs/en_errors.go
@@ -43,7 +43,7 @@ var (
 	MsgTypesInvalidDBUint256                 = pde("PD020013", "Integer incorrectly serialized to the database for a uint256: %s")
 	MsgTypesInvalidJSONFormatOptions         = pde("PD020014", "The JSON formatting options must be a valid set of key=value pairs in URL query string format '%s'")
 	MsgTypesUnknownJSONFormatOptions         = pde("PD020015", "JSON formatting option unknown %s=%s")
-	MsgTypesInvalidStateQualifier            = pde("PD020016", "Status must be one of 'available','confirmed','unconfirmed','spent','all'")
+	MsgTypesInvalidStateQualifier            = pde("PD020016", "Status must be one of 'confirmed','unconfirmed','spent','all'")
 	MsgTypesPrivateIdentityReqFullyQualified = pde("PD020017", "Locator string %s must be fully qualified with a node name")
 	MsgTypesRestoreFailed                    = pde("PD020018", "Failed to restore type '%T' into '%T'")
 	MsgTypesTimeParseFail                    = pde("PD020019", "Cannot parse time as RFC3339, Unix, or UnixNano: '%s'", 400)

--- a/core/go/internal/components/statemgr.go
+++ b/core/go/internal/components/statemgr.go
@@ -26,7 +26,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
-	"gorm.io/gorm"
 )
 
 type StateManager interface {
@@ -74,9 +73,6 @@ type StateManager interface {
 	// Write a batch of nullifiers that correspond to states just received
 	WriteNullifiersForReceivedStates(ctx context.Context, dbTX persistence.DBTX, domainName string, nullifiers []*pldapi.StateNullifier) error
 
-	// Find states from outside of a domain context (noting you can reference a domain context by ID)
-	FindStates(ctx context.Context, dbTX persistence.DBTX, domainName string, schemaID pldtypes.Bytes32, query *query.QueryJSON, extQueryOptions *StateQueryOptions) (s []*pldapi.State, err error)
-
 	// GetState returns state by ID, with optional labels
 	GetStatesByID(ctx context.Context, dbTX persistence.DBTX, domainName string, contractAddress *pldtypes.EthAddress, stateIDs []pldtypes.HexBytes, failNotFound, withLabels bool) ([]*pldapi.State, error)
 
@@ -104,13 +100,6 @@ type PendingPrivateStateDataEntry struct {
 	BlockNumber int64
 }
 
-type StateQueryOptions struct {
-	StatusQualifier      pldapi.StateStatusQualifier
-	ExcludedIDs          []pldtypes.HexBytes
-	ExcludedNullifierIDs []pldtypes.HexBytes
-	QueryModifier        func(db persistence.DBTX, query *gorm.DB) *gorm.DB
-}
-
 // DomainQueryContext is the state query interface exposed outside of the statestore package. It may
 // be backed by a remote view, in which case queries are executed against both the remote view and
 // the local persisted state store, with the results merged together.
@@ -123,8 +112,11 @@ type DomainQueryContext interface {
 	// its spend exclusions.
 	FindAvailableStates(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, query *query.QueryJSON) (Schema, []*pldapi.State, error)
 
-	// FindAvailableNullifiers is similar to FindAvailableStates for nullifier-based domains.
-	FindAvailableNullifiers(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, query *query.QueryJSON) (Schema, []*pldapi.State, error)
+	// FindAvailableNullifierBackedStates returns available states for domains that spend via nullifiers,
+	// where availability is decided by the nullifier's spend record rather than the state's own. A remote
+	// view carries no nullifiers, so these queries are answered from the local persisted state store
+	// alone, though the view's spend exclusions still apply.
+	FindAvailableNullifierBackedStates(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, query *query.QueryJSON) (Schema, []*pldapi.State, error)
 
 	// GetStatesByID retrieves states by ID regardless of confirmation/spend status,
 	// including states pending in memory.

--- a/core/go/internal/components/statemgr.go
+++ b/core/go/internal/components/statemgr.go
@@ -32,12 +32,11 @@ import (
 type StateManager interface {
 	ManagerLifecycle
 
-	// Create a new domain query context - caller is responsible for closing it.
+	// Create a new domain query context.
 	NewDomainQueryContext(ctx context.Context, domain Domain, contractAddress pldtypes.EthAddress) DomainQueryContext
 
 	// Create a domain query context that answers queries by merging the local DB view with a
 	// remote in-memory view: view serves its matching unconfirmed states and spent state IDs on demand.
-	// Caller is responsible for closing it.
 	NewDomainQueryContextWithRemoteView(ctx context.Context, domain Domain, contractAddress pldtypes.EthAddress, view RemoteStateView) DomainQueryContext
 
 	// FindMatchingInMemoryStates evaluates a domain state query against caller-supplied snapshot
@@ -48,9 +47,6 @@ type StateManager interface {
 	// nullifier records to the database within the given transaction. Nullifiers must be validated
 	// against and linked to their creating states by the caller.
 	WriteStateBatch(ctx context.Context, dbTX persistence.DBTX, states []*StateWithLabels, nullifiers ...*pldapi.StateNullifier) error
-
-	// Get a previously created domain query context
-	GetDomainQueryContext(ctx context.Context, id uuid.UUID) DomainQueryContext
 
 	// Ensure ABI schemas upserts all the specified schemas, using the given DB transaction
 	EnsureABISchemas(ctx context.Context, dbTX persistence.DBTX, domainName string, defs []*abi.Parameter) ([]Schema, error)
@@ -119,12 +115,9 @@ type StateQueryOptions struct {
 // be backed by a remote view, in which case queries are executed against both the remote view and
 // the local persisted state store, with the results merged together.
 //
-// A DomainQueryContext is typically short-lived and must be closed by its consumer when no longer needed
-// to avoid leaking resources.
+// A DomainQueryContext is typically short-lived, holds no resources of its own, and is collected
+// once its consumer drops it.
 type DomainQueryContext interface {
-	// ID returns the UUID that identifies this context in the state manager registry.
-	ID() uuid.UUID
-
 	// FindAvailableStates is the primary query function, returning only available states.
 	// For contexts created with a remote view, results merge the view's matches and respect
 	// its spend exclusions.
@@ -139,9 +132,6 @@ type DomainQueryContext interface {
 
 	// ContractAddress returns the contract address this context was opened for.
 	ContractAddress() pldtypes.EthAddress
-
-	// Close deregisters the context from the state manager and prevents further use.
-	Close(ctx context.Context)
 }
 
 type StateUpsertOutsideContext struct {

--- a/core/go/internal/domainmgr/domain.go
+++ b/core/go/internal/domainmgr/domain.go
@@ -338,7 +338,7 @@ func (d *domain) FindAvailableStates(ctx context.Context, req *prototk.FindAvail
 
 	var states []*pldapi.State
 	if req.UseNullifiers != nil && *req.UseNullifiers {
-		_, states, err = c.dqc.FindAvailableNullifiers(ctx, c.dbTX, schemaID, &query)
+		_, states, err = c.dqc.FindAvailableNullifierBackedStates(ctx, c.dbTX, schemaID, &query)
 	} else {
 		_, states, err = c.dqc.FindAvailableStates(ctx, c.dbTX, schemaID, &query)
 	}

--- a/core/go/internal/domainmgr/domain_test.go
+++ b/core/go/internal/domainmgr/domain_test.go
@@ -230,8 +230,6 @@ func newTestDomain(t *testing.T, realDB bool, domainConfig *prototk.DomainConfig
 		c = tp.d.newInFlightDomainRequest(dm.persistence.NOTX(), dqc, true /* readonly unless modified by test */)
 	} else {
 		mdc = componentsmocks.NewDomainQueryContext(t)
-		mdc.On("ID").Return(uuid.New()).Maybe()
-		mdc.On("Close", mock.Anything).Return()
 		c = tp.d.newInFlightDomainRequest(dm.persistence.NOTX(), mdc, true /* readonly unless modified by test */)
 		mc.stateStore.On("NewDomainQueryContext", mock.Anything, tp.d, mock.Anything, mock.Anything).Return(mdc).Maybe()
 	}
@@ -247,10 +245,6 @@ func newTestDomain(t *testing.T, realDB bool, domainConfig *prototk.DomainConfig
 			contractAddress: addr,
 		}, func() {
 			c.close()
-			c.dqc.Close(ctx)
-			if mdc != nil {
-				mdc.Close(ctx)
-			}
 			dmDone()
 		}
 }

--- a/core/go/internal/domainmgr/domain_test.go
+++ b/core/go/internal/domainmgr/domain_test.go
@@ -540,7 +540,7 @@ func storeTestState(t *testing.T, td *testDomainContext, txID uuid.UUID, amount 
 	require.NoError(t, err)
 
 	// Validate against the real statestore, write, then confirm so the state appears as
-	// "available" when queried by the domain context during assembly.
+	// "confirmed" when queried by the domain context during assembly.
 	schemaID := pldtypes.MustParseBytes32(td.tp.stateSchemas[0].Id)
 	states, err := td.dm.stateStore.ValidateStatesWithLabels(td.ctx, td.c.dbTX, td.d, td.contractAddress, &prototk.EndorsableState{
 		SchemaId:      schemaID.String(),

--- a/core/go/internal/domainmgr/event_indexer.go
+++ b/core/go/internal/domainmgr/event_indexer.go
@@ -278,7 +278,6 @@ func (d *domain) handleEventBatchForContract(ctx context.Context, dbTX persisten
 	// We have a domain context for queries, but we never flush it to DB - as the only updates
 	// we allow in this function are those performed within our dbTX.
 	dqc := d.dm.stateStore.NewDomainQueryContext(ctx, d, addr)
-	defer dqc.Close(ctx)
 	c := d.newInFlightDomainRequest(dbTX, dqc, false /* write enabled */)
 	defer c.close()
 

--- a/core/go/internal/domainmgr/rpcmodule.go
+++ b/core/go/internal/domainmgr/rpcmodule.go
@@ -147,7 +147,6 @@ func (dm *domainManager) rpcInvokeRPC() rpcserver.RPCHandler {
 				return i18n.NewError(ctx, msgs.MsgDomainUnsupportedStateQualifier, stateQualifier)
 			}
 			dqc := dm.stateStore.NewDomainQueryContext(ctx, sc.Domain(), address)
-			defer dqc.Close(ctx)
 			resultJSON, err = sc.InvokeRPC(ctx, dqc, dbTX, rpcCall)
 			return err
 		})

--- a/core/go/internal/domainmgr/rpcmodule.go
+++ b/core/go/internal/domainmgr/rpcmodule.go
@@ -143,7 +143,7 @@ func (dm *domainManager) rpcInvokeRPC() rpcserver.RPCHandler {
 			if err != nil {
 				return err
 			}
-			if stateQualifier != "" && stateQualifier != pldapi.StateStatusAvailable {
+			if stateQualifier != "" && stateQualifier != pldapi.StateStatusConfirmed {
 				return i18n.NewError(ctx, msgs.MsgDomainUnsupportedStateQualifier, stateQualifier)
 			}
 			dqc := dm.stateStore.NewDomainQueryContext(ctx, sc.Domain(), address)

--- a/core/go/internal/domainmgr/rpcmodule_test.go
+++ b/core/go/internal/domainmgr/rpcmodule_test.go
@@ -913,9 +913,6 @@ func TestRPCInvokeRPC_Success(t *testing.T) {
 	}
 
 	mdc := componentsmocks.NewDomainQueryContext(t)
-	mdc.On("Close", mock.Anything).Return()
-	
-	mdc.On("ID").Return(uuid.New()).Maybe()
 	mc.stateStore.On("NewDomainQueryContext", mock.Anything, mock.Anything, mock.Anything).Return(mdc)
 
 	contractAddr := pldtypes.RandAddress()
@@ -1016,9 +1013,6 @@ func TestRPCInvokeRPC_InvokeError(t *testing.T) {
 	}
 
 	mdc := componentsmocks.NewDomainQueryContext(t)
-	mdc.On("Close", mock.Anything).Return()
-	
-	mdc.On("ID").Return(uuid.New()).Maybe()
 	mc.stateStore.On("NewDomainQueryContext", mock.Anything, mock.Anything, mock.Anything).Return(mdc)
 
 	contractAddr := pldtypes.RandAddress()

--- a/core/go/internal/domainmgr/rpcmodule_test.go
+++ b/core/go/internal/domainmgr/rpcmodule_test.go
@@ -932,7 +932,7 @@ func TestRPCInvokeRPC_Success(t *testing.T) {
 		Method:  "domain_invokeRPC",
 		Params: []pldtypes.RawJSON{
 			pldtypes.JSONString(contractAddr.String()),
-			pldtypes.JSONString(string(pldapi.StateStatusAvailable)),
+			pldtypes.JSONString(string(pldapi.StateStatusConfirmed)),
 			pldtypes.JSONString(pldapi.DomainInvokeRPC{Method: "someMethod", Params: pldtypes.RawJSON(`[]`)}),
 		},
 	}
@@ -993,7 +993,7 @@ func TestRPCInvokeRPC_ContractNotFound(t *testing.T) {
 		Method:  "domain_invokeRPC",
 		Params: []pldtypes.RawJSON{
 			pldtypes.JSONString(contractAddr.String()),
-			pldtypes.JSONString(string(pldapi.StateStatusAvailable)),
+			pldtypes.JSONString(string(pldapi.StateStatusConfirmed)),
 			pldtypes.JSONString(pldapi.DomainInvokeRPC{Method: "someMethod", Params: pldtypes.RawJSON(`[]`)}),
 		},
 	}
@@ -1032,7 +1032,7 @@ func TestRPCInvokeRPC_InvokeError(t *testing.T) {
 		Method:  "domain_invokeRPC",
 		Params: []pldtypes.RawJSON{
 			pldtypes.JSONString(contractAddr.String()),
-			pldtypes.JSONString(string(pldapi.StateStatusAvailable)),
+			pldtypes.JSONString(string(pldapi.StateStatusConfirmed)),
 			pldtypes.JSONString(pldapi.DomainInvokeRPC{Method: "someMethod", Params: pldtypes.RawJSON(`[]`)}),
 		},
 	}

--- a/core/go/internal/groupmgr/groupmgr_rpc_test.go
+++ b/core/go/internal/groupmgr/groupmgr_rpc_test.go
@@ -295,7 +295,7 @@ func TestRPCInvokeRPCError(t *testing.T) {
 	client := newTestRPCServer(t, ctx, gm)
 
 	var result pldtypes.RawJSON
-	rpcErr := client.CallRPC(ctx, &result, "pgroup_invokeRPC", "domain1", pldtypes.HexBytes(pldtypes.RandBytes(32)), pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
+	rpcErr := client.CallRPC(ctx, &result, "pgroup_invokeRPC", "domain1", pldtypes.HexBytes(pldtypes.RandBytes(32)), pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
 	require.Regexp(t, "PD012502", rpcErr)
 }
 
@@ -312,7 +312,7 @@ func TestRPCInvokeRPCOK(t *testing.T) {
 	client := newTestRPCServer(t, ctx, gm)
 
 	var result pldtypes.RawJSON
-	rpcErr := client.CallRPC(ctx, &result, "pgroup_invokeRPC", "domain1", groupID, pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
+	rpcErr := client.CallRPC(ctx, &result, "pgroup_invokeRPC", "domain1", groupID, pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
 	require.NoError(t, rpcErr)
 	assert.Equal(t, pldtypes.RawJSON(`"0xdeadbeef"`), result)
 }

--- a/core/go/internal/groupmgr/manager.go
+++ b/core/go/internal/groupmgr/manager.go
@@ -577,6 +577,5 @@ func (gm *groupManager) invokeRPC(ctx context.Context, dbTX persistence.DBTX, do
 		return nil, i18n.NewError(ctx, msgs.MsgDomainUnsupportedStateQualifier, stateQualifier)
 	}
 	dqc := gm.stateManager.NewDomainQueryContext(ctx, psc.Domain(), *pg.ContractAddress)
-	defer dqc.Close(ctx)
 	return psc.InvokeRPC(ctx, dqc, dbTX, rpcCall)
 }

--- a/core/go/internal/groupmgr/manager.go
+++ b/core/go/internal/groupmgr/manager.go
@@ -573,7 +573,7 @@ func (gm *groupManager) invokeRPC(ctx context.Context, dbTX persistence.DBTX, do
 	if err != nil {
 		return nil, err
 	}
-	if stateQualifier != "" && stateQualifier != pldapi.StateStatusAvailable {
+	if stateQualifier != "" && stateQualifier != pldapi.StateStatusConfirmed {
 		return nil, i18n.NewError(ctx, msgs.MsgDomainUnsupportedStateQualifier, stateQualifier)
 	}
 	dqc := gm.stateManager.NewDomainQueryContext(ctx, psc.Domain(), *pg.ContractAddress)

--- a/core/go/internal/groupmgr/manager_test.go
+++ b/core/go/internal/groupmgr/manager_test.go
@@ -705,7 +705,6 @@ func mockGetPrivateSmartContract(t *testing.T, mc *mockComponents, schemaID pldt
 	psc.On("Domain").Return(mc.domain).Maybe()
 	mdc := componentsmocks.NewDomainQueryContext(t)
 	mc.stateManager.On("NewDomainQueryContext", mock.Anything, mc.domain, *contractAddr).Return(mdc)
-	mdc.On("Close", mock.Anything).Return()
 	return psc
 }
 

--- a/core/go/internal/groupmgr/manager_test.go
+++ b/core/go/internal/groupmgr/manager_test.go
@@ -714,7 +714,7 @@ func TestInvokeRPCGroupNotFound(t *testing.T) {
 
 	mc.db.Mock.ExpectQuery("SELECT.*privacy_groups").WillReturnRows(sqlmock.NewRows([]string{}))
 
-	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", pldtypes.RandBytes(32), pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
+	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", pldtypes.RandBytes(32), pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
 	require.Regexp(t, "PD012502", err)
 }
 
@@ -726,7 +726,7 @@ func TestInvokeRPCGroupNotReady(t *testing.T) {
 	groupID := pldtypes.RandBytes(32)
 	mockDBPrivacyGroup(mc, schemaID, groupID, nil)
 
-	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
+	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`[]`)})
 	require.Regexp(t, "PD012503", err)
 }
 
@@ -741,7 +741,7 @@ func TestInvokeRPCOK(t *testing.T) {
 
 	psc.On("InvokeRPC", mock.Anything, mock.Anything, mock.Anything, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)}).Return(pldtypes.RawJSON(`"0xdeadbeef"`), nil)
 
-	result, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
+	result, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
 	require.NoError(t, err)
 	assert.Equal(t, pldtypes.RawJSON(`"0xdeadbeef"`), result)
 }
@@ -757,7 +757,7 @@ func TestInvokeRPCError(t *testing.T) {
 
 	psc.On("InvokeRPC", mock.Anything, mock.Anything, mock.Anything, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)}).Return(nil, fmt.Errorf("pop"))
 
-	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusAvailable, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
+	_, err := gm.invokeRPC(ctx, gm.p.NOTX(), "domain1", groupID, pldapi.StateStatusConfirmed, pldapi.DomainInvokeRPC{Method: "pente_getCodeHash", Params: pldtypes.RawJSON(`["0x1234"]`)})
 	require.Regexp(t, "pop", err)
 }
 

--- a/core/go/internal/msgs/en_errors.go
+++ b/core/go/internal/msgs/en_errors.go
@@ -106,10 +106,10 @@ var (
 	// PD010119 removed
 	MsgStateSpendConflictUnexpected   = pde("PD010120", "Pending spend for transaction %s found when attempting to spend from transaction %s")
 	MsgStateConfirmConflictUnexpected = pde("PD010121", "Pending confirmation for transaction %s found when attempting to confirm from transaction %s")
-	MsgStateDomainContextClosed       = pde("PD010122", "Domain context has been closed")
-	MsgStateDomainContextNotActive    = pde("PD010123", "There is no domain context with UUID %s active")
-	MsgStateLockNoTransaction         = pde("PD010124", "Transaction missing from state lock")
-	MsgStateLockNoState               = pde("PD010125", "State missing from state lock")
+	// PD010122 removed
+	// PD010123 removed
+	MsgStateLockNoTransaction = pde("PD010124", "Transaction missing from state lock")
+	MsgStateLockNoState       = pde("PD010125", "State missing from state lock")
 	// PD010126 removed
 	MsgStateNullifierConflict      = pde("PD010127", "State %s already has nullifier %s associated")
 	MsgStateInvalidCalculatingHash = pde("PD010128", "Failed to generate hash as state is invalid")

--- a/core/go/internal/sequencer/common/engine_integration.go
+++ b/core/go/internal/sequencer/common/engine_integration.go
@@ -114,9 +114,8 @@ func (e *engineIntegration) Assemble(ctx context.Context, transactionID uuid.UUI
 
 	log.L(ctx).Debugf("Assembling transaction %s. Creating domain context with coordinator view", transactionID)
 
-	// Create a domain context just for this call, wired to the coordinator's ahead-of-chain view.
+	// Create a domain context for this call, wired to the coordinator's ahead-of-chain view.
 	dqc := e.components.StateManager().NewDomainQueryContextWithRemoteView(ctx, e.domainSmartContract.Domain(), e.domainSmartContract.Address(), view)
-	defer dqc.Close(ctx)
 
 	// Verifiers were resolved before delegation and passed in, so assembly reads them directly with zero
 	// resolution work. The state machine drops assemble requests until State_Delegated, which a transaction

--- a/core/go/internal/sequencer/common/engine_integration_test.go
+++ b/core/go/internal/sequencer/common/engine_integration_test.go
@@ -259,7 +259,6 @@ func TestAssemble_UsesStoredVerifiers(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, contractAddr, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	// No identity resolver expectation: the golden path must not resolve at assembly time.
 
@@ -316,7 +315,6 @@ func TestAssemble_UsesSuppliedLocalTx(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, contractAddr, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -425,7 +423,6 @@ func TestEngineIntegration_Assemble_NilLocalTx(t *testing.T) {
 			mockDqc := componentsmocks.NewDomainQueryContext(t)
 			m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 				Return(mockDqc).Once()
-			mockDqc.On("Close", mock.Anything).Return().Once()
 
 			_, err := ei.Assemble(ctx, uuid.New(), &prototk.TransactionPreAssembly{}, nil, nil, 100, tc.localTx)
 			require.Regexp(t, "PD012601", err)
@@ -450,7 +447,6 @@ func TestEngineIntegration_Assemble_WrongDomain(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -484,7 +480,6 @@ func TestEngineIntegration_Assemble_AssembleTransactionError(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -521,7 +516,6 @@ func TestEngineIntegration_Assemble_NilPostAssembly(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -556,7 +550,6 @@ func TestEngineIntegration_Assemble_UnsupportedAttestationType(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -638,7 +631,6 @@ func TestEngineIntegration_Assemble_EndorseAttestationType(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -714,7 +706,6 @@ func TestEngineIntegration_Assemble_DebugLogging(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{
@@ -779,7 +770,6 @@ func TestEngineIntegration_Assemble_DoesNotSign(t *testing.T) {
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	m.stateManager.On("NewDomainQueryContextWithRemoteView", mock.Anything, m.domain, mock.Anything, mock.Anything).
 		Return(mockDqc).Once()
-	mockDqc.On("Close", mock.Anything).Return().Once()
 
 	localTx := &components.ResolvedTransaction{
 		Transaction: &pldapi.Transaction{

--- a/core/go/internal/sequencer/coordinator/coordinator_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/coordinator_builder_test.go
@@ -349,7 +349,6 @@ func (b *CoordinatorBuilderForTesting) Build() (*coordinator, *CoordinatorDepend
 	mocks.DomainAPI.On("Domain").Return(mocks.Domain).Maybe()
 	mocks.Domain.On("Name").Return("test-domain").Maybe()
 	mocks.DomainAPI.On("Address").Return(*b.contractAddress).Maybe()
-	mocks.DomainQueryContext.On("Close", mock.Anything).Return().Maybe()
 	mocks.StateManager.On("NewDomainQueryContext", mock.Anything, mock.Anything, mock.Anything).Return(mocks.DomainQueryContext).Maybe()
 
 	if b.useMockTransportWriter {

--- a/core/go/internal/sequencer/coordinator/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/endorsing.go
@@ -261,7 +261,6 @@ func (c *coordinator) endorse(ctx context.Context, e *EndorsementRequestReceived
 	}
 
 	dc := c.components.StateManager().NewDomainQueryContext(ctx, c.domainAPI.Domain(), c.domainAPI.Address())
-	defer dc.Close(ctx)
 
 	endorsementResult, err := c.domainAPI.EndorseTransaction(ctx, dc, c.components.Persistence().NOTX(), endorsementRequest)
 	if err != nil {

--- a/core/go/internal/sequencer/coordinator/transaction/dispatch.go
+++ b/core/go/internal/sequencer/coordinator/transaction/dispatch.go
@@ -118,7 +118,6 @@ func (t *coordinatorTransaction) prepareAndBuildDispatch(ctx context.Context, pt
 	// states, as the prepare request contains all the states the transaction consumes/spends/creates, hence the decision
 	// to not import a snapshot at the time of writing this comment, but it is something to be aware of.
 	dqc := t.components.StateManager().NewDomainQueryContext(ctx, t.domainAPI.Domain(), t.domainAPI.Address())
-	defer dqc.Close(ctx)
 	prep, err := t.domainAPI.PrepareTransaction(ctx, dqc, t.components.Persistence().NOTX(), pt)
 	if err != nil {
 		log.L(ctx).Errorf("error preparing transaction %s: %s", pt.ID, err)

--- a/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/transaction_builder_test.go
@@ -605,7 +605,6 @@ func (b *TransactionBuilderForTesting) Build() (*coordinatorTransaction, *transa
 	mocks.AllComponents.On("SequencerManager").Return(mocks.SequenceManager).Maybe()
 	mocks.AllComponents.On("Persistence").Return(mp.P).Maybe()
 	mocks.AllComponents.On("StateManager").Return(mocks.StateManager).Maybe()
-	mocks.DomainQueryContext.On("Close", mock.Anything).Return().Maybe()
 	mocks.StateManager.On("NewDomainQueryContext", mock.Anything, mock.Anything, mock.Anything).Return(mocks.DomainQueryContext).Maybe()
 	mocks.DomainAPI.On("Domain").Return(mocks.Domain).Maybe()
 	mocks.DomainAPI.On("Address").Return(*pldtypes.RandAddress()).Maybe()

--- a/core/go/internal/sequencer/sequencer.go
+++ b/core/go/internal/sequencer/sequencer.go
@@ -859,7 +859,6 @@ func (sMgr *sequencerManager) CallPrivateSmartContract(ctx context.Context, call
 
 	// Create a throwaway domain context for this call
 	dc := sMgr.components.StateManager().NewDomainQueryContext(ctx, psc.Domain(), psc.Address())
-	defer dc.Close(ctx)
 
 	// Do the actual call
 	return psc.ExecCall(ctx, dc, sMgr.components.Persistence().NOTX(), call, verifiers)

--- a/core/go/internal/sequencer/sequencer_test.go
+++ b/core/go/internal/sequencer/sequencer_test.go
@@ -1044,7 +1044,6 @@ func TestSequencerManager_CallPrivateSmartContract_Success(t *testing.T) {
 
 	mockDqc := componentsmocks.NewDomainQueryContext(t)
 	mocks.stateManager.EXPECT().NewDomainQueryContext(ctx, mockDomain, *contractAddr).Return(mockDqc).Once()
-	mockDqc.EXPECT().Close(mock.Anything).Once()
 	mocks.domainAPI.EXPECT().ExecCall(mock.Anything, mockDqc, nil, call, mock.Anything).Return(&abi.ComponentValue{}, nil).Once()
 
 	result, err := sm.CallPrivateSmartContract(ctx, call)

--- a/core/go/internal/statemgr/abi_schema_test.go
+++ b/core/go/internal/statemgr/abi_schema_test.go
@@ -233,7 +233,7 @@ func TestStoreRetrieveABISchema(t *testing.T) {
 		]
 	}`), &query)
 	require.NoError(t, err)
-	states, err = ss.FindContractStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
+	_, states, err = ss.findStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
 	require.NoError(t, err)
 	assert.Len(t, states, 1)
 
@@ -244,7 +244,7 @@ func TestStoreRetrieveABISchema(t *testing.T) {
 		]
 	}`), &query)
 	require.NoError(t, err)
-	states, err = ss.FindContractStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
+	_, states, err = ss.findStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
 	require.NoError(t, err)
 	assert.Len(t, states, 0)
 
@@ -255,7 +255,7 @@ func TestStoreRetrieveABISchema(t *testing.T) {
 		]
 	}`), &query)
 	require.NoError(t, err)
-	states, err = ss.FindContractStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
+	_, states, err = ss.findStates(ctx, ss.p.NOTX(), as.Persisted().DomainName, contractAddress, schemaID, query, "all")
 	require.NoError(t, err)
 	assert.Len(t, states, 0)
 }

--- a/core/go/internal/statemgr/domain_query_context.go
+++ b/core/go/internal/statemgr/domain_query_context.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"strings"
-	"sync"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
@@ -61,36 +60,28 @@ func createLogContext(ctx context.Context, domainName string, contractAddress pl
 	return ctx
 }
 
-// Short-lived, registered in the state manager. Always closed by the caller via defer dqc.Close(ctx).
+// Short-lived, and holds no resources of its own - it is collected once its consumer drops it.
 // May carry a remote view (spend exclusions + on-demand state queries) for FindAvailableStates queries.
 type domainQueryContext struct {
 	ss                 *stateManager
 	domainName         string
 	customHashFunction bool
 	contractAddress    pldtypes.EthAddress
-	stateLock          sync.Mutex
-	id                 uuid.UUID
-	closed             bool
+	id                 uuid.UUID // correlates this context's log lines
 	remoteStateView    components.RemoteStateView
 }
 
-// Very important that callers Close domain query contexts they open.
 func (ss *stateManager) NewDomainQueryContext(ctx context.Context, domain components.Domain, contractAddress pldtypes.EthAddress) components.DomainQueryContext {
 	id := uuid.New()
 	log.L(ctx).Debugf("Domain context %s for domain %s contract %s created", id, domain.Name(), contractAddress)
 
-	ss.domainContextLock.Lock()
-	defer ss.domainContextLock.Unlock()
-
-	dqc := &domainQueryContext{
+	return &domainQueryContext{
 		ss:                 ss,
 		domainName:         domain.Name(),
 		customHashFunction: domain.CustomHashFunction(),
 		contractAddress:    contractAddress,
 		id:                 id,
 	}
-	ss.domainContexts[id] = dqc
-	return dqc
 }
 
 // NewDomainQueryContextWithRemoteView creates a domain query context whose FindAvailableStates
@@ -102,10 +93,7 @@ func (ss *stateManager) NewDomainQueryContextWithRemoteView(ctx context.Context,
 	id := uuid.New()
 	log.L(ctx).Debugf("Assembly domain context %s for domain %s contract %s created", id, domain.Name(), contractAddress)
 
-	ss.domainContextLock.Lock()
-	defer ss.domainContextLock.Unlock()
-
-	dqc := &domainQueryContext{
+	return &domainQueryContext{
 		ss:                 ss,
 		domainName:         domain.Name(),
 		customHashFunction: domain.CustomHashFunction(),
@@ -113,8 +101,6 @@ func (ss *stateManager) NewDomainQueryContextWithRemoteView(ctx context.Context,
 		id:                 id,
 		remoteStateView:    remoteStateView,
 	}
-	ss.domainContexts[id] = dqc
-	return dqc
 }
 
 // getSpentStateIDs returns the remote view's spend exclusion set. Returns nil for local-only contexts.
@@ -130,49 +116,9 @@ func (dqc *domainQueryContext) getSpentStateIDs(ctx context.Context) ([]pldtypes
 	return spendStateIDs, nil
 }
 
-// nil if not found
-func (ss *stateManager) GetDomainQueryContext(ctx context.Context, id uuid.UUID) components.DomainQueryContext {
-	ss.domainContextLock.Lock()
-	defer ss.domainContextLock.Unlock()
-
-	ret, found := ss.domainContexts[id]
-	if found {
-		return ret
-	}
-	return nil // means an actual nil value to the interface
-}
-
-// ensureOpen fails if the context has been closed.
-func (dqc *domainQueryContext) ensureOpen(ctx context.Context) error {
-	dqc.stateLock.Lock()
-	defer dqc.stateLock.Unlock()
-	if dqc.closed {
-		return i18n.NewError(ctx, msgs.MsgStateDomainContextClosed)
-	}
-	return nil
-}
-
-// ID returns the UUID that identifies this context in the state manager registry.
-func (dqc *domainQueryContext) ID() uuid.UUID {
-	return dqc.id
-}
-
 // ContractAddress returns the contract address this context was opened for.
 func (dqc *domainQueryContext) ContractAddress() pldtypes.EthAddress {
 	return dqc.contractAddress
-}
-
-// Close deregisters the context from the state manager.
-func (dqc *domainQueryContext) Close(ctx context.Context) {
-	dqc.stateLock.Lock()
-	dqc.closed = true
-	dqc.stateLock.Unlock()
-
-	log.L(ctx).Debugf("Domain query context %s for domain %s contract %s closed", dqc.id, dqc.domainName, dqc.contractAddress)
-
-	dqc.ss.domainContextLock.Lock()
-	defer dqc.ss.domainContextLock.Unlock()
-	delete(dqc.ss.domainContexts, dqc.id)
 }
 
 // labelPreloadModifier returns a query modifier that preloads the persisted label rows, but only
@@ -398,10 +344,6 @@ func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX per
 	ctx = createLogContext(ctx, dqc.domainName, dqc.contractAddress, &schemaID)
 	log.L(ctx).Debugf("FindAvailableStates query=%s", q)
 
-	if err := dqc.ensureOpen(ctx); err != nil {
-		return nil, nil, err
-	}
-
 	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -446,10 +388,6 @@ func (dqc *domainQueryContext) FindAvailableNullifiers(ctx context.Context, dbTX
 	ctx = createLogContext(ctx, dqc.domainName, dqc.contractAddress, &schemaID)
 	log.L(ctx).Debugf("FindAvailableNullifiers query=%s", q)
 
-	if err := dqc.ensureOpen(ctx); err != nil {
-		return nil, nil, err
-	}
-
 	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -469,10 +407,6 @@ func (dqc *domainQueryContext) GetStatesByID(ctx context.Context, dbTX persisten
 		idsAny[i] = id
 	}
 	q := query.NewQueryBuilder().In(".id", idsAny).Sort(".created").Query()
-
-	if err := dqc.ensureOpen(ctx); err != nil {
-		return nil, nil, err
-	}
 
 	waitRemote := dqc.startRemoteViewFetch(ctx, schemaID, q)
 	schema, dbStates, dbErr := dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q, &components.StateQueryOptions{

--- a/core/go/internal/statemgr/domain_query_context.go
+++ b/core/go/internal/statemgr/domain_query_context.go
@@ -31,7 +31,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
-	"gorm.io/gorm"
 
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
@@ -61,7 +60,8 @@ func createLogContext(ctx context.Context, domainName string, contractAddress pl
 }
 
 // Short-lived, and holds no resources of its own - it is collected once its consumer drops it.
-// May carry a remote view (spend exclusions + on-demand state queries) for FindAvailableStates queries.
+// May carry a remote view (spend exclusions + on-demand state queries), which both FindAvailableStates
+// and GetStatesByID merge with the local DB.
 type domainQueryContext struct {
 	ss                 *stateManager
 	domainName         string
@@ -84,9 +84,8 @@ func (ss *stateManager) NewDomainQueryContext(ctx context.Context, domain compon
 	}
 }
 
-// NewDomainQueryContextWithRemoteView creates a domain query context whose FindAvailableStates
-// queries merge a remote view with the local DB. This view is fixed for the life of the
-// context.
+// NewDomainQueryContextWithRemoteView creates a domain query context whose queries merge a remote view
+// with the local DB. This view is fixed for the life of the context.
 func (ss *stateManager) NewDomainQueryContextWithRemoteView(ctx context.Context, domain components.Domain, contractAddress pldtypes.EthAddress, remoteStateView components.RemoteStateView) components.DomainQueryContext {
 	ctx = createLogContext(ctx, domain.Name(), contractAddress, nil)
 
@@ -121,32 +120,6 @@ func (dqc *domainQueryContext) ContractAddress() pldtypes.EthAddress {
 	return dqc.contractAddress
 }
 
-// labelPreloadModifier returns a query modifier that preloads the persisted label rows, but only
-// when this context has a remote view — the sole case where mergeSortLimit runs against DB
-// states and needs their label values to sort them alongside view-returned states. This is
-// an optimization: RecoverLabels falls back to re-parsing the state data when the rows are absent,
-// so returning nil on the common path (no extra DB round-trips) stays correct.
-//
-// TODO: Under sustained load this preload fires on essentially every query and its cost
-// (two extra SELECTs, on state_labels and state_int64labels) is paid per query. A further
-// optimization is possible: findStatesCommon already INNER-JOINs the label tables for the fields
-// referenced by the query's filter/sort, and the recovered values are consumed only by the
-// in-memory sort in mergeSortLimit (which needs only the sort-key labels). Selecting those
-// already-joined columns into the result would supply the sort values with zero extra round-trips
-// and no re-parse, superseding both this preload and the RecoverLabels fallback — at the cost of a
-// custom projection/scan, since GORM will not map arbitrary selected columns onto pldapi.State.
-func (dqc *domainQueryContext) labelPreloadModifier() func(persistence.DBTX, *gorm.DB) *gorm.DB {
-	// TODO: this isn't the same as the previous creating refs check- it means we're going to
-	// always do this on assembly because we can't see if we're going to need to merge or not.
-	// The optimisation which addresses the TODO is coming imminently
-	if dqc.remoteStateView == nil {
-		return nil
-	}
-	return func(_ persistence.DBTX, q *gorm.DB) *gorm.DB {
-		return q.Preload("Labels").Preload("Int64Labels")
-	}
-}
-
 // fetchRemoteViewStates sends the pre-marshaled query to the remote in-memory view and returns the
 // raw matches. Network only — no DB access — so it can run concurrently with the local DB read.
 // Runs unlocked — the remote query blocks on a network round-trip, and the dqc
@@ -160,15 +133,11 @@ func (dqc *domainQueryContext) fetchRemoteViewStates(ctx context.Context, schema
 	return queried, nil
 }
 
-// startRemoteViewFetch launches the remote view query (when a remote view is attached) concurrently
-// with the caller's local DB read, and returns a wait function that blocks until the fetch completes
-// and returns its results. All failures — including a query that cannot be re-marshaled for the
-// round-trip — are reported through the wait function, so callers have a single error path. With no
-// remote view attached the wait function is an immediate no-op.
+// startRemoteViewFetch launches the remote view query concurrently with the caller's local DB read,
+// and returns a wait function that blocks until the fetch completes and returns its results. All
+// failures — including a query that cannot be re-marshaled for the round-trip — are reported through
+// the wait function, so callers have a single error path. Only called where a remote view is attached.
 func (dqc *domainQueryContext) startRemoteViewFetch(ctx context.Context, schemaID pldtypes.Bytes32, q *query.QueryJSON) func() ([]*prototk.QueriedState, error) {
-	if dqc.remoteStateView == nil {
-		return func() ([]*prototk.QueriedState, error) { return nil, nil }
-	}
 	queryJSON, err := json.Marshal(q)
 	if err != nil {
 		return func() ([]*prototk.QueriedState, error) { return nil, err }
@@ -201,6 +170,7 @@ func (dqc *domainQueryContext) mergeRemoteViewStates(ctx context.Context, dbTX p
 	if err != nil {
 		return nil, err
 	}
+
 	if len(validated) == 0 {
 		return dbStates, nil
 	}
@@ -339,11 +309,38 @@ func (dqc *domainQueryContext) mergeSortLimit(ctx context.Context, schema compon
 	return retList, nil
 }
 
-// FindAvailableStates queries available states, merging the remote view's matches.
+// FindAvailableStates queries available states. With no remote view attached this is a plain read of
+// the available states this node holds; with one, the view's spend exclusions narrow that read and its
+// own matches are merged into the result.
 func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, q *query.QueryJSON) (components.Schema, []*pldapi.State, error) {
 	ctx = createLogContext(ctx, dqc.domainName, dqc.contractAddress, &schemaID)
 	log.L(ctx).Debugf("FindAvailableStates query=%s", q)
 
+	var schema components.Schema
+	var states []*pldapi.State
+	var err error
+	if dqc.remoteStateView == nil {
+		schema, states, err = dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
+			pldapi.StateStatusAvailable)
+	} else {
+		schema, states, err = dqc.availableStatesWithRemoteView(ctx, dbTX, schemaID, q)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if log.IsTraceEnabled() {
+		for _, s := range states {
+			log.L(ctx).Tracef("returning available state %s", s.ID)
+		}
+	}
+	log.L(ctx).Debugf("FindAvailableStates returning %d states: %s", len(states), logStateSummary(states))
+	return schema, states, nil
+}
+
+// availableStatesWithRemoteView reads available states alongside the attached remote view, running the
+// view query concurrently with the DB read and merging the two results.
+func (dqc *domainQueryContext) availableStatesWithRemoteView(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, q *query.QueryJSON) (components.Schema, []*pldapi.State, error) {
 	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -356,11 +353,8 @@ func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX per
 	}
 
 	waitRemote := dqc.startRemoteViewFetch(ctx, schemaID, q)
-	schema, dbStates, dbErr := dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q, &components.StateQueryOptions{
-		StatusQualifier: pldapi.StateStatusAvailable,
-		ExcludedIDs:     spentStateIDs,
-		QueryModifier:   dqc.labelPreloadModifier(),
-	})
+	schema, dbStates, dbErr := dqc.ss.findStatesForRemoteViewMerge(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
+		pldapi.StateStatusAvailable, spentStateIDs)
 	remoteStates, fetchErr := waitRemote()
 	if fetchErr != nil {
 		return nil, nil, fetchErr
@@ -370,32 +364,26 @@ func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX per
 	}
 	log.L(ctx).Tracef("FindAvailableStates read %d states from DB", len(dbStates))
 
-	dbStates, err = dqc.mergeRemoteViewStates(ctx, dbTX, schema, dbStates, remoteStates, q)
-	if log.IsTraceEnabled() {
-		for _, s := range dbStates {
-			log.L(ctx).Tracef("returning available state %s", s.ID)
-		}
+	merged, err := dqc.mergeRemoteViewStates(ctx, dbTX, schema, dbStates, remoteStates, q)
+	if err != nil {
+		return nil, nil, err
 	}
-	log.L(ctx).Debugf("FindAvailableStates read+merged %d states: %s", len(dbStates), logStateSummary(dbStates))
-
-	return schema, dbStates, err
+	return schema, merged, nil
 }
 
-// FindAvailableNullifiers queries available nullifier-based states. The remote in-memory view
-// carries no nullifiers, so nullifier queries answer from the DB only — the view's exclusion
-// set still applies.
-func (dqc *domainQueryContext) FindAvailableNullifiers(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, q *query.QueryJSON) (components.Schema, []*pldapi.State, error) {
+// FindAvailableNullifierBackedStates reads the states whose availability is decided by their nullifier's
+// spend record rather than their own. The remote in-memory view carries no nullifiers, so these queries
+// are answered from the DB alone — the view's spend exclusions still apply.
+func (dqc *domainQueryContext) FindAvailableNullifierBackedStates(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, q *query.QueryJSON) (components.Schema, []*pldapi.State, error) {
 	ctx = createLogContext(ctx, dqc.domainName, dqc.contractAddress, &schemaID)
-	log.L(ctx).Debugf("FindAvailableNullifiers query=%s", q)
+	log.L(ctx).Debugf("FindAvailableNullifierBackedStates query=%s", q)
 
 	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	return dqc.ss.findNullifiers(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q, &components.StateQueryOptions{
-		StatusQualifier: pldapi.StateStatusAvailable,
-		ExcludedIDs:     spentStateIDs,
-	})
+	return dqc.ss.findNullifierBackedStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
+		pldapi.StateStatusAvailable, spentStateIDs)
 }
 
 // GetStatesByID retrieves states by ID regardless of confirmation/spend status,
@@ -408,11 +396,14 @@ func (dqc *domainQueryContext) GetStatesByID(ctx context.Context, dbTX persisten
 	}
 	q := query.NewQueryBuilder().In(".id", idsAny).Sort(".created").Query()
 
+	if dqc.remoteStateView == nil {
+		return dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
+			pldapi.StateStatusAll)
+	}
+
 	waitRemote := dqc.startRemoteViewFetch(ctx, schemaID, q)
-	schema, dbStates, dbErr := dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q, &components.StateQueryOptions{
-		StatusQualifier: pldapi.StateStatusAll,
-		QueryModifier:   dqc.labelPreloadModifier(),
-	})
+	schema, dbStates, dbErr := dqc.ss.findStatesForRemoteViewMerge(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
+		pldapi.StateStatusAll, nil)
 	remoteStates, fetchErr := waitRemote()
 	if fetchErr != nil {
 		return nil, nil, fetchErr

--- a/core/go/internal/statemgr/domain_query_context.go
+++ b/core/go/internal/statemgr/domain_query_context.go
@@ -102,8 +102,8 @@ func (ss *stateManager) NewDomainQueryContextWithRemoteView(ctx context.Context,
 	}
 }
 
-// getSpentStateIDs returns the remote view's spend exclusion set. Returns nil for local-only contexts.
-func (dqc *domainQueryContext) getSpentStateIDs(ctx context.Context) ([]pldtypes.HexBytes, error) {
+// getRemoteSpentStateIDs returns the remote view's spend exclusion set. Returns nil for local-only contexts.
+func (dqc *domainQueryContext) getRemoteSpentStateIDs(ctx context.Context) ([]pldtypes.HexBytes, error) {
 	if dqc.remoteStateView == nil {
 		return nil, nil
 	}
@@ -344,7 +344,7 @@ func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX per
 // availableStatesWithRemoteView reads available states alongside the attached remote view, running the
 // view query concurrently with the DB read and merging the two results.
 func (dqc *domainQueryContext) availableStatesWithRemoteView(ctx context.Context, dbTX persistence.DBTX, schemaID pldtypes.Bytes32, q *query.QueryJSON) (components.Schema, []*pldapi.State, error) {
-	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
+	spentStateIDs, err := dqc.getRemoteSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -381,7 +381,7 @@ func (dqc *domainQueryContext) FindAvailableNullifierBackedStates(ctx context.Co
 	ctx = createLogContext(ctx, dqc.domainName, dqc.contractAddress, &schemaID)
 	log.L(ctx).Debugf("FindAvailableNullifierBackedStates query=%s", q)
 
-	spentStateIDs, err := dqc.getSpentStateIDs(ctx)
+	spentStateIDs, err := dqc.getRemoteSpentStateIDs(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/go/internal/statemgr/domain_query_context.go
+++ b/core/go/internal/statemgr/domain_query_context.go
@@ -135,8 +135,11 @@ func (dqc *domainQueryContext) fetchRemoteViewStates(ctx context.Context, schema
 
 // startRemoteViewFetch launches the remote view query concurrently with the caller's local DB read,
 // and returns a wait function that blocks until the fetch completes and returns its results. All
-// failures — including a query that cannot be re-marshaled for the round-trip — are reported through
-// the wait function, so callers have a single error path. Only called where a remote view is attached.
+// failures are reported through the wait function, so callers have a single error path. Where statemgr
+// functions with remote view fetches are used for assembly by a domain, the domain should consider an error
+// from the remote fetch as an assemble error (as opposed to a revert), meaning that the coordinator
+// will repool the transaction for a further assemble  rather than finalising it as failed.
+// Only called where a remote view is attached.
 func (dqc *domainQueryContext) startRemoteViewFetch(ctx context.Context, schemaID pldtypes.Bytes32, q *query.QueryJSON) func() ([]*prototk.QueriedState, error) {
 	queryJSON, err := json.Marshal(q)
 	if err != nil {

--- a/core/go/internal/statemgr/domain_query_context.go
+++ b/core/go/internal/statemgr/domain_query_context.go
@@ -321,7 +321,7 @@ func (dqc *domainQueryContext) FindAvailableStates(ctx context.Context, dbTX per
 	var err error
 	if dqc.remoteStateView == nil {
 		schema, states, err = dqc.ss.findStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
-			pldapi.StateStatusAvailable)
+			pldapi.StateStatusConfirmed)
 	} else {
 		schema, states, err = dqc.availableStatesWithRemoteView(ctx, dbTX, schemaID, q)
 	}
@@ -354,7 +354,7 @@ func (dqc *domainQueryContext) availableStatesWithRemoteView(ctx context.Context
 
 	waitRemote := dqc.startRemoteViewFetch(ctx, schemaID, q)
 	schema, dbStates, dbErr := dqc.ss.findStatesForRemoteViewMerge(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
-		pldapi.StateStatusAvailable, spentStateIDs)
+		pldapi.StateStatusConfirmed, spentStateIDs)
 	remoteStates, fetchErr := waitRemote()
 	if fetchErr != nil {
 		return nil, nil, fetchErr
@@ -383,7 +383,7 @@ func (dqc *domainQueryContext) FindAvailableNullifierBackedStates(ctx context.Co
 		return nil, nil, err
 	}
 	return dqc.ss.findNullifierBackedStates(ctx, dbTX, dqc.domainName, &dqc.contractAddress, schemaID, q,
-		pldapi.StateStatusAvailable, spentStateIDs)
+		pldapi.StateStatusConfirmed, spentStateIDs)
 }
 
 // GetStatesByID retrieves states by ID regardless of confirmation/spend status,

--- a/core/go/internal/statemgr/domain_query_context_test.go
+++ b/core/go/internal/statemgr/domain_query_context_test.go
@@ -208,19 +208,6 @@ func TestUpsertSchemaEmptyList(t *testing.T) {
 
 }
 
-// TestDCClosedErrorPaths verifies that a closed DomainQueryContext returns the correct errors.
-func TestDCClosedErrorPaths(t *testing.T) {
-
-	ctx, ss, _, _, done := newDBMockStateManager(t)
-	defer done()
-
-	_, dc2 := newTestDomainContext(t, ctx, ss, "domain1", false)
-	dc2.Close(ctx)
-	_, _, err := dc2.FindAvailableStates(ctx, ss.p.NOTX(), pldtypes.Bytes32(pldtypes.RandBytes(32)), nil)
-	assert.Regexp(t, "PD010122", err) // closed
-
-}
-
 func TestDomainQueryContextContractAddress(t *testing.T) {
 
 	ctx, ss, _, _, done := newDBMockStateManager(t)
@@ -247,7 +234,6 @@ func TestDCMergeRemoteViewDedup(t *testing.T) {
 
 	view := &staticView{states: queriedStatesOf(0, s1)}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	// Simulate the DB having returned s1 already — the coordinator copy is dropped, and since
 	// nothing else was returned the DB result is passed through untouched.
@@ -279,7 +265,6 @@ func TestDCMMergeAndSortStatesSortFail(t *testing.T) {
 	ss.abiSchemaCache.Set(schemaCacheKey("domain1", schema.ID()), schema)
 
 	contractAddress, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	s1, err := schema.ProcessStateWithLabels(ctx, contractAddress, pldtypes.RawJSON(fmt.Sprintf(
 		`{"amount": 20, "owner": "0x615dD09124271D8008225054d85Ffe720E7a447A", "salt": "%s"}`,
@@ -302,7 +287,6 @@ func TestDCMergeAndSortStatesRecoverLabelsFail(t *testing.T) {
 	ss.abiSchemaCache.Set(schemaCacheKey("domain1", schema.ID()), schema)
 
 	_, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	// State with no preloaded labels and unparseable data forces the RecoverLabels re-parse to fail.
 	_, err = dqc.mergeSortLimit(ctx, schema, []*pldapi.State{
@@ -326,7 +310,6 @@ func TestDCMergeCoordinatorStatesResultMergeFail(t *testing.T) {
 	s1 := makeFakeCoin(t, ctx, schema, contractAddress, false, 20)
 	view := &staticView{states: queriedStatesOf(0, s1)}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	// The DB state has unparseable data, so the merge fails recovering its labels.
 	q := query.NewQueryBuilder().Query()
@@ -351,7 +334,6 @@ func TestDCFindBadQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	_, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	schemaID := schema.ID()
 	assert.Equal(t, "type=FakeCoin(bytes32 salt,address owner,uint256 amount),labels=[owner,amount]", schema.Signature())
@@ -375,7 +357,6 @@ func TestMergeInMemoryMatchesLimit(t *testing.T) {
 	ss.abiSchemaCache.Set(schemaCacheKey("domain1", schema.ID()), schema)
 
 	contractAddress, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	mkState := func(amount int) *components.StateWithLabels {
 		s, e := schema.ProcessStateWithLabels(ctx, contractAddress, pldtypes.RawJSON(fmt.Sprintf(
@@ -390,30 +371,6 @@ func TestMergeInMemoryMatchesLimit(t *testing.T) {
 	result, err := dqc.mergeSortLimit(ctx, schema, dbStates, nil, query.NewQueryBuilder().Limit(limit).Sort(".created").Query(), ss.labelSetFor(schema))
 	require.NoError(t, err)
 	assert.Len(t, result, 2)
-}
-
-// TestMergeCoordinatorClosedContext verifies that a closed assembly DomainQueryContext fails at
-// the query entry points, before the DB read or the remote fetch is launched.
-func TestMergeCoordinatorClosedContext(t *testing.T) {
-	ctx, ss, _, _, done := newDBMockStateManager(t)
-	defer done()
-
-	schema, err := newABISchema(ctx, "domain1", testABIParam(t, fakeCoinABI))
-	require.NoError(t, err)
-	ss.abiSchemaCache.Set(schemaCacheKey("domain1", schema.ID()), schema)
-
-	contractAddress := pldtypes.RandAddress()
-	view := &staticView{}
-	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	dqc.Close(ctx)
-
-	_, _, err = dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema.ID(), query.NewQueryBuilder().Query())
-	assert.Regexp(t, "PD010122", err)
-
-	_, _, err = dqc.GetStatesByID(ctx, ss.p.NOTX(), schema.ID(), []string{pldtypes.RandHex(32)})
-	assert.Regexp(t, "PD010122", err)
-
-	assert.Zero(t, view.calls)
 }
 
 // blockingDBTX holds every DB access blocked until release is closed, signalling the first
@@ -456,7 +413,6 @@ func TestFindAvailableStatesOverlapsRemoteFetch(t *testing.T) {
 		fetchStarted:    make(chan struct{}),
 	}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	dbTX := &blockingDBTX{DBTX: ss.p.NOTX(), dbAccessed: make(chan struct{}), release: make(chan struct{})}
 
@@ -477,19 +433,6 @@ func TestFindAvailableStatesOverlapsRemoteFetch(t *testing.T) {
 	assert.Equal(t, s1.ID, states[0].ID)
 }
 
-// TestFindAvailableNullifiersClosedContext verifies FindAvailableNullifiers
-// returns an error when the DomainQueryContext is closed.
-func TestFindAvailableNullifiersClosedContext(t *testing.T) {
-	ctx, ss, _, _, done := newDBMockStateManager(t)
-	defer done()
-
-	_, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	dqc.Close(ctx)
-
-	_, _, err := dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), pldtypes.Bytes32(pldtypes.RandBytes(32)), nil)
-	assert.Regexp(t, "PD010122", err)
-}
-
 func TestBadSchema(t *testing.T) {
 
 	ctx, ss, _, _, done := newDBMockStateManager(t)
@@ -505,7 +448,6 @@ func TestCheckEvalGTTimestamp(t *testing.T) {
 	defer done()
 
 	_, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	jq := query.NewQueryBuilder().GreaterThan(".created", 1726545933211347000).Limit(10).Sort(".created").Query()
 
@@ -553,7 +495,6 @@ func TestFindAvailableStatesWithRemoteView(t *testing.T) {
 	s2 := makeFakeCoin(t, ctx, schema1, contractAddress, false, 20)
 
 	view, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, s1, s2)
-	defer dqc.Close(ctx)
 
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
@@ -585,7 +526,6 @@ func TestFindAvailableStatesQueryEvaluatedOnCoordinator(t *testing.T) {
 	s30 := makeFakeCoin(t, ctx, schema1, contractAddress, false, 30)
 
 	_, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, s10, s20, s30)
-	defer dqc.Close(ctx)
 
 	// Label equality
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(),
@@ -616,7 +556,6 @@ func TestFindAvailableStatesSchemaFilteredOnCoordinator(t *testing.T) {
 
 	s1 := makeFakeCoin(t, ctx, schema1, contractAddress, false, 10)
 	view, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, s1)
-	defer dqc.Close(ctx)
 
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema2.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
@@ -632,7 +571,6 @@ func TestNullifierQueriesSkipRemoteView(t *testing.T) {
 
 	s1 := makeFakeCoin(t, ctx, schema1, contractAddress, false, 10)
 	view, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, s1)
-	defer dqc.Close(ctx)
 
 	_, states, err := dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
@@ -647,7 +585,6 @@ func TestRemoteViewQueryError(t *testing.T) {
 
 	view := &testRemoteView{err: errors.New("pop")}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010134.*pop", err)
@@ -666,13 +603,11 @@ func TestQueriedStateBadIDsRejected(t *testing.T) {
 	})
 	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.Error(t, err)
-	dqc.Close(ctx)
 
 	// Bad schema ID
 	dqc2 := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, &staticView{
 		states: []*prototk.QueriedState{{State: &prototk.EndorsableState{Id: pldtypes.RandHex(32), SchemaId: "not-a-schema"}}},
 	})
-	defer dqc2.Close(ctx)
 	_, _, err = dqc2.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.Error(t, err)
 }
@@ -693,7 +628,6 @@ func TestQueriedStateSchemaMismatch(t *testing.T) {
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, &staticView{
 		states: queriedStatesOf(0, s1),
 	})
-	defer dqc.Close(ctx)
 
 	_, _, err = dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema2.ID(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010136", err)
@@ -711,7 +645,6 @@ func TestQueriedStateNoMatchRejected(t *testing.T) {
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, &staticView{
 		states: queriedStatesOf(0, s1),
 	})
-	defer dqc.Close(ctx)
 
 	jq := query.NewQueryBuilder().Equal("amount", 9999).Query()
 	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), jq)
@@ -740,7 +673,6 @@ func TestQueriedStatePopulatesCache(t *testing.T) {
 	const coordinatorCreated int64 = 1_700_000_000_000_000_000
 	view := &testRemoteView{ss: ss, domainName: "domain1", candidates: []*prototk.SnapshotState{snapshotStateOf(s1, coordinatorCreated)}}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
@@ -793,7 +725,6 @@ func TestQueriedStateCustomHashBypass(t *testing.T) {
 	view := &testRemoteView{ss: ss, domainName: "domain1", candidates: []*prototk.SnapshotState{snapshotStateOf(s1, 0)}}
 
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", true, contractAddress, view)
-	defer dqc.Close(ctx)
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
 	require.Len(t, states, 1)
@@ -829,7 +760,6 @@ func TestQueriedStateCustomHashDomainErrors(t *testing.T) {
 	dqc := newTestAssemblyContext(t, ctx, ss, "customdomain", true, contractAddress, &staticView{
 		states: queriedStatesOf(0, s1),
 	})
-	defer dqc.Close(ctx)
 
 	// The domain lookup fails: the whole select fails.
 	m.domainManager.On("GetDomainByName", mock.Anything, "customdomain").Return(nil, errors.New("no such domain")).Once()
@@ -867,7 +797,6 @@ func TestQueriedStateCachePoisoning(t *testing.T) {
 			StateDataJson: string(s1.Data),
 		}}},
 	})
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010129", err) // state hash mismatch
@@ -895,7 +824,6 @@ func TestQueriedCreatedOrdering(t *testing.T) {
 		snapshotStateOf(early, 1000),
 	}}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Sort(".created").Query())
 	require.NoError(t, err)
@@ -968,14 +896,12 @@ func TestQueriedStatesMixedHitMiss(t *testing.T) {
 	_, dqc1 := newTestRemoteViewContext(t, ctx, ss, contractAddress, cachedState)
 	_, _, err := dqc1.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
-	dqc1.Close(ctx)
 
 	hits, misses := cacheCounts(ss)
 	require.Equal(t, 0, hits)
 	require.Equal(t, 1, misses)
 
 	_, dqc2 := newTestRemoteViewContext(t, ctx, ss, contractAddress, cachedState, freshState)
-	defer dqc2.Close(ctx)
 	_, states, err := dqc2.FindAvailableStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Sort(".created").Query())
 	require.NoError(t, err)
 	require.Len(t, states, 2)
@@ -1086,7 +1012,6 @@ func TestQueriedStateEvalQueryError(t *testing.T) {
 
 	view := &staticView{states: queriedStatesOf(0, s1)}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	// The returned state validates, but the query references an unknown field, so the
 	// re-evaluation against the recomputed labels fails.
@@ -1105,7 +1030,6 @@ func TestFindAvailableStatesSpentIDsFetchError(t *testing.T) {
 
 	view := &testRemoteView{spentErr: errors.New("pop")}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010137.*pop", err)
@@ -1120,7 +1044,6 @@ func TestFindAvailableNullifiersSpentIDsFetchError(t *testing.T) {
 
 	view := &testRemoteView{spentErr: errors.New("pop")}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010137.*pop", err)
@@ -1135,7 +1058,6 @@ func TestFindAvailableStatesUnmarshalableQuery(t *testing.T) {
 
 	view := &staticView{}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
-	defer dqc.Close(ctx)
 
 	// A raw JSON value that is not valid JSON fails json.Marshal of the whole query.
 	q := &query.QueryJSON{
@@ -1169,7 +1091,6 @@ func TestGetStatesByIDWithRemoteView(t *testing.T) {
 	writeStateBatch(t, ctx, ss, dbStates)
 
 	view, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, sRemote)
-	defer dqc.Close(ctx)
 
 	schema, states, err := dqc.GetStatesByID(ctx, ss.p.NOTX(), schema1.ID(), []string{sDB.ID.String(), sRemote.ID.String()})
 	require.NoError(t, err)
@@ -1188,7 +1109,6 @@ func TestGetStatesByIDRemoteFetchError(t *testing.T) {
 
 	view := &testRemoteView{err: errors.New("pop")}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, view)
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.GetStatesByID(ctx, ss.p.NOTX(), schema1.ID(), []string{pldtypes.RandHex(32)})
 	assert.Regexp(t, "PD010134.*pop", err)
@@ -1204,7 +1124,6 @@ func TestGetStatesByIDMergeError(t *testing.T) {
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress, &staticView{
 		states: queriedStatesOf(0, s1),
 	})
-	defer dqc.Close(ctx)
 
 	_, _, err := dqc.GetStatesByID(ctx, ss.p.NOTX(), schema1.ID(), []string{pldtypes.RandHex(32)})
 	assert.Regexp(t, "PD010135", err)
@@ -1214,7 +1133,6 @@ func TestGetStatesByIDFail(t *testing.T) {
 	ctx, ss, db, _, done := newDBMockStateManager(t)
 	defer done()
 	_, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	defer dqc.Close(ctx)
 
 	db.ExpectQuery("SELECT.*schemas").WillReturnError(fmt.Errorf("pop"))
 
@@ -1234,7 +1152,6 @@ func TestNewDomainQueryContextWithRemoteView_DelegatesSpentIDsToView(t *testing.
 	md.On("CustomHashFunction").Return(false)
 
 	dqc := ss.NewDomainQueryContextWithRemoteView(ctx, md, *pldtypes.RandAddress(), view)
-	defer dqc.Close(ctx)
 
 	// Construction does not fetch the exclusion set.
 	assert.Zero(t, view.spentCalls)
@@ -1262,7 +1179,6 @@ func TestNewDomainQueryContextWithRemoteView_SpentIDsFetchError(t *testing.T) {
 	md.On("CustomHashFunction").Return(false)
 
 	dqc := ss.NewDomainQueryContextWithRemoteView(ctx, md, *pldtypes.RandAddress(), view)
-	defer dqc.Close(ctx)
 
 	// The fetch is lazy, so the error surfaces from the query rather than construction, and a
 	// failed fetch is not cached — the next call retries.

--- a/core/go/internal/statemgr/domain_query_context_test.go
+++ b/core/go/internal/statemgr/domain_query_context_test.go
@@ -1051,6 +1051,23 @@ func TestFindAvailableStatesUnmarshalableQuery(t *testing.T) {
 	assert.Zero(t, view.calls)
 }
 
+// TestFindAvailableStatesDBError proves a failed local DB read fails FindAvailableStates even
+// though the remote view answered successfully, so a working view cannot mask a broken local read.
+func TestFindAvailableStatesDBError(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	view := &staticView{}
+	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
+
+	db.ExpectQuery("SELECT.*schemas").WillReturnError(fmt.Errorf("pop"))
+
+	_, _, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), query.NewQueryBuilder().Query())
+	assert.Regexp(t, "pop", err)
+	// The view was still queried - the fetch runs concurrently with the DB read, not after it.
+	assert.Equal(t, 1, view.calls)
+}
+
 // TestGetStatesByIDWithRemoteView proves GetStatesByID merges remote-view-served states with
 // DB states: one requested state lives only in the DB, the other only in the remote view, and
 // both come back.
@@ -1115,6 +1132,23 @@ func TestGetStatesByIDFail(t *testing.T) {
 
 	_, _, err := dqc.GetStatesByID(ctx, dqc.ss.p.NOTX(), pldtypes.Bytes32(pldtypes.RandBytes(32)), []string{pldtypes.RandHex(32)})
 	assert.Regexp(t, "pop", err)
+}
+
+// TestGetStatesByIDWithRemoteViewDBError proves a failed local DB read fails GetStatesByID even
+// though the remote view answered successfully.
+func TestGetStatesByIDWithRemoteViewDBError(t *testing.T) {
+	ctx, ss, db, _, done := newDBMockStateManager(t)
+	defer done()
+
+	view := &staticView{}
+	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
+
+	db.ExpectQuery("SELECT.*schemas").WillReturnError(fmt.Errorf("pop"))
+
+	_, _, err := dqc.GetStatesByID(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), []string{pldtypes.RandHex(32)})
+	assert.Regexp(t, "pop", err)
+	// The view was still queried - the fetch runs concurrently with the DB read, not after it.
+	assert.Equal(t, 1, view.calls)
 }
 
 func TestNewDomainQueryContextWithRemoteView_DelegatesSpentIDsToView(t *testing.T) {

--- a/core/go/internal/statemgr/domain_query_context_test.go
+++ b/core/go/internal/statemgr/domain_query_context_test.go
@@ -341,7 +341,7 @@ func TestDCFindBadQuery(t *testing.T) {
 	_, _, err = dqc.FindAvailableStates(ctx, ss.p.NOTX(), schemaID, query.NewQueryBuilder().Sort("wrong").Query())
 	assert.Regexp(t, "PD010700", err)
 
-	_, _, err = dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), schemaID, query.NewQueryBuilder().Sort("wrong").Query())
+	_, _, err = dqc.FindAvailableNullifierBackedStates(ctx, ss.p.NOTX(), schemaID, query.NewQueryBuilder().Sort("wrong").Query())
 	assert.Regexp(t, "PD010700", err)
 
 }
@@ -572,7 +572,7 @@ func TestNullifierQueriesSkipRemoteView(t *testing.T) {
 	s1 := makeFakeCoin(t, ctx, schema1, contractAddress, false, 10)
 	view, dqc := newTestRemoteViewContext(t, ctx, ss, contractAddress, s1)
 
-	_, states, err := dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
+	_, states, err := dqc.FindAvailableNullifierBackedStates(ctx, ss.p.NOTX(), schema1.ID(), query.NewQueryBuilder().Query())
 	require.NoError(t, err)
 	assert.Empty(t, states)
 	assert.Empty(t, view.calls)
@@ -953,47 +953,24 @@ func TestFindNullifiersSpendingExclusion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Both are visible without exclusions
-	found, err := ss.FindContractNullifiers(ctx, ss.p.NOTX(), "domain1", *contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), pldapi.StateStatusAvailable)
+	_, found, err := ss.findNullifierBackedStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
+		query.NewQueryBuilder().Query(), pldapi.StateStatusAvailable, nil)
 	require.NoError(t, err)
 	assert.Len(t, found, 2)
 
-	// Exclude state[0] via spendingStates — only state[1] should appear
-	_, found, err = ss.findNullifiers(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), &components.StateQueryOptions{
-			StatusQualifier: pldapi.StateStatusAvailable,
-			ExcludedIDs:     []pldtypes.HexBytes{states1[0].ID},
-		})
+	// Exclude state[0] by state ID — only state[1] should appear
+	_, found, err = ss.findNullifierBackedStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
+		query.NewQueryBuilder().Query(), pldapi.StateStatusAvailable,
+		[]pldtypes.HexBytes{states1[0].ID})
 	require.NoError(t, err)
 	assert.Len(t, found, 1)
 	assert.Equal(t, states1[1].ID, found[0].ID)
 
-	// Exclude state[1]'s nullifier via spendingNullifiers — only state[0] should appear
-	_, found, err = ss.findNullifiers(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), &components.StateQueryOptions{
-			StatusQualifier:      pldapi.StateStatusAvailable,
-			ExcludedNullifierIDs: []pldtypes.HexBytes{nullID2},
-		})
-	require.NoError(t, err)
-	assert.Len(t, found, 1)
-	assert.Equal(t, states1[0].ID, found[0].ID)
-
-	// nil options defaults the status qualifier to "all" and returns both nullifier states
-	_, found, err = ss.findNullifiers(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), nil)
+	// An omitted status qualifier means all, returning both nullifier states
+	_, found, err = ss.findNullifierBackedStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
+		query.NewQueryBuilder().Query(), "", nil)
 	require.NoError(t, err)
 	assert.Len(t, found, 2)
-
-	// empty options also defaults the status qualifier, and a QueryModifier narrows to state[0]
-	_, found, err = ss.findNullifiers(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), &components.StateQueryOptions{
-			QueryModifier: func(_ persistence.DBTX, q *gorm.DB) *gorm.DB {
-				return q.Where(`"states"."id" = ?`, states1[0].ID)
-			},
-		})
-	require.NoError(t, err)
-	assert.Len(t, found, 1)
-	assert.Equal(t, states1[0].ID, found[0].ID)
 }
 
 // TestQueriedStateEvalQueryError proves a query that cannot be evaluated against the schema's
@@ -1036,16 +1013,16 @@ func TestFindAvailableStatesSpentIDsFetchError(t *testing.T) {
 	assert.Empty(t, view.calls)
 }
 
-// TestFindAvailableNullifiersSpentIDsFetchError proves the same spend exclusion fetch failure
-// fails FindAvailableNullifiers.
-func TestFindAvailableNullifiersSpentIDsFetchError(t *testing.T) {
+// TestFindAvailableNullifierBackedStatesSpentIDsFetchError proves the same spend exclusion fetch failure
+// fails FindAvailableNullifierBackedStates.
+func TestFindAvailableNullifierBackedStatesSpentIDsFetchError(t *testing.T) {
 	ctx, ss, _, _, done := newDBMockStateManager(t)
 	defer done()
 
 	view := &testRemoteView{spentErr: errors.New("pop")}
 	dqc := newTestAssemblyContext(t, ctx, ss, "domain1", false, pldtypes.RandAddress(), view)
 
-	_, _, err := dqc.FindAvailableNullifiers(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), query.NewQueryBuilder().Query())
+	_, _, err := dqc.FindAvailableNullifierBackedStates(ctx, ss.p.NOTX(), pldtypes.RandBytes32(), query.NewQueryBuilder().Query())
 	assert.Regexp(t, "PD010137.*pop", err)
 	assert.Empty(t, view.calls)
 }

--- a/core/go/internal/statemgr/domain_query_context_test.go
+++ b/core/go/internal/statemgr/domain_query_context_test.go
@@ -1168,12 +1168,12 @@ func TestNewDomainQueryContextWithRemoteView_DelegatesSpentIDsToView(t *testing.
 	assert.Zero(t, view.spentCalls)
 
 	// getSpentStateIDs delegates straight to the view, so each call reaches it.
-	got, err := dqc.(*domainQueryContext).getSpentStateIDs(ctx)
+	got, err := dqc.(*domainQueryContext).getRemoteSpentStateIDs(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, spent, got)
 	assert.Equal(t, 1, view.spentCalls)
 
-	got, err = dqc.(*domainQueryContext).getSpentStateIDs(ctx)
+	got, err = dqc.(*domainQueryContext).getRemoteSpentStateIDs(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, spent, got)
 	assert.Equal(t, 2, view.spentCalls)
@@ -1193,12 +1193,12 @@ func TestNewDomainQueryContextWithRemoteView_SpentIDsFetchError(t *testing.T) {
 
 	// The fetch is lazy, so the error surfaces from the query rather than construction, and a
 	// failed fetch is not cached — the next call retries.
-	_, err := dqc.(*domainQueryContext).getSpentStateIDs(ctx)
+	_, err := dqc.(*domainQueryContext).getRemoteSpentStateIDs(ctx)
 	assert.Regexp(t, "PD010137", err)
 	assert.Regexp(t, "pop", err)
 	assert.Equal(t, 1, view.spentCalls)
 
-	_, err = dqc.(*domainQueryContext).getSpentStateIDs(ctx)
+	_, err = dqc.(*domainQueryContext).getRemoteSpentStateIDs(ctx)
 	assert.Regexp(t, "PD010137", err)
 	assert.Equal(t, 2, view.spentCalls)
 }

--- a/core/go/internal/statemgr/domain_query_context_test.go
+++ b/core/go/internal/statemgr/domain_query_context_test.go
@@ -954,13 +954,13 @@ func TestFindNullifiersSpendingExclusion(t *testing.T) {
 
 	// Both are visible without exclusions
 	_, found, err := ss.findNullifierBackedStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), pldapi.StateStatusAvailable, nil)
+		query.NewQueryBuilder().Query(), pldapi.StateStatusConfirmed, nil)
 	require.NoError(t, err)
 	assert.Len(t, found, 2)
 
 	// Exclude state[0] by state ID — only state[1] should appear
 	_, found, err = ss.findNullifierBackedStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schema1.ID(),
-		query.NewQueryBuilder().Query(), pldapi.StateStatusAvailable,
+		query.NewQueryBuilder().Query(), pldapi.StateStatusConfirmed,
 		[]pldtypes.HexBytes{states1[0].ID})
 	require.NoError(t, err)
 	assert.Len(t, found, 1)

--- a/core/go/internal/statemgr/state.go
+++ b/core/go/internal/statemgr/state.go
@@ -357,8 +357,8 @@ func (ss *stateManager) findStates(
 		func(_ persistence.DBTX, q *gorm.DB) *gorm.DB { return scope(q) })
 }
 
-// findStatesForRemoteViewMerge reads states for a domain context that has a remote view, ready to be
-// merged with the view's own matches. It excludes the states the view reports spent ahead of the
+// findStatesForRemoteViewMerge reads states from the local database in a way that they can be merged with the
+// states returned from querying a remote view. It excludes the states the view reports spent ahead of the
 // chain, and brings each state's persisted label rows with it, because the merge sorts DB states and
 // view states into a single order and needs label values for both sides.
 //

--- a/core/go/internal/statemgr/state.go
+++ b/core/go/internal/statemgr/state.go
@@ -315,27 +315,34 @@ func (ss *stateManager) labelSetFor(schema components.Schema) *trackingLabelSet 
 	return &tls
 }
 
-func (ss *stateManager) FindContractStates(ctx context.Context, dbTX persistence.DBTX, domainName string, contractAddress *pldtypes.EthAddress, schemaID pldtypes.Bytes32, query *query.QueryJSON, status pldapi.StateStatusQualifier) (s []*pldapi.State, err error) {
-	_, s, err = ss.findStates(ctx, dbTX, domainName, contractAddress, schemaID, query, &components.StateQueryOptions{StatusQualifier: status})
-	return s, err
+// statusScope returns the query modifier that scopes a states query to a status qualifier and
+// excludes the given state IDs. Available, and its synonym confirmed, are served from the maintained
+// confirmed/spent flags and the states_available partial index, so they need neither the
+// Confirmed/Spent joins nor whereClauseForQual. Every other qualifier expresses status via those joins.
+func statusScope(ctx context.Context, dbTX persistence.DBTX, status pldapi.StateStatusQualifier, excludedIDs []pldtypes.HexBytes) func(*gorm.DB) *gorm.DB {
+	var whereClause *gorm.DB
+	var needsStatusJoins bool
+	if status == pldapi.StateStatusAvailable || status == pldapi.StateStatusConfirmed {
+		whereClause = dbTX.DB(ctx).Where(`"states"."confirmed" AND NOT "states"."spent"`)
+	} else {
+		whereClause = whereClauseForQual(dbTX.DB(ctx), status, "Spent")
+		needsStatusJoins = true
+	}
+	return func(q *gorm.DB) *gorm.DB {
+		if needsStatusJoins {
+			q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
+				Joins("Spent", dbTX.DB(ctx).Select("transaction"))
+		}
+		if len(excludedIDs) > 0 {
+			q = q.Not(`"states"."id" IN(?)`, excludedIDs)
+		}
+		return q.Where(whereClause)
+	}
 }
 
-func (ss *stateManager) FindStates(ctx context.Context, dbTX persistence.DBTX, domainName string, schemaID pldtypes.Bytes32, query *query.QueryJSON, options *components.StateQueryOptions) (s []*pldapi.State, err error) {
-	ctx = log.WithComponent(ctx, "statemanager")
-	_, s, err = ss.findStates(ctx, dbTX, domainName, nil, schemaID, query, options)
-	return s, err
-}
-
-func (ss *stateManager) FindContractNullifiers(ctx context.Context, dbTX persistence.DBTX, domainName string, contractAddress pldtypes.EthAddress, schemaID pldtypes.Bytes32, query *query.QueryJSON, status pldapi.StateStatusQualifier) (s []*pldapi.State, err error) {
-	_, s, err = ss.findNullifiers(ctx, dbTX, domainName, &contractAddress, schemaID, query, &components.StateQueryOptions{StatusQualifier: status})
-	return s, err
-}
-
-func (ss *stateManager) FindNullifiers(ctx context.Context, dbTX persistence.DBTX, domainName string, schemaID pldtypes.Bytes32, query *query.QueryJSON, status pldapi.StateStatusQualifier) (s []*pldapi.State, err error) {
-	_, s, err = ss.findNullifiers(ctx, dbTX, domainName, nil, schemaID, query, &components.StateQueryOptions{StatusQualifier: status})
-	return s, err
-}
-
+// findStates reads states from the local DB alone, scoped by the given status qualifier and
+// provided query. It serves the query API, which passes whatever qualifier its
+// caller asked for, and domain query contexts with no remote view, which have nothing to merge against.
 func (ss *stateManager) findStates(
 	ctx context.Context,
 	dbTX persistence.DBTX,
@@ -343,61 +350,57 @@ func (ss *stateManager) findStates(
 	contractAddress *pldtypes.EthAddress,
 	schemaID pldtypes.Bytes32,
 	jq *query.QueryJSON,
-	options *components.StateQueryOptions,
-) (schema components.Schema, s []*pldapi.State, err error) {
-	if options == nil {
-		options = &components.StateQueryOptions{}
-	}
-	if options.StatusQualifier == "" {
-		options.StatusQualifier = pldapi.StateStatusAll
-	}
-	// Available, and its synonym confirmed, are served from the maintained confirmed/spent flags
-	// and the states_available partial index, so they need neither the Confirmed/Spent joins nor
-	// whereClauseForQual. Every other qualifier expresses status via those joins.
-	var whereClause *gorm.DB
-	var needsStatusJoins bool
-	if options.StatusQualifier == pldapi.StateStatusAvailable || options.StatusQualifier == pldapi.StateStatusConfirmed {
-		whereClause = dbTX.DB(ctx).Where(`"states"."confirmed" AND NOT "states"."spent"`)
-	} else {
-		whereClause = whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Spent")
-		needsStatusJoins = true
-	}
-	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
-		if needsStatusJoins {
-			q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
-				Joins("Spent", dbTX.DB(ctx).Select("transaction"))
-		}
-
-		if len(options.ExcludedIDs) > 0 {
-			q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
-		}
-
-		// Scope the query based on the status qualifier
-		q = q.Where(whereClause)
-
-		if options.QueryModifier != nil {
-			q = options.QueryModifier(dbTX, q)
-		}
-		return q
-	})
+	status pldapi.StateStatusQualifier,
+) (components.Schema, []*pldapi.State, error) {
+	scope := statusScope(ctx, dbTX, status, nil)
+	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq,
+		func(_ persistence.DBTX, q *gorm.DB) *gorm.DB { return scope(q) })
 }
 
-func (ss *stateManager) findNullifiers(
+// findStatesForRemoteViewMerge reads states for a domain context that has a remote view, ready to be
+// merged with the view's own matches. It excludes the states the view reports spent ahead of the
+// chain, and brings each state's persisted label rows with it, because the merge sorts DB states and
+// view states into a single order and needs label values for both sides.
+//
+// TODO: the label rows cost two extra SELECTs, on state_labels and state_int64_labels, per query.
+// findStatesCommon already INNER-JOINs the label tables for the fields the query filters and sorts
+// on, and the merge sort needs only the sort-key labels, so selecting those already-joined columns
+// alongside the states would supply the sort values with no extra round-trips and no re-parse. That
+// needs a custom projection/scan, since GORM will not map arbitrary selected columns onto
+// pldapi.State, and the values need somewhere to live other than pldapi.State.Labels: a sort-key-only
+// subset there would fail the completeness check RecoverLabels makes before trusting those fields,
+// and would leave an API-visible label set that understates what the state has.
+func (ss *stateManager) findStatesForRemoteViewMerge(
 	ctx context.Context,
 	dbTX persistence.DBTX,
 	domainName string,
 	contractAddress *pldtypes.EthAddress,
 	schemaID pldtypes.Bytes32,
 	jq *query.QueryJSON,
-	options *components.StateQueryOptions,
-) (schema components.Schema, s []*pldapi.State, err error) {
-	if options == nil {
-		options = &components.StateQueryOptions{}
-	}
-	if options.StatusQualifier == "" {
-		options.StatusQualifier = pldapi.StateStatusAll
-	}
-	whereClause := whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Nullifier__Spent")
+	status pldapi.StateStatusQualifier,
+	excludedIDs []pldtypes.HexBytes,
+) (components.Schema, []*pldapi.State, error) {
+	scope := statusScope(ctx, dbTX, status, excludedIDs)
+	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq,
+		func(_ persistence.DBTX, q *gorm.DB) *gorm.DB {
+			return scope(q).Preload("Labels").Preload("Int64Labels")
+		})
+}
+
+// findNullifierBackedStates reads states that carry a nullifier, dropping those that do not. Status is
+// expressed through the Confirmed join and the nullifier's own spend join, since the chain records the
+// spend against the nullifier rather than against the state it consumes.
+func (ss *stateManager) findNullifierBackedStates(
+	ctx context.Context,
+	dbTX persistence.DBTX,
+	domainName string,
+	contractAddress *pldtypes.EthAddress,
+	schemaID pldtypes.Bytes32,
+	jq *query.QueryJSON,
+	status pldapi.StateStatusQualifier,
+	excludedIDs []pldtypes.HexBytes,
+) (components.Schema, []*pldapi.State, error) {
+	whereClause := whereClauseForQual(dbTX.DB(ctx), status, "Nullifier__Spent")
 	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
 		hasNullifier := dbTX.DB(ctx).Where(`"Nullifier"."id" IS NOT NULL`)
 
@@ -406,21 +409,11 @@ func (ss *stateManager) findNullifiers(
 			Joins("Nullifier.Spent", dbTX.DB(ctx).Select("transaction")).
 			Where(hasNullifier)
 
-		if len(options.ExcludedIDs) > 0 {
-			q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
-		}
-		if len(options.ExcludedNullifierIDs) > 0 {
-			q = q.Not(`"Nullifier"."id" IN(?)`, options.ExcludedNullifierIDs)
+		if len(excludedIDs) > 0 {
+			q = q.Not(`"states"."id" IN(?)`, excludedIDs)
 		}
 
-		// Scope to only unspent
-		q = q.Where(whereClause)
-
-		if options.QueryModifier != nil {
-			q = options.QueryModifier(dbTX, q)
-		}
-
-		return q
+		return q.Where(whereClause)
 	})
 }
 

--- a/core/go/internal/statemgr/state.go
+++ b/core/go/internal/statemgr/state.go
@@ -316,13 +316,13 @@ func (ss *stateManager) labelSetFor(schema components.Schema) *trackingLabelSet 
 }
 
 // statusScope returns the query modifier that scopes a states query to a status qualifier and
-// excludes the given state IDs. Available, and its synonym confirmed, are served from the maintained
-// confirmed/spent flags and the states_available partial index, so they need neither the
-// Confirmed/Spent joins nor whereClauseForQual. Every other qualifier expresses status via those joins.
+// excludes the given state IDs. The confirmed qualifier is served from the maintained confirmed/spent
+// flags and the states_available partial index, so it needs neither the Confirmed/Spent joins nor
+// whereClauseForQual. Every other qualifier expresses status via those joins.
 func statusScope(ctx context.Context, dbTX persistence.DBTX, status pldapi.StateStatusQualifier, excludedIDs []pldtypes.HexBytes) func(*gorm.DB) *gorm.DB {
 	var whereClause *gorm.DB
 	var needsStatusJoins bool
-	if status == pldapi.StateStatusAvailable || status == pldapi.StateStatusConfirmed {
+	if status == pldapi.StateStatusConfirmed {
 		whereClause = dbTX.DB(ctx).Where(`"states"."confirmed" AND NOT "states"."spent"`)
 	} else {
 		whereClause = whereClauseForQual(dbTX.DB(ctx), status, "Spent")

--- a/core/go/internal/statemgr/state.go
+++ b/core/go/internal/statemgr/state.go
@@ -27,7 +27,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/core/internal/filters"
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -352,50 +351,35 @@ func (ss *stateManager) findStates(
 	if options.StatusQualifier == "" {
 		options.StatusQualifier = pldapi.StateStatusAll
 	}
-	// Available is served from the maintained confirmed/spent flags and the states_available
-	// partial index, so it needs neither the Confirmed/Spent joins nor whereClauseForQual. Every
-	// other plain-DB qualifier still expresses status via those joins.
+	// Available, and its synonym confirmed, are served from the maintained confirmed/spent flags
+	// and the states_available partial index, so they need neither the Confirmed/Spent joins nor
+	// whereClauseForQual. Every other qualifier expresses status via those joins.
 	var whereClause *gorm.DB
-	needsStatusJoins, isPlainDB := true, true
-	if options.StatusQualifier == pldapi.StateStatusAvailable {
+	var needsStatusJoins bool
+	if options.StatusQualifier == pldapi.StateStatusAvailable || options.StatusQualifier == pldapi.StateStatusConfirmed {
 		whereClause = dbTX.DB(ctx).Where(`"states"."confirmed" AND NOT "states"."spent"`)
-		needsStatusJoins = false
 	} else {
-		whereClause, isPlainDB = whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Spent")
+		whereClause = whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Spent")
+		needsStatusJoins = true
 	}
-	if isPlainDB {
-		return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
-			if needsStatusJoins {
-				q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
-					Joins("Spent", dbTX.DB(ctx).Select("transaction"))
-			}
-
-			if len(options.ExcludedIDs) > 0 {
-				q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
-			}
-
-			// Scope the query based on the status qualifier
-			q = q.Where(whereClause)
-
-			if options.QueryModifier != nil {
-				q = options.QueryModifier(dbTX, q)
-			}
-			return q
-		})
-	}
-
-	// Otherwise, we need to run it against the specified domain context
-	var dqc components.DomainQueryContext
-	dcID, err := uuid.Parse(string(options.StatusQualifier))
-	if err == nil {
-		if dqc = ss.GetDomainQueryContext(ctx, dcID); dqc == nil {
-			err = i18n.NewError(ctx, msgs.MsgStateDomainContextNotActive, dcID)
+	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
+		if needsStatusJoins {
+			q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
+				Joins("Spent", dbTX.DB(ctx).Select("transaction"))
 		}
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-	return dqc.FindAvailableStates(ctx, dbTX, schemaID, jq)
+
+		if len(options.ExcludedIDs) > 0 {
+			q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
+		}
+
+		// Scope the query based on the status qualifier
+		q = q.Where(whereClause)
+
+		if options.QueryModifier != nil {
+			q = options.QueryModifier(dbTX, q)
+		}
+		return q
+	})
 }
 
 func (ss *stateManager) findNullifiers(
@@ -413,47 +397,31 @@ func (ss *stateManager) findNullifiers(
 	if options.StatusQualifier == "" {
 		options.StatusQualifier = pldapi.StateStatusAll
 	}
-	whereClause, isPlainDB := whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Nullifier__Spent")
-	if isPlainDB {
-		schema, s, err = ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
-			hasNullifier := dbTX.DB(ctx).Where(`"Nullifier"."id" IS NOT NULL`)
+	whereClause := whereClauseForQual(dbTX.DB(ctx), options.StatusQualifier, "Nullifier__Spent")
+	return ss.findStatesCommon(ctx, dbTX, domainName, contractAddress, schemaID, jq, func(dbTX persistence.DBTX, q *gorm.DB) *gorm.DB {
+		hasNullifier := dbTX.DB(ctx).Where(`"Nullifier"."id" IS NOT NULL`)
 
-			q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
-				Joins("Nullifier", dbTX.DB(ctx).Select(`"Nullifier"."id"`)).
-				Joins("Nullifier.Spent", dbTX.DB(ctx).Select("transaction")).
-				Where(hasNullifier)
+		q = q.Joins("Confirmed", dbTX.DB(ctx).Select("transaction")).
+			Joins("Nullifier", dbTX.DB(ctx).Select(`"Nullifier"."id"`)).
+			Joins("Nullifier.Spent", dbTX.DB(ctx).Select("transaction")).
+			Where(hasNullifier)
 
-			if len(options.ExcludedIDs) > 0 {
-				q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
-			}
-			if len(options.ExcludedNullifierIDs) > 0 {
-				q = q.Not(`"Nullifier"."id" IN(?)`, options.ExcludedNullifierIDs)
-			}
-
-			// Scope to only unspent
-			q = q.Where(whereClause)
-
-			if options.QueryModifier != nil {
-				q = options.QueryModifier(dbTX, q)
-			}
-
-			return q
-		})
-		return schema, s, err
-	}
-
-	// Otherwise, we need to run it against the specified domain context
-	var dqc components.DomainQueryContext
-	dcID, err := uuid.Parse(string(options.StatusQualifier))
-	if err == nil {
-		if dqc = ss.GetDomainQueryContext(ctx, dcID); dqc == nil {
-			err = i18n.NewError(ctx, msgs.MsgStateDomainContextNotActive, dcID)
+		if len(options.ExcludedIDs) > 0 {
+			q = q.Not(`"states"."id" IN(?)`, options.ExcludedIDs)
 		}
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-	return dqc.FindAvailableNullifiers(ctx, dbTX, schemaID, jq)
+		if len(options.ExcludedNullifierIDs) > 0 {
+			q = q.Not(`"Nullifier"."id" IN(?)`, options.ExcludedNullifierIDs)
+		}
+
+		// Scope to only unspent
+		q = q.Where(whereClause)
+
+		if options.QueryModifier != nil {
+			q = options.QueryModifier(dbTX, q)
+		}
+
+		return q
+	})
 }
 
 func (ss *stateManager) findStatesCommon(

--- a/core/go/internal/statemgr/state_availability.go
+++ b/core/go/internal/statemgr/state_availability.go
@@ -26,7 +26,7 @@ import (
 )
 
 // The confirmed/spent columns on the states table are denormalized from state_confirm_records/state_spend_records
-// so the "available" query can use the states_available partial index instead of anti-joining the
+// so the "confirmed" query can use the states_available partial index instead of anti-joining the
 // ever-growing record tables.
 //
 // Private state data are distibuted off chain via reliable messaging, whereas confirm/spend records

--- a/core/go/internal/statemgr/state_status_qualifier.go
+++ b/core/go/internal/statemgr/state_status_qualifier.go
@@ -23,33 +23,20 @@ import (
 	"gorm.io/gorm"
 )
 
-// Only called for one of the static qualifiers - not for a domain context
-func whereClauseForQual(db *gorm.DB /* must be the DB not the query */, q pldapi.StateStatusQualifier, spentColumn string) (*gorm.DB, bool) {
+// whereClauseForQual scopes a query to the states matching a status qualifier, expressed through the
+// Confirmed join and the given spend join. Confirmed is a synonym of available - a state is
+// confirmed for use only while it is also unspent - so both select the same states.
+func whereClauseForQual(db *gorm.DB /* must be the DB not the query */, q pldapi.StateStatusQualifier, spentColumn string) *gorm.DB {
 	switch q {
-	case pldapi.StateStatusAvailable:
+	case pldapi.StateStatusAvailable, pldapi.StateStatusConfirmed:
 		return db.
-				Where(fmt.Sprintf(`"%s"."transaction" IS NULL`, spentColumn)).
-				Where(`"Confirmed"."transaction" IS NOT NULL`),
-			true
-	case pldapi.StateStatusConfirmed:
-		return db.
-				Where(`"Confirmed"."transaction" IS NOT NULL`).
-				Where(fmt.Sprintf(`"%s"."transaction" IS NULL`, spentColumn)),
-			true
+			Where(fmt.Sprintf(`"%s"."transaction" IS NULL`, spentColumn)).
+			Where(`"Confirmed"."transaction" IS NOT NULL`)
 	case pldapi.StateStatusUnconfirmed:
-		return db.
-				Where(`"Confirmed"."transaction" IS NULL`),
-			true
+		return db.Where(`"Confirmed"."transaction" IS NULL`)
 	case pldapi.StateStatusSpent:
-		return db.
-				Where(fmt.Sprintf(`"%s"."transaction" IS NOT NULL`, spentColumn)),
-			true
-	case pldapi.StateStatusAll:
-		return db.Where("TRUE"),
-			true
-	default:
-		// This is a domain context query - so the caller should pass it to the appropriate domain context
-		// rather than just executing the query directly against the DB
-		return nil, false
+		return db.Where(fmt.Sprintf(`"%s"."transaction" IS NOT NULL`, spentColumn))
+	default: // pldapi.StateStatusAll, which is also what the reader defaults an unset qualifier to
+		return db.Where("TRUE")
 	}
 }

--- a/core/go/internal/statemgr/state_status_qualifier.go
+++ b/core/go/internal/statemgr/state_status_qualifier.go
@@ -36,7 +36,7 @@ func whereClauseForQual(db *gorm.DB /* must be the DB not the query */, q pldapi
 		return db.Where(`"Confirmed"."transaction" IS NULL`)
 	case pldapi.StateStatusSpent:
 		return db.Where(fmt.Sprintf(`"%s"."transaction" IS NOT NULL`, spentColumn))
-	default: // pldapi.StateStatusAll, which is also what the reader defaults an unset qualifier to
+	default: // pldapi.StateStatusAll, and an unset qualifier, which also means all
 		return db.Where("TRUE")
 	}
 }

--- a/core/go/internal/statemgr/state_status_qualifier.go
+++ b/core/go/internal/statemgr/state_status_qualifier.go
@@ -24,11 +24,11 @@ import (
 )
 
 // whereClauseForQual scopes a query to the states matching a status qualifier, expressed through the
-// Confirmed join and the given spend join. Confirmed is a synonym of available - a state is
-// confirmed for use only while it is also unspent - so both select the same states.
+// Confirmed join and the given spend join. A state is confirmed for use only while it is also
+// unspent, so the confirmed qualifier requires a confirm record and no spend record.
 func whereClauseForQual(db *gorm.DB /* must be the DB not the query */, q pldapi.StateStatusQualifier, spentColumn string) *gorm.DB {
 	switch q {
-	case pldapi.StateStatusAvailable, pldapi.StateStatusConfirmed:
+	case pldapi.StateStatusConfirmed:
 		return db.
 			Where(fmt.Sprintf(`"%s"."transaction" IS NULL`, spentColumn)).
 			Where(`"Confirmed"."transaction" IS NOT NULL`)

--- a/core/go/internal/statemgr/state_status_qualifier_test.go
+++ b/core/go/internal/statemgr/state_status_qualifier_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence/mockpersistence"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
@@ -90,7 +89,7 @@ func TestFindStatesUnsetQualifier(t *testing.T) {
 	mockGetSchemaOK(mdb)
 	mdb.ExpectQuery(`SELECT.*FROM "states".*WHERE.*TRUE`).WillReturnError(fmt.Errorf("called"))
 
-	_, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", pldtypes.RandBytes32(),
-		query.NewQueryBuilder().Query(), &components.StateQueryOptions{})
+	_, _, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", nil, pldtypes.RandBytes32(),
+		query.NewQueryBuilder().Query(), "")
 	assert.Regexp(t, "called", err)
 }

--- a/core/go/internal/statemgr/state_status_qualifier_test.go
+++ b/core/go/internal/statemgr/state_status_qualifier_test.go
@@ -1,0 +1,96 @@
+// Copyright contributors to Paladin, an LFDT project
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statemgr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/LFDT-Paladin/paladin/core/internal/components"
+	"github.com/LFDT-Paladin/paladin/core/pkg/persistence/mockpersistence"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldapi"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
+	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// qualifierSQL returns the WHERE clause whereClauseForQual builds for a qualifier, as SQL.
+func qualifierSQL(t *testing.T, q pldapi.StateStatusQualifier, spentColumn string) string {
+	p, err := mockpersistence.NewSQLMockProvider()
+	require.NoError(t, err)
+	ctx := context.Background()
+	return p.P.DB(ctx).ToSQL(func(tx *gorm.DB) *gorm.DB {
+		var count int64
+		db := tx.Table("states").Where(whereClauseForQual(p.P.DB(ctx), q, spentColumn)).Count(&count)
+		require.NoError(t, db.Error)
+		return db
+	})
+}
+
+func TestWhereClauseForQual(t *testing.T) {
+	// Available requires a confirm record and no spend record
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE "Spent"."transaction" IS NULL AND "Confirmed"."transaction" IS NOT NULL`,
+		qualifierSQL(t, pldapi.StateStatusAvailable, "Spent"))
+
+	// Confirmed is a synonym of available, selecting via the identical clause
+	require.Equal(t,
+		qualifierSQL(t, pldapi.StateStatusAvailable, "Spent"),
+		qualifierSQL(t, pldapi.StateStatusConfirmed, "Spent"))
+
+	// Unconfirmed requires no confirm record, and says nothing about spending
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE "Confirmed"."transaction" IS NULL`,
+		qualifierSQL(t, pldapi.StateStatusUnconfirmed, "Spent"))
+
+	// Spent requires a spend record, and says nothing about confirmation
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE "Spent"."transaction" IS NOT NULL`,
+		qualifierSQL(t, pldapi.StateStatusSpent, "Spent"))
+
+	// All scopes nothing
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE TRUE`,
+		qualifierSQL(t, pldapi.StateStatusAll, "Spent"))
+
+	// The spend column is a parameter, so nullifier queries scope on the nullifier's spend record
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE "Nullifier__Spent"."transaction" IS NULL AND "Confirmed"."transaction" IS NOT NULL`,
+		qualifierSQL(t, pldapi.StateStatusAvailable, "Nullifier__Spent"))
+
+	// An empty qualifier means all, matching the default the reader applies before calling here
+	require.Equal(t,
+		`SELECT count(*) FROM "states" WHERE TRUE`,
+		qualifierSQL(t, pldapi.StateStatusQualifier(""), "Spent"))
+}
+
+// TestFindStatesUnsetQualifier proves the reader treats an unset qualifier as all, scoping the
+// query on TRUE rather than on any confirm/spend predicate.
+func TestFindStatesUnsetQualifier(t *testing.T) {
+	ctx, ss, mdb, _, done := newDBMockStateManager(t)
+	defer done()
+
+	mockGetSchemaOK(mdb)
+	mdb.ExpectQuery(`SELECT.*FROM "states".*WHERE.*TRUE`).WillReturnError(fmt.Errorf("called"))
+
+	_, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", pldtypes.RandBytes32(),
+		query.NewQueryBuilder().Query(), &components.StateQueryOptions{})
+	assert.Regexp(t, "called", err)
+}

--- a/core/go/internal/statemgr/state_status_qualifier_test.go
+++ b/core/go/internal/statemgr/state_status_qualifier_test.go
@@ -44,14 +44,9 @@ func qualifierSQL(t *testing.T, q pldapi.StateStatusQualifier, spentColumn strin
 }
 
 func TestWhereClauseForQual(t *testing.T) {
-	// Available requires a confirm record and no spend record
+	// Confirmed requires a confirm record and no spend record
 	require.Equal(t,
 		`SELECT count(*) FROM "states" WHERE "Spent"."transaction" IS NULL AND "Confirmed"."transaction" IS NOT NULL`,
-		qualifierSQL(t, pldapi.StateStatusAvailable, "Spent"))
-
-	// Confirmed is a synonym of available, selecting via the identical clause
-	require.Equal(t,
-		qualifierSQL(t, pldapi.StateStatusAvailable, "Spent"),
 		qualifierSQL(t, pldapi.StateStatusConfirmed, "Spent"))
 
 	// Unconfirmed requires no confirm record, and says nothing about spending
@@ -72,7 +67,7 @@ func TestWhereClauseForQual(t *testing.T) {
 	// The spend column is a parameter, so nullifier queries scope on the nullifier's spend record
 	require.Equal(t,
 		`SELECT count(*) FROM "states" WHERE "Nullifier__Spent"."transaction" IS NULL AND "Confirmed"."transaction" IS NOT NULL`,
-		qualifierSQL(t, pldapi.StateStatusAvailable, "Nullifier__Spent"))
+		qualifierSQL(t, pldapi.StateStatusConfirmed, "Nullifier__Spent"))
 
 	// An empty qualifier means all, matching the default the reader applies before calling here
 	require.Equal(t,

--- a/core/go/internal/statemgr/state_status_test.go
+++ b/core/go/internal/statemgr/state_status_test.go
@@ -150,7 +150,6 @@ func TestStateLockingQuery(t *testing.T) {
 	schemaID := schema.ID()
 
 	contractAddress, dqc := newTestDomainContext(t, ctx, ss, "domain1", false)
-	seqQual := pldapi.StateStatusQualifier(dqc.ID().String())
 
 	widgets := makeWidgets(t, ctx, ss, "domain1", contractAddress, schemaID, []string{
 		`{"size": 11111, "color": "red",  "price": 100}`,
@@ -160,9 +159,7 @@ func TestStateLockingQuery(t *testing.T) {
 		`{"size": 55555, "color": "blue", "price": 500}`,
 	})
 
-	checkQuery := func(jq *query.QueryJSON, status pldapi.StateStatusQualifier, expected ...int) {
-		states, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, jq, status)
-		require.NoError(t, err)
+	checkStates := func(states []*pldapi.State, expected ...int) {
 		assert.Len(t, states, len(expected))
 		for _, wIndex := range expected {
 			found := false
@@ -177,9 +174,24 @@ func TestStateLockingQuery(t *testing.T) {
 		}
 	}
 
+	// checkQuery asserts what the query API returns for a status qualifier.
+	checkQuery := func(jq *query.QueryJSON, status pldapi.StateStatusQualifier, expected ...int) {
+		states, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, jq, status)
+		require.NoError(t, err)
+		checkStates(states, expected...)
+	}
+
+	// checkContextQuery asserts what the current domain query context returns as available: the DB
+	// available states merged with the states its remote view serves.
+	checkContextQuery := func(jq *query.QueryJSON, expected ...int) {
+		_, states, err := dqc.FindAvailableStates(ctx, ss.p.NOTX(), schemaID, jq)
+		require.NoError(t, err)
+		checkStates(states, expected...)
+	}
+
 	// setTestRemoteView closes the current context and opens a fresh one whose remote view serves
-	// the given ahead-of-chain candidates and spent-state exclusion set, updating dqc and its
-	// seqQual (a view is fixed for a context's life). Which states the coordinator serves as
+	// the given ahead-of-chain candidates and spent-state exclusion set, updating dqc (a view is
+	// fixed for a context's life). Which states the coordinator serves as
 	// candidates vs. exclusions is its business, not under test here — each call just states the
 	// response the view gives.
 	setTestRemoteView := func(candidateStates []*prototk.EndorsableState, spentStateIDs ...pldtypes.HexBytes) {
@@ -191,20 +203,19 @@ func TestStateLockingQuery(t *testing.T) {
 			require.NoError(t, err)
 			candidates = append(candidates, snapshotStateOf(sw, 0))
 		}
-		dqc.Close(ctx)
 		dqc = newTestAssemblyContext(t, ctx, ss, "domain1", false, contractAddress,
 			&testRemoteView{ss: ss, domainName: "domain1", candidates: candidates, spentStateIDs: spentStateIDs})
-		seqQual = pldapi.StateStatusQualifier(dqc.ID().String())
 	}
 
 	all := query.NewQueryBuilder().Query()
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4)
+	// Confirmed is a synonym of available, so it must track it exactly throughout
 	checkQuery(all, pldapi.StateStatusAvailable)
 	checkQuery(all, pldapi.StateStatusConfirmed)
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 0, 1, 2, 3, 4)
 	checkQuery(all, pldapi.StateStatusSpent)
-	checkQuery(all, seqQual)
+	checkContextQuery(all)
 
 	// Mark them all confirmed apart from one
 	for i, w := range widgets {
@@ -222,7 +233,7 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 0, 1, 2, 4) // added all but 3
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // added 3
 	checkQuery(all, pldapi.StateStatusSpent)                 // unchanged
-	checkQuery(all, seqQual, 0, 1, 2, 4)                     // added all but 3
+	checkContextQuery(all, 0, 1, 2, 4)                       // added all but 3
 
 	// Mark one spent
 	err = ss.WriteStateFinalizations(ss.bgCtx, ss.p.NOTX(),
@@ -236,10 +247,10 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4) // removed 0
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)           // added 0
-	checkQuery(all, seqQual, 1, 2, 4)                     // unchanged
+	checkContextQuery(all, 1, 2, 4)                       // unchanged
 
 	// Write widget[5] to DB (unconfirmed) via WritePreVerifiedStates, then serve it via a fresh
-	// DomainQueryContext remote view so the seqQual query can see the creating state.
+	// DomainQueryContext remote view so the context query can see the creating state.
 	// This mirrors what the coordinator does: the DSW flushes the state to DB, then the
 	// assembler opens an assembly context wired to the coordinator's remote state view.
 	widget5State := genWidget(t, schemaID, `{"size": 66666, "color": "blue", "price": 600}`)
@@ -261,7 +272,7 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // added 5
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
-	checkQuery(all, seqQual, 1, 2, 4, 5)                     // added 5 (via the remote view)
+	checkContextQuery(all, 1, 2, 4, 5)                       // added 5 (via the remote view)
 
 	// The coordinator spend-locks widget[5]: its view stops serving it as a candidate and its ID
 	// joins the spent exclusion set.
@@ -272,7 +283,7 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
-	checkQuery(all, seqQual, 1, 2, 4)                        // removed 5
+	checkContextQuery(all, 1, 2, 4)                          // removed 5
 
 	// The spend lock is released: the new view serves widget[5] as a candidate again, with no
 	// exclusions.
@@ -283,7 +294,7 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
-	checkQuery(all, seqQual, 1, 2, 4, 5)                     // added 5 back
+	checkContextQuery(all, 1, 2, 4, 5)                       // added 5 back
 
 	// Mark widget[5] confirmed in DB
 	err = ss.WriteStateFinalizations(ss.bgCtx, ss.p.NOTX(),
@@ -298,23 +309,20 @@ func TestStateLockingQuery(t *testing.T) {
 
 	// Close the old DQC and open a fresh one with no remote view.
 	// Widget[5] is now confirmed in DB so it is visible via DB-available queries without a remote view.
-	dqc.Close(ctx)
 	md2 := componentsmocks.NewDomain(t)
 	md2.On("Name").Return("domain1")
 	md2.On("CustomHashFunction").Return(false)
 	dqc = ss.NewDomainQueryContext(ctx, md2, *contractAddress).(*domainQueryContext)
-	defer dqc.Close(ctx)
-	seqQual = pldapi.StateStatusQualifier(dqc.ID().String())
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
 	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4, 5) // added 5
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4, 5) // added 5
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // removed 5
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
-	checkQuery(all, seqQual, 1, 2, 4, 5)                     // unchanged (5 now confirmed in DB)
+	checkContextQuery(all, 1, 2, 4, 5)                       // unchanged (5 now confirmed in DB)
 
 	// Serve widget[3] via a new remote view: it's unconfirmed in DB (never confirmed above) but
-	// the seqQual can see it once the coordinator's view serves it as a candidate.
+	// the context can see it once the coordinator's view serves it as a candidate.
 	setTestRemoteView([]*prototk.EndorsableState{{SchemaId: schemaID.String(), StateDataJson: string(widgets[3].Data), Id: widgets[3].ID.String()}})
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
@@ -322,10 +330,10 @@ func TestStateLockingQuery(t *testing.T) {
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4, 5) // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
-	checkQuery(all, seqQual, 1, 2, 3, 4, 5)                  // added 3 (via the remote view)
+	checkContextQuery(all, 1, 2, 3, 4, 5)                    // added 3 (via the remote view)
 
 	// check a sub-select
-	checkQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), seqQual, 3)
+	checkContextQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), 3)
 	checkQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), pldapi.StateStatusAvailable)
 
 }

--- a/core/go/internal/statemgr/state_status_test.go
+++ b/core/go/internal/statemgr/state_status_test.go
@@ -176,7 +176,7 @@ func TestStateLockingQuery(t *testing.T) {
 
 	// checkQuery asserts what the query API returns for a status qualifier.
 	checkQuery := func(jq *query.QueryJSON, status pldapi.StateStatusQualifier, expected ...int) {
-		states, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, jq, status)
+		_, states, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, jq, status)
 		require.NoError(t, err)
 		checkStates(states, expected...)
 	}
@@ -380,9 +380,9 @@ func TestAvailabilityFlagsReconcileOnLateArrival(t *testing.T) {
 	require.NoError(t, err)
 
 	findAvailable := func() []*pldapi.State {
-		s, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", schemaID,
+		_, s, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", nil, schemaID,
 			query.NewQueryBuilder().Query(),
-			&components.StateQueryOptions{StatusQualifier: pldapi.StateStatusAvailable})
+			pldapi.StateStatusAvailable)
 		require.NoError(t, err)
 		return s
 	}

--- a/core/go/internal/statemgr/state_status_test.go
+++ b/core/go/internal/statemgr/state_status_test.go
@@ -210,8 +210,6 @@ func TestStateLockingQuery(t *testing.T) {
 	all := query.NewQueryBuilder().Query()
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4)
-	// Confirmed is a synonym of available, so it must track it exactly throughout
-	checkQuery(all, pldapi.StateStatusAvailable)
 	checkQuery(all, pldapi.StateStatusConfirmed)
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 0, 1, 2, 3, 4)
 	checkQuery(all, pldapi.StateStatusSpent)
@@ -229,7 +227,6 @@ func TestStateLockingQuery(t *testing.T) {
 	}
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4)    // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 0, 1, 2, 4) // added all but 3
 	checkQuery(all, pldapi.StateStatusConfirmed, 0, 1, 2, 4) // added all but 3
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // added 3
 	checkQuery(all, pldapi.StateStatusSpent)                 // unchanged
@@ -243,7 +240,6 @@ func TestStateLockingQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4) // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4) // removed 0
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4) // removed 0
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)           // added 0
@@ -268,7 +264,6 @@ func TestStateLockingQuery(t *testing.T) {
 	setTestRemoteView([]*prototk.EndorsableState{widget5State})
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // added 5
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // added 5
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
@@ -279,7 +274,6 @@ func TestStateLockingQuery(t *testing.T) {
 	setTestRemoteView(nil, widgets[5].ID)
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
@@ -290,7 +284,6 @@ func TestStateLockingQuery(t *testing.T) {
 	setTestRemoteView([]*prototk.EndorsableState{widget5State})
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4)    // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3, 5)     // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
@@ -315,7 +308,6 @@ func TestStateLockingQuery(t *testing.T) {
 	dqc = ss.NewDomainQueryContext(ctx, md2, *contractAddress).(*domainQueryContext)
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4, 5) // added 5
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4, 5) // added 5
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // removed 5
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
@@ -326,7 +318,6 @@ func TestStateLockingQuery(t *testing.T) {
 	setTestRemoteView([]*prototk.EndorsableState{{SchemaId: schemaID.String(), StateDataJson: string(widgets[3].Data), Id: widgets[3].ID.String()}})
 
 	checkQuery(all, pldapi.StateStatusAll, 0, 1, 2, 3, 4, 5) // unchanged
-	checkQuery(all, pldapi.StateStatusAvailable, 1, 2, 4, 5) // unchanged
 	checkQuery(all, pldapi.StateStatusConfirmed, 1, 2, 4, 5) // unchanged
 	checkQuery(all, pldapi.StateStatusUnconfirmed, 3)        // unchanged
 	checkQuery(all, pldapi.StateStatusSpent, 0)              // unchanged
@@ -334,7 +325,7 @@ func TestStateLockingQuery(t *testing.T) {
 
 	// check a sub-select
 	checkContextQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), 3)
-	checkQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), pldapi.StateStatusAvailable)
+	checkQuery(query.NewQueryBuilder().Equal("color", "pink").Query(), pldapi.StateStatusConfirmed)
 
 }
 
@@ -382,7 +373,7 @@ func TestAvailabilityFlagsReconcileOnLateArrival(t *testing.T) {
 	findAvailable := func() []*pldapi.State {
 		_, s, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", nil, schemaID,
 			query.NewQueryBuilder().Query(),
-			pldapi.StateStatusAvailable)
+			pldapi.StateStatusConfirmed)
 		require.NoError(t, err)
 		return s
 	}

--- a/core/go/internal/statemgr/state_test.go
+++ b/core/go/internal/statemgr/state_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
 func TestPersistStateMissingSchema(t *testing.T) {
@@ -103,7 +102,7 @@ func TestFindStatesMissingSchema(t *testing.T) {
 	db.ExpectQuery("SELECT").WillReturnRows(db.NewRows([]string{}))
 
 	contractAddress := pldtypes.RandAddress()
-	_, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, pldtypes.Bytes32Keccak(([]byte)("schema1")), &query.QueryJSON{}, "all")
+	_, _, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", contractAddress, pldtypes.Bytes32Keccak(([]byte)("schema1")), &query.QueryJSON{}, "all")
 	assert.Regexp(t, "PD010106", err)
 }
 
@@ -118,7 +117,7 @@ func TestFindStatesBadQuery(t *testing.T) {
 	})
 
 	contractAddress := pldtypes.RandAddress()
-	_, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, &query.QueryJSON{
+	_, _, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, &query.QueryJSON{
 		Statements: query.Statements{
 			Ops: query.Ops{
 				Equal: []*query.OpSingleVal{
@@ -145,7 +144,7 @@ func TestFindStatesFail(t *testing.T) {
 	db.ExpectQuery("SELECT.*created").WillReturnError(fmt.Errorf("pop"))
 
 	contractAddress := pldtypes.RandAddress()
-	_, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, &query.QueryJSON{
+	_, _, err := ss.findStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, &query.QueryJSON{
 		Statements: query.Statements{
 			Ops: query.Ops{
 				GreaterThan: []*query.OpSingleVal{
@@ -250,37 +249,6 @@ func TestWriteNullifiersForReceivedStatesBadDomain(t *testing.T) {
 		},
 	})
 	assert.Regexp(t, "not found", err)
-
-}
-
-func TestFindStatesWithAdvancedDBQueryModifier(t *testing.T) {
-	ctx, ss, mdb, _, done := newDBMockStateManager(t)
-	defer done()
-
-	mockGetSchemaOK(mdb)
-	mdb.ExpectQuery(`SELECT.*FROM "states".*LEFT JOIN "another_table".*"j"."state_id" IS NOT NULL`).
-		WillReturnError(fmt.Errorf("called"))
-
-	_, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", pldtypes.RandBytes32(), query.NewQueryBuilder().Query(), &components.StateQueryOptions{
-		QueryModifier: func(db persistence.DBTX, query *gorm.DB) *gorm.DB {
-			return query.
-				Joins(`LEFT JOIN "another_table" AS "j" WHERE "j"."state_id" = "states"."id"`).
-				Where(`"j"."state_id" IS NOT NULL`)
-		},
-	})
-	assert.Regexp(t, "called", err)
-
-}
-
-func TestFindStatesWithNilOptions(t *testing.T) {
-	ctx, ss, mdb, _, done := newDBMockStateManager(t)
-	defer done()
-
-	mockGetSchemaOK(mdb)
-	mdb.ExpectQuery(`SELECT.*FROM`).WillReturnError(fmt.Errorf("called"))
-
-	_, err := ss.FindStates(ctx, ss.p.NOTX(), "domain1", pldtypes.RandBytes32(), query.NewQueryBuilder().Query(), nil)
-	assert.Regexp(t, "called", err)
 
 }
 

--- a/core/go/internal/statemgr/state_test.go
+++ b/core/go/internal/statemgr/state_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/LFDT-Paladin/paladin/core/internal/components"
 	"github.com/LFDT-Paladin/paladin/core/mocks/componentsmocks"
 	"github.com/LFDT-Paladin/paladin/core/pkg/persistence"
@@ -30,7 +29,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/query"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
-	"github.com/google/uuid"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -162,27 +160,6 @@ func TestFindStatesFail(t *testing.T) {
 
 }
 
-func TestFindStatesUnknownContext(t *testing.T) {
-	ctx, ss, _, _, done := newDBMockStateManager(t)
-	defer done()
-
-	schemaID := pldtypes.Bytes32Keccak(([]byte)("schema1"))
-	contractAddress := pldtypes.RandAddress()
-	_, err := ss.FindContractStates(ctx, ss.p.NOTX(), "domain1", contractAddress, schemaID, &query.QueryJSON{
-		Statements: query.Statements{
-			Ops: query.Ops{
-				GreaterThan: []*query.OpSingleVal{
-					{Op: query.Op{
-						Field: ".created",
-					}, Value: pldtypes.RawJSON(fmt.Sprintf("%d", time.Now().UnixNano()))},
-				},
-			},
-		},
-	}, pldapi.StateStatusQualifier(uuid.NewString()))
-	assert.Regexp(t, "PD010123", err)
-
-}
-
 func TestWritePreVerifiedStateInvalidDomain(t *testing.T) {
 	ctx, ss, _, m, done := newDBMockStateManager(t)
 	defer done()
@@ -273,55 +250,6 @@ func TestWriteNullifiersForReceivedStatesBadDomain(t *testing.T) {
 		},
 	})
 	assert.Regexp(t, "not found", err)
-
-}
-
-func TestFindNullifiersInContext(t *testing.T) {
-	ctx, ss, db, _, done := newDBMockStateManager(t)
-	defer done()
-
-	db.ExpectQuery("SELECT.*states").WillReturnRows(sqlmock.NewRows([]string{}))
-
-	schemaID := pldtypes.Bytes32Keccak(([]byte)("schema1"))
-	cacheKey := schemaCacheKey("domain1", schemaID)
-	ss.abiSchemaCache.Set(cacheKey, &abiSchema{
-		definition: &abi.Parameter{},
-		Schema:     &pldapi.Schema{},
-	})
-
-	td := componentsmocks.NewDomain(t)
-	td.On("Name").Return("domain1")
-	td.On("CustomHashFunction").Return(false)
-
-	dqc := ss.NewDomainQueryContext(ctx, td, *pldtypes.RandAddress())
-	defer dqc.Close(ctx)
-
-	contractAddress := pldtypes.RandAddress()
-	results, err := ss.FindContractNullifiers(ctx, ss.p.NOTX(), "domain1", *contractAddress, schemaID,
-		query.NewQueryBuilder().Limit(1).Query(), pldapi.StateStatusQualifier(dqc.ID().String()))
-	require.NoError(t, err)
-	require.Empty(t, results)
-
-}
-
-func TestFindNullifiersUnknownContext(t *testing.T) {
-	ctx, ss, _, _, done := newDBMockStateManager(t)
-	defer done()
-
-	schemaID := pldtypes.Bytes32Keccak(([]byte)("schema1"))
-	contractAddress := pldtypes.RandAddress()
-	_, err := ss.FindContractNullifiers(ctx, ss.p.NOTX(), "domain1", *contractAddress, schemaID, &query.QueryJSON{
-		Statements: query.Statements{
-			Ops: query.Ops{
-				GreaterThan: []*query.OpSingleVal{
-					{Op: query.Op{
-						Field: ".created",
-					}, Value: pldtypes.RawJSON(fmt.Sprintf("%d", time.Now().UnixNano()))},
-				},
-			},
-		},
-	}, pldapi.StateStatusQualifier(uuid.NewString()))
-	assert.Regexp(t, "PD010123", err)
 
 }
 

--- a/core/go/internal/statemgr/statestore.go
+++ b/core/go/internal/statemgr/statestore.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/config/pkg/pldconf"
@@ -44,8 +43,6 @@ type stateManager struct {
 	abiSchemaCache      cache.Cache[string, components.Schema]
 	validatedStateCache cache.Cache[string, *components.StateWithLabels]
 	rpcModule           *rpcserver.RPCModule
-	domainContextLock   sync.Mutex
-	domainContexts      map[uuid.UUID]*domainQueryContext
 }
 
 type logStateSpendRecords []*pldapi.StateSpendRecord
@@ -95,7 +92,6 @@ func NewStateManager(ctx context.Context, conf *pldconf.StateStoreConfig, p pers
 		abiSchemaCache: cache.NewCache[string, components.Schema](&conf.SchemaCache, &pldconf.StateStoreConfigDefaults.SchemaCache),
 		validatedStateCache: cache.NewCache[string, *components.StateWithLabels](
 			&conf.ValidatedStateCache, &pldconf.StateStoreConfigDefaults.ValidatedStateCache),
-		domainContexts: make(map[uuid.UUID]*domainQueryContext),
 	}
 	ss.bgCtx, ss.cancelCtx = context.WithCancel(log.WithComponent(ctx, "statemanager"))
 	return ss

--- a/core/go/internal/statemgr/statestore_rpc.go
+++ b/core/go/internal/statemgr/statestore_rpc.go
@@ -88,7 +88,8 @@ func (ss *stateManager) rpcQueryStates() rpcserver.RPCHandler {
 		status pldapi.StateStatusQualifier,
 	) ([]*pldapi.State, error) {
 		ctx = log.WithComponent(ctx, "statemanager")
-		return ss.FindStates(ctx, ss.p.NOTX(), domain, schema, &query, &components.StateQueryOptions{StatusQualifier: status})
+		_, states, err := ss.findStates(ctx, ss.p.NOTX(), domain, nil, schema, &query, status)
+		return states, err
 	})
 }
 
@@ -101,7 +102,8 @@ func (ss *stateManager) rpcQueryContractStates() rpcserver.RPCHandler {
 		status pldapi.StateStatusQualifier,
 	) ([]*pldapi.State, error) {
 		ctx = log.WithComponent(ctx, "statemanager")
-		return ss.FindContractStates(ctx, ss.p.NOTX(), domain, contractAddress, schema, &query, status)
+		_, states, err := ss.findStates(ctx, ss.p.NOTX(), domain, contractAddress, schema, &query, status)
+		return states, err
 	})
 }
 
@@ -113,7 +115,8 @@ func (ss *stateManager) rpcQueryNullifiers() rpcserver.RPCHandler {
 		status pldapi.StateStatusQualifier,
 	) ([]*pldapi.State, error) {
 		ctx = log.WithComponent(ctx, "statemanager")
-		return ss.FindNullifiers(ctx, ss.p.NOTX(), domain, schema, &query, status)
+		_, states, err := ss.findNullifierBackedStates(ctx, ss.p.NOTX(), domain, nil, schema, &query, status, nil)
+		return states, err
 	})
 }
 
@@ -126,7 +129,8 @@ func (ss *stateManager) rpcQueryContractNullifiers() rpcserver.RPCHandler {
 		status pldapi.StateStatusQualifier,
 	) ([]*pldapi.State, error) {
 		ctx = log.WithComponent(ctx, "statemanager")
-		return ss.FindContractNullifiers(ctx, ss.p.NOTX(), domain, contractAddress, schema, &query, status)
+		_, states, err := ss.findNullifierBackedStates(ctx, ss.p.NOTX(), domain, &contractAddress, schema, &query, status, nil)
+		return states, err
 	})
 }
 

--- a/core/go/internal/statemgr/statestore_rpc_test.go
+++ b/core/go/internal/statemgr/statestore_rpc_test.go
@@ -169,6 +169,42 @@ func TestRPC(t *testing.T) {
 
 }
 
+// TestRPCQueryHandlersValidateQualifier calls each pstate query handler directly, checking an
+// unrecognised qualifier - including a transaction UUID - is rejected as the request is parsed,
+// before any query runs, so no DB interaction is mocked.
+func TestRPCQueryHandlersValidateQualifier(t *testing.T) {
+	ctx, ss, _, _, done := newDBMockStateManager(t)
+	defer done()
+
+	domain := pldtypes.JSONString("domain1")
+	schemaID := pldtypes.JSONString(pldtypes.RandBytes32())
+	contractAddress := pldtypes.JSONString(pldtypes.RandAddress())
+	emptyQuery := pldtypes.RawJSON(`{}`)
+
+	for _, qualifier := range []string{"wrong", uuid.NewString()} {
+		badQualifier := pldtypes.JSONString(qualifier)
+		for _, tc := range []struct {
+			method  string
+			handler rpcserver.RPCHandler
+			params  []pldtypes.RawJSON
+		}{
+			{"pstate_queryStates", ss.rpcQueryStates(), []pldtypes.RawJSON{domain, schemaID, emptyQuery, badQualifier}},
+			{"pstate_queryNullifiers", ss.rpcQueryNullifiers(), []pldtypes.RawJSON{domain, schemaID, emptyQuery, badQualifier}},
+			{"pstate_queryContractStates", ss.rpcQueryContractStates(), []pldtypes.RawJSON{domain, contractAddress, schemaID, emptyQuery, badQualifier}},
+			{"pstate_queryContractNullifiers", ss.rpcQueryContractNullifiers(), []pldtypes.RawJSON{domain, contractAddress, schemaID, emptyQuery, badQualifier}},
+		} {
+			resp := tc.handler.Handle(ctx, &rpcclient.RPCRequest{
+				JSONRpc: "2.0",
+				ID:      pldtypes.RawJSON(`"1"`),
+				Method:  tc.method,
+				Params:  tc.params,
+			})
+			require.NotNil(t, resp.Error, "%s accepted qualifier %q", tc.method, qualifier)
+			assert.Regexp(t, "PD020016", resp.Error.Message)
+		}
+	}
+}
+
 func TestRPCTransferState(t *testing.T) {
 	ctx, ss, c, m, done := newTestRPCServer(t)
 	defer done()

--- a/core/go/noderuntests/componenttest/component_test.go
+++ b/core/go/noderuntests/componenttest/component_test.go
@@ -1502,7 +1502,7 @@ func TestPrivacyGroupEndorsement(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bobSchemas, 1)
 
-	bobStates, err := bob.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, bobSchemas[0].ID, &query.QueryJSON{}, "available")
+	bobStates, err := bob.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, bobSchemas[0].ID, &query.QueryJSON{}, "confirmed")
 	require.NoError(t, err)
 	require.Len(t, bobStates, 1)
 	stateData := make(map[string]string)
@@ -1521,7 +1521,7 @@ func TestPrivacyGroupEndorsement(t *testing.T) {
 	require.Len(t, aliceSchemas, 1)
 	assert.Equal(t, bobSchemas[0].ID, aliceSchemas[0].ID)
 
-	aliceStates, err := alice.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, aliceSchemas[0].ID, &query.QueryJSON{}, "available")
+	aliceStates, err := alice.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, aliceSchemas[0].ID, &query.QueryJSON{}, "confirmed")
 
 	require.NoError(t, err)
 	require.Len(t, aliceStates, 1)
@@ -1662,16 +1662,16 @@ func TestPrivacyGroupEndorsementConcurrent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, schemas, 1)
 
-	aliceStates, err := alice.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "available")
+	aliceStates, err := alice.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "confirmed")
 	require.NoError(t, err)
 	require.Len(t, aliceStates, 1)
 
-	bobStates, err := bob.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "available")
+	bobStates, err := bob.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "confirmed")
 	require.NoError(t, err)
 	require.Len(t, bobStates, 1)
 	assert.Equal(t, aliceStates[0].Data, bobStates[0].Data)
 
-	carolStates, err := carol.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "available")
+	carolStates, err := carol.GetClient().StateStore().QueryContractStates(ctx, "simpleStorageDomain", *contractAddress, schemas[0].ID, &query.QueryJSON{}, "confirmed")
 	require.NoError(t, err)
 	require.Len(t, carolStates, 1)
 	assert.Equal(t, aliceStates[0].Data, carolStates[0].Data)

--- a/core/go/pkg/testbed/testbed_jsonrpc_actions.go
+++ b/core/go/pkg/testbed/testbed_jsonrpc_actions.go
@@ -272,7 +272,6 @@ func (tb *testbed) execPrivateTransaction(ctx context.Context, tx *testbedTransa
 
 	// Testbed uses a domain context for queries; writes go directly to the state manager below.
 	dqc := tb.c.StateManager().NewDomainQueryContext(ctx, tx.psc.Domain(), tx.psc.Address())
-	defer dqc.Close(ctx)
 
 	// First we call init on the smart contract to:
 	// - validate the transaction ABI is understood by the contract
@@ -551,7 +550,6 @@ func (tb *testbed) rpcTestbedCall() rpcserver.RPCHandler {
 		}
 
 		dqc := tb.c.StateManager().NewDomainQueryContext(ctx, tx.psc.Domain(), tx.psc.Address())
-		defer dqc.Close(ctx)
 
 		cv, err := tx.psc.ExecCall(ctx, dqc, tb.c.Persistence().NOTX(), tx.localTx, resolvedVerifiers)
 		if err != nil {

--- a/doc-site/docs/reference/types/_includes/statestatusqualifier_description.md
+++ b/doc-site/docs/reference/types/_includes/statestatusqualifier_description.md
@@ -1,8 +1,7 @@
 The following qualifiers can be used in queries to the state store:
 
 - `available` - states that have been confirmed by a blockchain transaction, and not yet been spent in a subsequent transaction
+- `confirmed` - a synonym of `available`: a state is only confirmed for use while it also remains unspent
 - `unconfirmed` - states where no transaction has yet been processed from the blockchain to confirm the state
-- `confirmed` - states that have not been marked spent as a result of indexing a blockchain transaction
-- `spent` - states that have not been marked spent as a result of indexing a blockchain transaction
+- `spent` - states that have been marked spent as a result of indexing a blockchain transaction
 - `all` - all states stored in this node, regardless of status
-- `[uuid]` - any other value is parsed as the UUID, and if there is an in-memory domain context active for that UUID the query is executed within that domain context

--- a/doc-site/docs/reference/types/_includes/statestatusqualifier_description.md
+++ b/doc-site/docs/reference/types/_includes/statestatusqualifier_description.md
@@ -1,7 +1,6 @@
 The following qualifiers can be used in queries to the state store:
 
-- `available` - states that have been confirmed by a blockchain transaction, and not yet been spent in a subsequent transaction
-- `confirmed` - a synonym of `available`: a state is only confirmed for use while it also remains unspent
 - `unconfirmed` - states where no transaction has yet been processed from the blockchain to confirm the state
+- `confirmed` - states that have been confirmed by a blockchain transaction, and not yet been spent in a subsequent transaction. A state is only confirmed for use while it also remains unspent.
 - `spent` - states that have been marked spent as a result of indexing a blockchain transaction
 - `all` - all states stored in this node, regardless of status

--- a/domains/integration-test/util.go
+++ b/domains/integration-test/util.go
@@ -238,7 +238,7 @@ notReady:
 			address,
 			coinSchemaID,
 			jq,
-			"available")
+			"confirmed")
 		if rpcerr != nil {
 			require.NoError(t, rpcerr)
 		}

--- a/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/DomainIntegrationTests.java
+++ b/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/DomainIntegrationTests.java
@@ -396,7 +396,7 @@ public class DomainIntegrationTests {
                     notoInstanceAddress,
                     notoSchema.id,
                     null,
-                    "available");
+                    "confirmed");
             assertEquals(1, notoStates.size());
             var notoCoin = mapper.convertValue(notoStates.getFirst(), NotoCoin.class);
             assertEquals("1000000", notoCoin.data.amount);

--- a/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/helpers/NotoHelper.java
+++ b/domains/pente/src/test/java/io/kaleido/paladin/pente/domain/helpers/NotoHelper.java
@@ -130,7 +130,7 @@ public class NotoHelper {
 
     public List<NotoCoin> queryStates(JsonHex.Bytes32 schemaID, JsonQuery.Query query) throws IOException {
         List<HashMap<String, Object>> states = testbed.getRpcClient().request("pstate_queryContractStates",
-                domainName, address, schemaID, query, "available");
+                domainName, address, schemaID, query, "confirmed");
         var mapper = new ObjectMapper();
         return states.stream().map(state -> mapper.convertValue(state, NotoCoin.class)).toList();
     }

--- a/operator/test/e2e/e2e_noto_pente_test.go
+++ b/operator/test/e2e/e2e_noto_pente_test.go
@@ -243,7 +243,7 @@ var _ = Describe("noto/pente - simple", Ordered, func() {
 			var coins []*nototypes.NotoCoinState
 			err = rpc[node].CallRPC(ctx, &coins, "pstate_queryContractStates", "noto", notoContract, notoCoinSchemaID,
 				query.NewQueryBuilder().Equal("owner", addr).Limit(100).Query(),
-				"available")
+				"confirmed")
 			Expect(err).To(BeNil())
 			balance := big.NewInt(0)
 			summary := make([]string, len(coins))

--- a/operator/test/e2e/e2e_zeto_test.go
+++ b/operator/test/e2e/e2e_zeto_test.go
@@ -150,7 +150,7 @@ var _ = Describe(fmt.Sprintf("zeto - %s", tokenType), Ordered, func() {
 			var coins []*zetotypes.ZetoCoinState
 			err = rpc[node].CallRPC(ctx, &coins, method, "zeto", zetoContract, zetoCoinSchemaID,
 				query.NewQueryBuilder().Equal("owner", addr).Limit(100).Query(),
-				"available")
+				"confirmed")
 			Expect(err).To(BeNil())
 			balance := big.NewInt(0)
 			summary := make([]string, len(coins))
@@ -269,7 +269,7 @@ var _ = Describe(fmt.Sprintf("zeto - %s", tokenType), Ordered, func() {
 			var coins []*zetotypes.ZetoCoinState
 			err := rpc[paladinPrefix+"1"].CallRPC(ctx, &coins, "pstate_queryContractStates", "zeto", zetoContract, zetoCoinSchemaID,
 				query.NewQueryBuilder().Equal("locked", true).Limit(1).Query(),
-				"available")
+				"confirmed")
 			Expect(err).To(BeNil())
 			Expect(coins).To(HaveLen(1))
 

--- a/sdk/go/pkg/pldapi/enum_test.go
+++ b/sdk/go/pkg/pldapi/enum_test.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,9 +47,4 @@ func TestStateStatusQualifierJSON(t *testing.T) {
 	err = json.Unmarshal(([]byte)(`"ALL"`), &q)
 	require.NoError(t, err)
 	require.Equal(t, StateStatusAll, q)
-
-	u := uuid.New().String()
-	err = json.Unmarshal(pldtypes.JSONString(u), &q)
-	require.NoError(t, err)
-	assert.Equal(t, u, (string)(q))
 }

--- a/sdk/go/pkg/pldapi/states.go
+++ b/sdk/go/pkg/pldapi/states.go
@@ -44,17 +44,27 @@ func (st SchemaType) Options() []string {
 	}
 }
 
-// Queries against the state store can be made in the context of a
-// transaction UUID, or one of the standard qualifiers
-// (confirmed/unconfirmed/spent/all)
+// Queries against the state store are qualified by the confirm/spend status of the states to
+// return, using one of the standard qualifiers below.
 //
-// Note this is not modelled as a normal Paladin Enum, as you can fall back to a UUID.
+// Note this is not modelled as a normal Paladin Enum, as the set of qualifiers is open to
+// extension with forms that are not a fixed list of options - such as a reference to a
+// particular point in the history of the chain.
 type StateStatusQualifier string
 
+// States with a confirmation record, and no spend record
 const StateStatusAvailable StateStatusQualifier = "available"
+
+// Synonym for StateStatusAvailable - a state is confirmed for use only while it is also unspent
 const StateStatusConfirmed StateStatusQualifier = "confirmed"
+
+// States with no confirmation record
 const StateStatusUnconfirmed StateStatusQualifier = "unconfirmed"
+
+// States with a spend record
 const StateStatusSpent StateStatusQualifier = "spent"
+
+// All states, whatever their confirm/spend status
 const StateStatusAll StateStatusQualifier = "all"
 
 func (q *StateStatusQualifier) UnmarshalJSON(b []byte) error {
@@ -70,11 +80,7 @@ func (q *StateStatusQualifier) UnmarshalJSON(b []byte) error {
 			StateStatusAll:
 			*q = qText
 		default:
-			u, err := uuid.Parse(string(text))
-			if err != nil {
-				return i18n.NewError(context.Background(), pldmsgs.MsgTypesInvalidStateQualifier)
-			}
-			*q = (StateStatusQualifier)(u.String())
+			return i18n.NewError(context.Background(), pldmsgs.MsgTypesInvalidStateQualifier)
 		}
 	}
 	return err

--- a/sdk/go/pkg/pldapi/states.go
+++ b/sdk/go/pkg/pldapi/states.go
@@ -52,10 +52,8 @@ func (st SchemaType) Options() []string {
 // particular point in the history of the chain.
 type StateStatusQualifier string
 
-// States with a confirmation record, and no spend record
-const StateStatusAvailable StateStatusQualifier = "available"
-
-// Synonym for StateStatusAvailable - a state is confirmed for use only while it is also unspent
+// States with a confirmation record, and no spend record - a state is confirmed for
+// use only while it is also unspent
 const StateStatusConfirmed StateStatusQualifier = "confirmed"
 
 // States with no confirmation record
@@ -73,8 +71,7 @@ func (q *StateStatusQualifier) UnmarshalJSON(b []byte) error {
 	if err == nil {
 		qText := StateStatusQualifier(strings.ToLower(text))
 		switch qText {
-		case StateStatusAvailable,
-			StateStatusConfirmed,
+		case StateStatusConfirmed,
 			StateStatusUnconfirmed,
 			StateStatusSpent,
 			StateStatusAll:

--- a/sdk/go/pkg/pldclient/statestore.go
+++ b/sdk/go/pkg/pldclient/statestore.go
@@ -91,7 +91,7 @@ func (r *stateStore) StoreState(ctx context.Context, domain string, contractAddr
 }
 
 func (r *stateStore) QueryStates(ctx context.Context, domain string, schemaRef pldtypes.Bytes32, query *query.QueryJSON, status pldapi.StateStatusQualifier) (states []*pldapi.State, err error) {
-	err = r.c.CallRPC(ctx, &states, "pstate_queryStates", domain, schemaRef, query)
+	err = r.c.CallRPC(ctx, &states, "pstate_queryStates", domain, schemaRef, query, status)
 	return
 }
 

--- a/sdk/typescript/src/interfaces/states.ts
+++ b/sdk/typescript/src/interfaces/states.ts
@@ -67,7 +67,6 @@ export interface IStateNullifier {
 }
 
 export type StateStatus =
-  | "available"
   | "confirmed"
   | "unconfirmed"
   | "spent"


### PR DESCRIPTION
Two commits to clean up the internals and externals of state manager and the state store.

---
### Commit 1: remove UUID support- domain query contexts no longer need to close

External JSON RPC calls to query the state store claimed the ability to specify a transaction UUID as the status qualifier parameter. This might have made sense in an earlier architecture but is certainly meaningless in the current state tracking/optimistic state tracking model. States stopped being locked on transactions in 10/2024, ahead of the initial release. The remaining implementation suggested a wiring into a domain context, however since the V1 release, ahead of chain state views have been stored in the grapher not the domain context. A queryable ahead of chain view would be achievable on the coordinator by querying via the grapher (similar to how available states are found for assembly), but since this feature has been clearly broken for a long time, and the value of querying a rapidly changing view which may or may not be confirmed on chain feels limited, I have chosen simply to fully remove at this point in time.

There had been some discussion of removing either the `confirmed` or 'available` status qualifier as they are identical in meaning, whereas in an earlier but now replaced architecture, where an confirmed but unspent state could be attached to a sequencer, thereby rendering it unavailable, they had different meanings. I have chosen not to as they still feel both like meaningful ways of describing the same state status, and instead call them out more explicitly as synonyms.


---
### Commit 2: refine external state store interface

These changes came about as I was finding it hard to make what should have been a simple change to the state manager. The knock on effects were repeatedly more impactful and problematic then they should have been. This package has had a lot of changes in functionality recently; this commit

* Remove external functions (on the interface and implementation) which do not have any callers
* Remove the external state query options from components which weren't actually used externally
* Instead of having an options object where the potential permutations increase exponentially with each newly added option, refactor the three permutations of the options that are actually used into three separate internal functions whose names self describe their purpose, layered onto a common base function
* Rename functions which claim to be finding nullifiers to be more explicit that they are finding states backed by nullifiers