### PR TITLE
feat(java-sdk): add state store RPC client

### DIFF
--- a/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/statestore/StateStoreClient.java
+++ b/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/statestore/StateStoreClient.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.client.statestore;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.lfdt.paladin.sdk.client.rpc.RpcClient;
+import org.lfdt.paladin.sdk.core.query.QueryJSON;
+import org.lfdt.paladin.sdk.core.statestore.Schema;
+import org.lfdt.paladin.sdk.core.statestore.State;
+import org.lfdt.paladin.sdk.core.statestore.StateStatusQualifier;
+import org.lfdt.paladin.sdk.core.types.Bytes32;
+import org.lfdt.paladin.sdk.core.types.EthAddress;
+import org.lfdt.paladin.sdk.core.types.HexBytes;
+
+/**
+ * Client for the {@code pstate_*} RPC namespace (state store).
+ *
+ * <p>Each method maps one-to-one to a JSON-RPC call on the underlying {@link RpcClient} and returns
+ * a {@link CompletableFuture}; failures complete it exceptionally with a {@code PaladinException}
+ * subtype.
+ */
+public final class StateStoreClient {
+
+  private final RpcClient rpc;
+
+  /**
+   * Creates a client over the given RPC transport.
+   *
+   * @param rpc the RPC client used to make calls; must not be {@code null}
+   */
+  public StateStoreClient(final RpcClient rpc) {
+    this.rpc = Objects.requireNonNull(rpc, "rpc");
+  }
+
+  /**
+   * Lists the schemas registered by a domain ({@code pstate_listSchemas}).
+   *
+   * @param domain the domain whose schemas to list
+   * @return a future completing with the domain's schemas
+   */
+  public CompletableFuture<List<Schema>> listSchemas(final String domain) {
+    return rpc.callRpc(new TypeReference<List<Schema>>() {}, "pstate_listSchemas", domain);
+  }
+
+  /**
+   * Stores a state directly in the state store ({@code pstate_storeState}).
+   *
+   * @param domain the domain that owns the state
+   * @param contractAddress the contract the state belongs to
+   * @param schemaRef the schema the state conforms to
+   * @param data the state's private data
+   * @return a future completing with the stored state
+   */
+  public CompletableFuture<State> storeState(
+      final String domain,
+      final EthAddress contractAddress,
+      final Bytes32 schemaRef,
+      final JsonNode data) {
+    return rpc.callRpc(State.class, "pstate_storeState", domain, contractAddress, schemaRef, data);
+  }
+
+  /**
+   * Queries states of a schema across all contracts of a domain ({@code pstate_queryStates}).
+   *
+   * @param domain the domain to query
+   * @param schemaRef the schema whose states to query
+   * @param query the query to run
+   * @param qualifier which states to include (a standard qualifier or a transaction id)
+   * @return a future completing with the matching states
+   */
+  public CompletableFuture<List<State>> queryStates(
+      final String domain,
+      final Bytes32 schemaRef,
+      final QueryJSON query,
+      final StateStatusQualifier qualifier) {
+    return rpc.callRpc(
+        new TypeReference<List<State>>() {},
+        "pstate_queryStates",
+        domain,
+        schemaRef,
+        query,
+        qualifier);
+  }
+
+  /**
+   * Queries states of a schema within a single contract ({@code pstate_queryContractStates}).
+   *
+   * @param domain the domain to query
+   * @param contractAddress the contract whose states to query
+   * @param schemaRef the schema whose states to query
+   * @param query the query to run
+   * @param qualifier which states to include (a standard qualifier or a transaction id)
+   * @return a future completing with the matching states
+   */
+  public CompletableFuture<List<State>> queryContractStates(
+      final String domain,
+      final EthAddress contractAddress,
+      final Bytes32 schemaRef,
+      final QueryJSON query,
+      final StateStatusQualifier qualifier) {
+    return rpc.callRpc(
+        new TypeReference<List<State>>() {},
+        "pstate_queryContractStates",
+        domain,
+        contractAddress,
+        schemaRef,
+        query,
+        qualifier);
+  }
+
+  /**
+   * Queries states by nullifier across all contracts of a domain ({@code pstate_queryNullifiers}).
+   *
+   * @param domain the domain to query
+   * @param schemaRef the schema whose states to query
+   * @param query the query to run
+   * @param qualifier which states to include (a standard qualifier or a transaction id)
+   * @return a future completing with the matching states
+   */
+  public CompletableFuture<List<State>> queryNullifiers(
+      final String domain,
+      final Bytes32 schemaRef,
+      final QueryJSON query,
+      final StateStatusQualifier qualifier) {
+    return rpc.callRpc(
+        new TypeReference<List<State>>() {},
+        "pstate_queryNullifiers",
+        domain,
+        schemaRef,
+        query,
+        qualifier);
+  }
+
+  /**
+   * Queries states by nullifier within a single contract ({@code pstate_queryContractNullifiers}).
+   *
+   * @param domain the domain to query
+   * @param contractAddress the contract whose states to query
+   * @param schemaRef the schema whose states to query
+   * @param query the query to run
+   * @param qualifier which states to include (a standard qualifier or a transaction id)
+   * @return a future completing with the matching states
+   */
+  public CompletableFuture<List<State>> queryContractNullifiers(
+      final String domain,
+      final EthAddress contractAddress,
+      final Bytes32 schemaRef,
+      final QueryJSON query,
+      final StateStatusQualifier qualifier) {
+    return rpc.callRpc(
+        new TypeReference<List<State>>() {},
+        "pstate_queryContractNullifiers",
+        domain,
+        contractAddress,
+        schemaRef,
+        query,
+        qualifier);
+  }
+
+  /**
+   * Transfers a private state to another node for reliable delivery ({@code
+   * pstate_transferPrivateState}).
+   *
+   * @param domain the domain that owns the state
+   * @param stateId the id of the state to transfer
+   * @param recipient the identity locator of the recipient
+   * @return a future completing with the id of the reliable message created for the transfer
+   */
+  public CompletableFuture<UUID> transferPrivateState(
+      final String domain, final HexBytes stateId, final String recipient) {
+    return rpc.callRpc(UUID.class, "pstate_transferPrivateState", domain, stateId, recipient);
+  }
+}

--- a/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/statestore/package-info.java
+++ b/sdk/java/client/src/main/java/org/lfdt/paladin/sdk/client/statestore/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client for the {@code pstate_*} RPC namespace (state store). Built on the SDK's {@code RpcClient}
+ * transport.
+ */
+package org.lfdt.paladin.sdk.client.statestore;

--- a/sdk/java/client/src/test/java/org/lfdt/paladin/sdk/client/statestore/StateStoreClientTest.java
+++ b/sdk/java/client/src/test/java/org/lfdt/paladin/sdk/client/statestore/StateStoreClientTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.client.statestore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+import org.lfdt.paladin.sdk.client.config.RetryPolicy;
+import org.lfdt.paladin.sdk.client.config.RpcClientConfig;
+import org.lfdt.paladin.sdk.client.exception.PaladinRpcException;
+import org.lfdt.paladin.sdk.client.rpc.HttpRpcClient;
+import org.lfdt.paladin.sdk.client.rpc.MockJsonRpcServer;
+import org.lfdt.paladin.sdk.core.json.PaladinObjectMapper;
+import org.lfdt.paladin.sdk.core.query.QueryJSON;
+import org.lfdt.paladin.sdk.core.statestore.Schema;
+import org.lfdt.paladin.sdk.core.statestore.State;
+import org.lfdt.paladin.sdk.core.statestore.StateStatusQualifier;
+import org.lfdt.paladin.sdk.core.types.Bytes32;
+import org.lfdt.paladin.sdk.core.types.EthAddress;
+import org.lfdt.paladin.sdk.core.types.HexBytes;
+
+class StateStoreClientTest {
+
+  private static final String SCHEMA_ID =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+  private static final String CONTRACT = "0x2222222222222222222222222222222222222222";
+
+  private static final String SCHEMA_JSON =
+      "{\"id\":\""
+          + SCHEMA_ID
+          + "\",\"created\":\"2024-01-01T00:00:00Z\",\"domain\":\"noto\",\"type\":\"abi\","
+          + "\"signature\":\"type=Coin\",\"definition\":{\"type\":\"tuple\"},"
+          + "\"labels\":[\"owner\"]}";
+
+  private static final String STATE_JSON =
+      "{\"id\":\"0xaa\",\"created\":\"2024-01-01T00:00:00Z\",\"domain\":\"noto\",\"schema\":\""
+          + SCHEMA_ID
+          + "\",\"contractAddress\":\""
+          + CONTRACT
+          + "\",\"data\":{\"amount\":\"100\"},"
+          + "\"confirmed\":{\"transaction\":\"3b8c1a2e-0000-0000-0000-000000000001\"}}";
+
+  private static String success(final String resultJson) {
+    return "{\"jsonrpc\":\"2.0\",\"id\":\"x\",\"result\":" + resultJson + "}";
+  }
+
+  private RpcClientConfig config(final String url) {
+    return RpcClientConfig.builder(url)
+        .connectTimeout(Duration.ofSeconds(5))
+        .requestTimeout(Duration.ofSeconds(5))
+        .retryPolicy(
+            RetryPolicy.builder()
+                .maxAttempts(1)
+                .initialDelay(Duration.ofMillis(1))
+                .maxDelay(Duration.ofMillis(5))
+                .build())
+        .build();
+  }
+
+  @Test
+  void listSchemas() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success("[" + SCHEMA_JSON + "]")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final List<Schema> schemas = new StateStoreClient(rpc).listSchemas("noto").join();
+      assertEquals(1, schemas.size());
+      assertEquals("noto", schemas.get(0).domain());
+      assertEquals("type=Coin", schemas.get(0).signature());
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_listSchemas", req.get("method").asText());
+      assertEquals("noto", req.get("params").get(0).asText());
+    }
+  }
+
+  @Test
+  void storeState() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success(STATE_JSON)));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final JsonNode data = PaladinObjectMapper.shared().readTree("{\"amount\":\"100\"}");
+      final State state =
+          new StateStoreClient(rpc)
+              .storeState(
+                  "noto", EthAddress.fromString(CONTRACT), Bytes32.fromString(SCHEMA_ID), data)
+              .join();
+      assertEquals(HexBytes.fromString("0xaa"), state.id());
+      assertEquals("100", state.data().get("amount").asText());
+      assertEquals(
+          UUID.fromString("3b8c1a2e-0000-0000-0000-000000000001"), state.confirmed().transaction());
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_storeState", req.get("method").asText());
+      assertEquals("noto", req.get("params").get(0).asText());
+      assertEquals(CONTRACT, req.get("params").get(1).asText());
+      assertEquals(SCHEMA_ID, req.get("params").get(2).asText());
+    }
+  }
+
+  @Test
+  void queryStatesSendsQualifier() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success("[" + STATE_JSON + "]")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final List<State> states =
+          new StateStoreClient(rpc)
+              .queryStates(
+                  "noto",
+                  Bytes32.fromString(SCHEMA_ID),
+                  QueryJSON.builder().limit(5).build(),
+                  StateStatusQualifier.AVAILABLE)
+              .join();
+      assertEquals(1, states.size());
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_queryStates", req.get("method").asText());
+      // Unlike the Go client, the qualifier is always sent as the fourth parameter.
+      assertEquals(4, req.get("params").size());
+      assertEquals("noto", req.get("params").get(0).asText());
+      assertEquals(SCHEMA_ID, req.get("params").get(1).asText());
+      assertEquals("available", req.get("params").get(3).asText());
+    }
+  }
+
+  @Test
+  void queryContractStates() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success("[" + STATE_JSON + "]")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final List<State> states =
+          new StateStoreClient(rpc)
+              .queryContractStates(
+                  "noto",
+                  EthAddress.fromString(CONTRACT),
+                  Bytes32.fromString(SCHEMA_ID),
+                  QueryJSON.builder().build(),
+                  StateStatusQualifier.CONFIRMED)
+              .join();
+      assertEquals(1, states.size());
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_queryContractStates", req.get("method").asText());
+      assertEquals(5, req.get("params").size());
+      assertEquals(CONTRACT, req.get("params").get(1).asText());
+      assertEquals("confirmed", req.get("params").get(4).asText());
+    }
+  }
+
+  @Test
+  void queryNullifiers() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success("[" + STATE_JSON + "]")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final UUID txId = UUID.fromString("3b8c1a2e-0000-0000-0000-000000000009");
+      final List<State> states =
+          new StateStoreClient(rpc)
+              .queryNullifiers(
+                  "noto",
+                  Bytes32.fromString(SCHEMA_ID),
+                  QueryJSON.builder().build(),
+                  StateStatusQualifier.forTransaction(txId))
+              .join();
+      assertEquals(1, states.size());
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_queryNullifiers", req.get("method").asText());
+      assertEquals(4, req.get("params").size());
+      assertEquals(txId.toString(), req.get("params").get(3).asText());
+    }
+  }
+
+  @Test
+  void queryContractNullifiersSendsQualifier() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) -> MockJsonRpcServer.Response.of(200, success("[" + STATE_JSON + "]")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final List<State> states =
+          new StateStoreClient(rpc)
+              .queryContractNullifiers(
+                  "noto",
+                  EthAddress.fromString(CONTRACT),
+                  Bytes32.fromString(SCHEMA_ID),
+                  QueryJSON.builder().build(),
+                  StateStatusQualifier.ALL)
+              .join();
+      assertEquals(1, states.size());
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_queryContractNullifiers", req.get("method").asText());
+      // Unlike the Go client, the qualifier is always sent as the fifth parameter.
+      assertEquals(5, req.get("params").size());
+      assertEquals("all", req.get("params").get(4).asText());
+    }
+  }
+
+  @Test
+  void transferPrivateState() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) ->
+                    MockJsonRpcServer.Response.of(
+                        200, success("\"3b8c1a2e-0000-0000-0000-000000000002\"")));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final UUID msgId =
+          new StateStoreClient(rpc)
+              .transferPrivateState("noto", HexBytes.fromString("0xaa"), "recipient@node2")
+              .join();
+      assertEquals(UUID.fromString("3b8c1a2e-0000-0000-0000-000000000002"), msgId);
+
+      final JsonNode req = server.requests().get(0);
+      assertEquals("pstate_transferPrivateState", req.get("method").asText());
+      assertEquals("noto", req.get("params").get(0).asText());
+      assertEquals("0xaa", req.get("params").get(1).asText());
+      assertEquals("recipient@node2", req.get("params").get(2).asText());
+    }
+  }
+
+  @Test
+  void propagatesRpcError() throws IOException {
+    try (MockJsonRpcServer server =
+            new MockJsonRpcServer(
+                (n, req) ->
+                    MockJsonRpcServer.Response.of(
+                        200,
+                        "{\"jsonrpc\":\"2.0\",\"id\":\"x\",\"error\":{\"code\":-32000,"
+                            + "\"message\":\"no such schema\"}}"));
+        HttpRpcClient rpc = new HttpRpcClient(config(server.baseUrl()))) {
+      final CompletionException ex =
+          assertThrows(
+              CompletionException.class,
+              () -> new StateStoreClient(rpc).listSchemas("noto").join());
+      assertInstanceOf(PaladinRpcException.class, ex.getCause());
+    }
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/Schema.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/Schema.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Objects;
+import org.lfdt.paladin.sdk.core.types.Bytes32;
+import org.lfdt.paladin.sdk.core.types.Timestamp;
+
+/** A state schema registered by a domain, defining the shape of its states. Immutable. */
+@JsonPropertyOrder({"id", "created", "domain", "type", "signature", "definition", "labels"})
+public final class Schema {
+
+  private final Bytes32 id;
+  private final Timestamp created;
+  private final String domain;
+  private final SchemaType type;
+  private final String signature;
+  private final JsonNode definition;
+  private final List<String> labels;
+
+  @JsonCreator
+  Schema(
+      @JsonProperty("id") final Bytes32 id,
+      @JsonProperty("created") final Timestamp created,
+      @JsonProperty("domain") final String domain,
+      @JsonProperty("type") final SchemaType type,
+      @JsonProperty("signature") final String signature,
+      @JsonProperty("definition") final JsonNode definition,
+      @JsonProperty("labels") final List<String> labels) {
+    this.id = id;
+    this.created = created;
+    this.domain = domain;
+    this.type = type;
+    this.signature = signature;
+    this.definition = definition;
+    this.labels = labels;
+  }
+
+  /**
+   * The schema identifier.
+   *
+   * @return the schema id
+   */
+  @JsonProperty("id")
+  public Bytes32 id() {
+    return id;
+  }
+
+  /**
+   * When the schema was created.
+   *
+   * @return the creation timestamp
+   */
+  @JsonProperty("created")
+  public Timestamp created() {
+    return created;
+  }
+
+  /**
+   * The name of the domain that owns the schema.
+   *
+   * @return the domain name
+   */
+  @JsonProperty("domain")
+  public String domain() {
+    return domain;
+  }
+
+  /**
+   * The kind of schema.
+   *
+   * @return the schema type
+   */
+  @JsonProperty("type")
+  public SchemaType type() {
+    return type;
+  }
+
+  /**
+   * The signature that uniquely identifies the schema definition.
+   *
+   * @return the schema signature
+   */
+  @JsonProperty("signature")
+  public String signature() {
+    return signature;
+  }
+
+  /**
+   * The schema definition as raw JSON.
+   *
+   * @return the schema definition
+   */
+  @JsonProperty("definition")
+  public JsonNode definition() {
+    return definition;
+  }
+
+  /**
+   * The names of the indexed labels defined by the schema.
+   *
+   * @return the label names
+   */
+  @JsonProperty("labels")
+  public List<String> labels() {
+    return labels;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof Schema other
+        && Objects.equals(id, other.id)
+        && Objects.equals(created, other.created)
+        && Objects.equals(domain, other.domain)
+        && type == other.type
+        && Objects.equals(signature, other.signature)
+        && Objects.equals(definition, other.definition)
+        && Objects.equals(labels, other.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, created, domain, type, signature, definition, labels);
+  }
+
+  @Override
+  public String toString() {
+    return "Schema{id=" + id + ", domain=" + domain + ", signature=" + signature + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/SchemaType.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/SchemaType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The kind of a state schema. Serializes to its lower-case JSON token; parsing is case-insensitive.
+ */
+public enum SchemaType {
+
+  /** An ABI schema, defining indexed fields with the same semantics as event parameters. */
+  ABI("abi");
+
+  private final String jsonValue;
+
+  SchemaType(final String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * The JSON token for this schema type.
+   *
+   * @return the lower-case JSON token
+   */
+  @JsonValue
+  public String jsonValue() {
+    return jsonValue;
+  }
+
+  /**
+   * Resolves a schema type from its JSON token, case-insensitively.
+   *
+   * @param s the JSON token to resolve
+   * @return the matching schema type
+   * @throws IllegalArgumentException if {@code s} is null or not a known schema type
+   */
+  @JsonCreator
+  public static SchemaType fromJson(final String s) {
+    if (s != null) {
+      for (SchemaType t : values()) {
+        if (t.jsonValue.equalsIgnoreCase(s)) {
+          return t;
+        }
+      }
+    }
+    throw new IllegalArgumentException("unknown schema type: " + s);
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/SchemaType.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/SchemaType.java
@@ -44,19 +44,17 @@ public enum SchemaType {
   /**
    * Resolves a schema type from its JSON token, case-insensitively.
    *
-   * @param s the JSON token to resolve
+   * @param typeString the JSON token to resolve
    * @return the matching schema type
-   * @throws IllegalArgumentException if {@code s} is null or not a known schema type
+   * @throws IllegalArgumentException if {@code typeString} is null or not a known schema type
    */
   @JsonCreator
-  public static SchemaType fromJson(final String s) {
-    if (s != null) {
-      for (SchemaType t : values()) {
-        if (t.jsonValue.equalsIgnoreCase(s)) {
-          return t;
-        }
+  public static SchemaType fromJson(final String typeString) {
+    for (SchemaType type : values()) {
+      if (type.jsonValue.equalsIgnoreCase(typeString)) {
+        return type;
       }
     }
-    throw new IllegalArgumentException("unknown schema type: " + s);
+    throw new IllegalArgumentException("unknown schema type: \"" + typeString + "\"");
   }
 }

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/State.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/State.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Objects;
+import org.lfdt.paladin.sdk.core.types.Bytes32;
+import org.lfdt.paladin.sdk.core.types.EthAddress;
+import org.lfdt.paladin.sdk.core.types.HexBytes;
+import org.lfdt.paladin.sdk.core.types.Timestamp;
+
+/**
+ * A state held in the state store, with its private data and any confirm, read, spend, lock, and
+ * nullifier records.
+ *
+ * <p>The lifecycle records ({@link #confirmed()}, {@link #read()}, {@link #spent()}, {@link
+ * #locks()}, {@link #nullifier()}) are present only when they apply; otherwise they are {@code
+ * null}. Immutable.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "id",
+  "created",
+  "domain",
+  "schema",
+  "contractAddress",
+  "data",
+  "confirmed",
+  "read",
+  "spent",
+  "locks",
+  "nullifier"
+})
+public final class State {
+
+  private final HexBytes id;
+  private final Timestamp created;
+  private final String domain;
+  private final Bytes32 schema;
+  private final EthAddress contractAddress;
+  private final JsonNode data;
+  private final StateConfirmRecord confirmed;
+  private final StateReadRecord read;
+  private final StateSpendRecord spent;
+  private final List<StateLock> locks;
+  private final StateNullifier nullifier;
+
+  @JsonCreator
+  State(
+      @JsonProperty("id") final HexBytes id,
+      @JsonProperty("created") final Timestamp created,
+      @JsonProperty("domain") final String domain,
+      @JsonProperty("schema") final Bytes32 schema,
+      @JsonProperty("contractAddress") final EthAddress contractAddress,
+      @JsonProperty("data") final JsonNode data,
+      @JsonProperty("confirmed") final StateConfirmRecord confirmed,
+      @JsonProperty("read") final StateReadRecord read,
+      @JsonProperty("spent") final StateSpendRecord spent,
+      @JsonProperty("locks") final List<StateLock> locks,
+      @JsonProperty("nullifier") final StateNullifier nullifier) {
+    this.id = id;
+    this.created = created;
+    this.domain = domain;
+    this.schema = schema;
+    this.contractAddress = contractAddress;
+    this.data = data;
+    this.confirmed = confirmed;
+    this.read = read;
+    this.spent = spent;
+    this.locks = locks;
+    this.nullifier = nullifier;
+  }
+
+  /**
+   * The state identifier.
+   *
+   * @return the state id
+   */
+  @JsonProperty("id")
+  public HexBytes id() {
+    return id;
+  }
+
+  /**
+   * When the state was created.
+   *
+   * @return the creation timestamp
+   */
+  @JsonProperty("created")
+  public Timestamp created() {
+    return created;
+  }
+
+  /**
+   * The name of the domain that owns the state.
+   *
+   * @return the domain name
+   */
+  @JsonProperty("domain")
+  public String domain() {
+    return domain;
+  }
+
+  /**
+   * The identifier of the schema the state conforms to.
+   *
+   * @return the schema id
+   */
+  @JsonProperty("schema")
+  public Bytes32 schema() {
+    return schema;
+  }
+
+  /**
+   * The contract the state belongs to, or {@code null} for states (such as a privacy group genesis)
+   * that exist before their contract.
+   *
+   * @return the contract address, or {@code null}
+   */
+  @JsonProperty("contractAddress")
+  public EthAddress contractAddress() {
+    return contractAddress;
+  }
+
+  /**
+   * The state's private data as raw JSON.
+   *
+   * @return the state data
+   */
+  @JsonProperty("data")
+  public JsonNode data() {
+    return data;
+  }
+
+  /**
+   * The confirm record for the state, or {@code null} if it is not confirmed on chain.
+   *
+   * @return the confirm record, or {@code null}
+   */
+  @JsonProperty("confirmed")
+  public StateConfirmRecord confirmed() {
+    return confirmed;
+  }
+
+  /**
+   * The read record for the state, or {@code null} if none applies.
+   *
+   * @return the read record, or {@code null}
+   */
+  @JsonProperty("read")
+  public StateReadRecord read() {
+    return read;
+  }
+
+  /**
+   * The spend record for the state, or {@code null} if it has not been spent.
+   *
+   * @return the spend record, or {@code null}
+   */
+  @JsonProperty("spent")
+  public StateSpendRecord spent() {
+    return spent;
+  }
+
+  /**
+   * The in-memory locks held against the state, or {@code null} if there are none.
+   *
+   * @return the locks, or {@code null}
+   */
+  @JsonProperty("locks")
+  public List<StateLock> locks() {
+    return locks;
+  }
+
+  /**
+   * The nullifier associated with the state, or {@code null} if the domain does not use nullifiers.
+   *
+   * @return the nullifier, or {@code null}
+   */
+  @JsonProperty("nullifier")
+  public StateNullifier nullifier() {
+    return nullifier;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof State other
+        && Objects.equals(id, other.id)
+        && Objects.equals(created, other.created)
+        && Objects.equals(domain, other.domain)
+        && Objects.equals(schema, other.schema)
+        && Objects.equals(contractAddress, other.contractAddress)
+        && Objects.equals(data, other.data)
+        && Objects.equals(confirmed, other.confirmed)
+        && Objects.equals(read, other.read)
+        && Objects.equals(spent, other.spent)
+        && Objects.equals(locks, other.locks)
+        && Objects.equals(nullifier, other.nullifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        created,
+        domain,
+        schema,
+        contractAddress,
+        data,
+        confirmed,
+        read,
+        spent,
+        locks,
+        nullifier);
+  }
+
+  @Override
+  public String toString() {
+    return "State{id=" + id + ", domain=" + domain + ", schema=" + schema + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateConfirmRecord.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateConfirmRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A join record written when a state's creation is confirmed on chain, linking the state to the
+ * transaction that created it. Immutable.
+ */
+@JsonPropertyOrder({"transaction"})
+public final class StateConfirmRecord {
+
+  private final UUID transaction;
+
+  @JsonCreator
+  StateConfirmRecord(@JsonProperty("transaction") final UUID transaction) {
+    this.transaction = transaction;
+  }
+
+  /**
+   * The transaction that confirmed the state.
+   *
+   * @return the confirming transaction id
+   */
+  @JsonProperty("transaction")
+  public UUID transaction() {
+    return transaction;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateConfirmRecord other && Objects.equals(transaction, other.transaction);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transaction);
+  }
+
+  @Override
+  public String toString() {
+    return "StateConfirmRecord{transaction=" + transaction + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLock.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLock.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * An in-memory record locking a state to a transaction while it is being assembled, endorsed, and
+ * submitted. Immutable.
+ */
+@JsonPropertyOrder({"transaction", "type"})
+public final class StateLock {
+
+  private final UUID transaction;
+  private final StateLockType type;
+
+  @JsonCreator
+  StateLock(
+      @JsonProperty("transaction") final UUID transaction,
+      @JsonProperty("type") final StateLockType type) {
+    this.transaction = transaction;
+    this.type = type;
+  }
+
+  /**
+   * The transaction the state is locked to.
+   *
+   * @return the locking transaction id
+   */
+  @JsonProperty("transaction")
+  public UUID transaction() {
+    return transaction;
+  }
+
+  /**
+   * The kind of lock.
+   *
+   * @return the lock type
+   */
+  @JsonProperty("type")
+  public StateLockType type() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateLock other
+        && Objects.equals(transaction, other.transaction)
+        && type == other.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transaction, type);
+  }
+
+  @Override
+  public String toString() {
+    return "StateLock{transaction=" + transaction + ", type=" + type + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLockType.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLockType.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How a state is locked to a transaction. Serializes to its lower-case JSON token; parsing is
+ * case-insensitive.
+ */
+public enum StateLockType {
+
+  /** An optimistic lock recording the creation of a state not yet confirmed on chain. */
+  CREATE("create"),
+  /** A lock recording that a transaction read the state. */
+  READ("read"),
+  /** A lock recording that a transaction spends the state. */
+  SPEND("spend");
+
+  private final String jsonValue;
+
+  StateLockType(final String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * The JSON token for this lock type.
+   *
+   * @return the lower-case JSON token
+   */
+  @JsonValue
+  public String jsonValue() {
+    return jsonValue;
+  }
+
+  /**
+   * Resolves a lock type from its JSON token, case-insensitively.
+   *
+   * @param s the JSON token to resolve
+   * @return the matching lock type
+   * @throws IllegalArgumentException if {@code s} is null or not a known lock type
+   */
+  @JsonCreator
+  public static StateLockType fromJson(final String s) {
+    if (s != null) {
+      for (StateLockType t : values()) {
+        if (t.jsonValue.equalsIgnoreCase(s)) {
+          return t;
+        }
+      }
+    }
+    throw new IllegalArgumentException("unknown state lock type: " + s);
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLockType.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateLockType.java
@@ -49,19 +49,17 @@ public enum StateLockType {
   /**
    * Resolves a lock type from its JSON token, case-insensitively.
    *
-   * @param s the JSON token to resolve
+   * @param typeString the JSON token to resolve
    * @return the matching lock type
-   * @throws IllegalArgumentException if {@code s} is null or not a known lock type
+   * @throws IllegalArgumentException if {@code typeString} is null or not a known lock type
    */
   @JsonCreator
-  public static StateLockType fromJson(final String s) {
-    if (s != null) {
-      for (StateLockType t : values()) {
-        if (t.jsonValue.equalsIgnoreCase(s)) {
-          return t;
-        }
+  public static StateLockType fromJson(final String typeString) {
+    for (StateLockType type : values()) {
+      if (type.jsonValue.equalsIgnoreCase(typeString)) {
+        return type;
       }
     }
-    throw new IllegalArgumentException("unknown state lock type: " + s);
+    throw new IllegalArgumentException("unknown state lock type: \"" + typeString + "\"");
   }
 }

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateNullifier.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateNullifier.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+import org.lfdt.paladin.sdk.core.types.HexBytes;
+
+/**
+ * A nullifier a domain uses to spend a state without revealing the state id. A spend record is
+ * written against the nullifier rather than the state. Immutable.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"id", "spent"})
+public final class StateNullifier {
+
+  private final HexBytes id;
+  private final StateSpendRecord spent;
+
+  @JsonCreator
+  StateNullifier(
+      @JsonProperty("id") final HexBytes id, @JsonProperty("spent") final StateSpendRecord spent) {
+    this.id = id;
+    this.spent = spent;
+  }
+
+  /**
+   * The nullifier identifier.
+   *
+   * @return the nullifier id
+   */
+  @JsonProperty("id")
+  public HexBytes id() {
+    return id;
+  }
+
+  /**
+   * The spend record written against this nullifier, or {@code null} if it has not been spent.
+   *
+   * @return the spend record, or {@code null}
+   */
+  @JsonProperty("spent")
+  public StateSpendRecord spent() {
+    return spent;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateNullifier other
+        && Objects.equals(id, other.id)
+        && Objects.equals(spent, other.spent);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, spent);
+  }
+
+  @Override
+  public String toString() {
+    return "StateNullifier{id=" + id + ", spent=" + spent + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateReadRecord.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateReadRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A join record written when a transaction reads a state without creating or spending it, linking
+ * the state to that transaction. Immutable.
+ */
+@JsonPropertyOrder({"transaction"})
+public final class StateReadRecord {
+
+  private final UUID transaction;
+
+  @JsonCreator
+  StateReadRecord(@JsonProperty("transaction") final UUID transaction) {
+    this.transaction = transaction;
+  }
+
+  /**
+   * The transaction that read the state.
+   *
+   * @return the reading transaction id
+   */
+  @JsonProperty("transaction")
+  public UUID transaction() {
+    return transaction;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateReadRecord other && Objects.equals(transaction, other.transaction);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transaction);
+  }
+
+  @Override
+  public String toString() {
+    return "StateReadRecord{transaction=" + transaction + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateSpendRecord.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateSpendRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A join record written when a state is spent, linking the state to the transaction that spent it.
+ * Immutable.
+ */
+@JsonPropertyOrder({"transaction"})
+public final class StateSpendRecord {
+
+  private final UUID transaction;
+
+  @JsonCreator
+  StateSpendRecord(@JsonProperty("transaction") final UUID transaction) {
+    this.transaction = transaction;
+  }
+
+  /**
+   * The transaction that spent the state.
+   *
+   * @return the spending transaction id
+   */
+  @JsonProperty("transaction")
+  public UUID transaction() {
+    return transaction;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateSpendRecord other && Objects.equals(transaction, other.transaction);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(transaction);
+  }
+
+  @Override
+  public String toString() {
+    return "StateSpendRecord{transaction=" + transaction + "}";
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateStatusQualifier.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/StateStatusQualifier.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Selects which states a state-store query returns: one of the standard qualifiers, or the id of a
+ * transaction whose in-flight domain context the query is evaluated against.
+ *
+ * <p>This is not a closed enumeration — alongside the standard qualifiers ({@link #AVAILABLE},
+ * {@link #CONFIRMED}, {@link #UNCONFIRMED}, {@link #SPENT}, {@link #ALL}) a query may be qualified
+ * by a transaction id via {@link #forTransaction(UUID)}. Serializes to a bare string. Immutable.
+ */
+public final class StateStatusQualifier {
+
+  /** States that are confirmed, have their private data, and are not spent. */
+  public static final StateStatusQualifier AVAILABLE = new StateStatusQualifier("available");
+
+  /** States that have a confirm record on chain. */
+  public static final StateStatusQualifier CONFIRMED = new StateStatusQualifier("confirmed");
+
+  /** States that do not yet have a confirm record on chain. */
+  public static final StateStatusQualifier UNCONFIRMED = new StateStatusQualifier("unconfirmed");
+
+  /** States that have a spend record. */
+  public static final StateStatusQualifier SPENT = new StateStatusQualifier("spent");
+
+  /** All states, regardless of status. */
+  public static final StateStatusQualifier ALL = new StateStatusQualifier("all");
+
+  private final String value;
+
+  private StateStatusQualifier(final String value) {
+    this.value = value;
+  }
+
+  /**
+   * Returns a qualifier that evaluates the query against the in-flight domain context of a
+   * transaction.
+   *
+   * @param transactionId the transaction whose domain context to query against
+   * @return a qualifier for that transaction
+   */
+  public static StateStatusQualifier forTransaction(final UUID transactionId) {
+    return new StateStatusQualifier(
+        Objects.requireNonNull(transactionId, "transactionId").toString());
+  }
+
+  /**
+   * Resolves a qualifier from its string form: a standard qualifier (case-insensitively) or a
+   * transaction id.
+   *
+   * @param s the string to resolve
+   * @return the matching qualifier
+   * @throws IllegalArgumentException if {@code s} is null or is neither a standard qualifier nor a
+   *     valid transaction id
+   */
+  @JsonCreator
+  public static StateStatusQualifier fromString(final String s) {
+    if (s != null) {
+      final String lower = s.toLowerCase(java.util.Locale.ROOT);
+      switch (lower) {
+        case "available":
+          return AVAILABLE;
+        case "confirmed":
+          return CONFIRMED;
+        case "unconfirmed":
+          return UNCONFIRMED;
+        case "spent":
+          return SPENT;
+        case "all":
+          return ALL;
+        default:
+          return forTransaction(UUID.fromString(s));
+      }
+    }
+    throw new IllegalArgumentException("state status qualifier must not be null");
+  }
+
+  /**
+   * The string form of this qualifier.
+   *
+   * @return the qualifier value
+   */
+  @JsonValue
+  public String value() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StateStatusQualifier other && value.equals(other.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/package-info.java
+++ b/sdk/java/core/src/main/java/org/lfdt/paladin/sdk/core/statestore/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Data models for the state store ({@code pstate_*}) RPC namespace: schemas, states, and their
+ * lifecycle records.
+ */
+package org.lfdt.paladin.sdk.core.statestore;

--- a/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
+++ b/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright contributors to Paladin, an LFDT project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.lfdt.paladin.sdk.core.statestore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.lfdt.paladin.sdk.core.json.PaladinObjectMapper;
+import org.lfdt.paladin.sdk.core.types.Bytes32;
+import org.lfdt.paladin.sdk.core.types.EthAddress;
+import org.lfdt.paladin.sdk.core.types.HexBytes;
+
+class StateStoreTypesTest {
+
+  private static final ObjectMapper MAPPER = PaladinObjectMapper.shared();
+
+  private static final String SCHEMA_ID =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+  private static final String CONTRACT = "0x2222222222222222222222222222222222222222";
+  private static final String TX = "3b8c1a2e-0000-0000-0000-000000000001";
+
+  @Test
+  void schemaTypeRoundTripsAndRejectsUnknown() throws Exception {
+    assertEquals(SchemaType.ABI, MAPPER.readValue("\"abi\"", SchemaType.class));
+    assertEquals("abi", SchemaType.ABI.jsonValue());
+    assertEquals(SchemaType.ABI, SchemaType.fromJson("ABI"));
+    assertThrows(IllegalArgumentException.class, () -> SchemaType.fromJson("bogus"));
+    assertThrows(IllegalArgumentException.class, () -> SchemaType.fromJson(null));
+  }
+
+  @Test
+  void stateLockTypeRoundTripsAndRejectsUnknown() throws Exception {
+    for (final StateLockType t : StateLockType.values()) {
+      assertEquals(t, MAPPER.readValue(MAPPER.writeValueAsString(t), StateLockType.class));
+    }
+    assertEquals("spend", StateLockType.SPEND.jsonValue());
+    assertEquals(StateLockType.CREATE, StateLockType.fromJson("CREATE"));
+    assertThrows(IllegalArgumentException.class, () -> StateLockType.fromJson("bogus"));
+    assertThrows(IllegalArgumentException.class, () -> StateLockType.fromJson(null));
+  }
+
+  @Test
+  void stateStatusQualifierHandlesStandardValuesAndUuids() throws Exception {
+    assertEquals(
+        StateStatusQualifier.AVAILABLE,
+        MAPPER.readValue("\"available\"", StateStatusQualifier.class));
+    assertEquals(StateStatusQualifier.SPENT, StateStatusQualifier.fromString("SPENT"));
+    assertEquals("all", StateStatusQualifier.ALL.value());
+    assertEquals("\"confirmed\"", MAPPER.writeValueAsString(StateStatusQualifier.CONFIRMED));
+
+    final UUID txId = UUID.fromString(TX);
+    final StateStatusQualifier forTx = StateStatusQualifier.forTransaction(txId);
+    assertEquals(TX, forTx.value());
+    assertEquals(forTx, StateStatusQualifier.fromString(TX));
+    assertEquals(forTx.hashCode(), StateStatusQualifier.fromString(TX).hashCode());
+    assertEquals(forTx.toString(), TX);
+    assertNotEquals(StateStatusQualifier.ALL, forTx);
+    assertNotEquals(StateStatusQualifier.ALL, "all");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> StateStatusQualifier.fromString("not-a-uuid"));
+    assertThrows(IllegalArgumentException.class, () -> StateStatusQualifier.fromString(null));
+    assertThrows(NullPointerException.class, () -> StateStatusQualifier.forTransaction(null));
+  }
+
+  @Test
+  void schemaRoundTrips() throws Exception {
+    final String json =
+        "{\"id\":\""
+            + SCHEMA_ID
+            + "\",\"created\":\"2024-01-01T00:00:00Z\",\"domain\":\"noto\",\"type\":\"abi\","
+            + "\"signature\":\"type=Coin\",\"definition\":{\"type\":\"tuple\"},"
+            + "\"labels\":[\"owner\"]}";
+    final Schema schema = MAPPER.readValue(json, Schema.class);
+    assertEquals(Bytes32.fromString(SCHEMA_ID), schema.id());
+    assertEquals("noto", schema.domain());
+    assertEquals(SchemaType.ABI, schema.type());
+    assertEquals("type=Coin", schema.signature());
+    assertEquals("tuple", schema.definition().get("type").asText());
+    assertEquals(java.util.List.of("owner"), schema.labels());
+    assertTrue(schema.created().toString().startsWith("2024-01-01"));
+
+    final Schema reparsed = MAPPER.readValue(MAPPER.writeValueAsString(schema), Schema.class);
+    assertEquals(schema, reparsed);
+    assertEquals(schema.hashCode(), reparsed.hashCode());
+    assertEquals(schema, schema);
+    assertNotEquals(schema, "not a schema");
+    assertTrue(schema.toString().contains("domain=noto"));
+  }
+
+  @Test
+  void stateRoundTripsWithAllRecords() throws Exception {
+    final String json =
+        "{\"id\":\"0xaa\",\"created\":\"2024-01-01T00:00:00Z\",\"domain\":\"noto\",\"schema\":\""
+            + SCHEMA_ID
+            + "\",\"contractAddress\":\""
+            + CONTRACT
+            + "\",\"data\":{\"amount\":\"100\"},"
+            + "\"confirmed\":{\"transaction\":\""
+            + TX
+            + "\"},\"read\":{\"transaction\":\""
+            + TX
+            + "\"},\"spent\":{\"transaction\":\""
+            + TX
+            + "\"},\"locks\":[{\"transaction\":\""
+            + TX
+            + "\",\"type\":\"spend\"}],"
+            + "\"nullifier\":{\"id\":\"0xbb\",\"spent\":{\"transaction\":\""
+            + TX
+            + "\"}}}";
+    final State state = MAPPER.readValue(json, State.class);
+    assertEquals(HexBytes.fromString("0xaa"), state.id());
+    assertEquals("noto", state.domain());
+    assertEquals(Bytes32.fromString(SCHEMA_ID), state.schema());
+    assertEquals(EthAddress.fromString(CONTRACT), state.contractAddress());
+    assertEquals("100", state.data().get("amount").asText());
+
+    final UUID txId = UUID.fromString(TX);
+    assertEquals(txId, state.confirmed().transaction());
+    assertEquals(txId, state.read().transaction());
+    assertEquals(txId, state.spent().transaction());
+    assertEquals(1, state.locks().size());
+    assertEquals(StateLockType.SPEND, state.locks().get(0).type());
+    assertEquals(txId, state.locks().get(0).transaction());
+    assertEquals(HexBytes.fromString("0xbb"), state.nullifier().id());
+    assertEquals(txId, state.nullifier().spent().transaction());
+
+    final State reparsed = MAPPER.readValue(MAPPER.writeValueAsString(state), State.class);
+    assertEquals(state, reparsed);
+    assertEquals(state.hashCode(), reparsed.hashCode());
+    assertEquals(state, state);
+    assertNotEquals(state, "not a state");
+    assertTrue(state.toString().contains("domain=noto"));
+
+    // Cover record and lock equality/toString directly.
+    assertEquals(state.confirmed(), reparsed.confirmed());
+    assertEquals(state.confirmed().hashCode(), reparsed.confirmed().hashCode());
+    assertNotEquals(state.confirmed(), "x");
+    assertTrue(state.confirmed().toString().contains("transaction="));
+    assertEquals(state.read(), reparsed.read());
+    assertNotEquals(state.read(), "x");
+    assertTrue(state.read().toString().contains("transaction="));
+    assertEquals(state.spent(), reparsed.spent());
+    assertNotEquals(state.spent(), "x");
+    assertTrue(state.spent().toString().contains("transaction="));
+    assertEquals(state.locks().get(0), reparsed.locks().get(0));
+    assertEquals(state.locks().get(0).hashCode(), reparsed.locks().get(0).hashCode());
+    assertNotEquals(state.locks().get(0), "x");
+    assertTrue(state.locks().get(0).toString().contains("type=SPEND"));
+    assertEquals(state.nullifier(), reparsed.nullifier());
+    assertEquals(state.nullifier().hashCode(), reparsed.nullifier().hashCode());
+    assertNotEquals(state.nullifier(), "x");
+    assertTrue(state.nullifier().toString().contains("id="));
+  }
+
+  @Test
+  void stateOmitsAbsentOptionalRecords() throws Exception {
+    final State state =
+        MAPPER.readValue(
+            "{\"id\":\"0xaa\",\"created\":\"2024-01-01T00:00:00Z\",\"domain\":\"noto\","
+                + "\"schema\":\""
+                + SCHEMA_ID
+                + "\",\"data\":{}}",
+            State.class);
+    assertNull(state.contractAddress());
+    assertNull(state.confirmed());
+    assertNull(state.read());
+    assertNull(state.spent());
+    assertNull(state.locks());
+    assertNull(state.nullifier());
+    final String serialized = MAPPER.writeValueAsString(state);
+    assertTrue(serialized.indexOf("confirmed") < 0);
+    assertTrue(serialized.indexOf("contractAddress") < 0);
+  }
+}

--- a/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
+++ b/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
@@ -41,7 +41,10 @@ class StateStoreTypesTest {
   void schemaTypeRoundTripsAndRejectsUnknown() throws Exception {
     assertEquals(SchemaType.ABI, MAPPER.readValue("\"abi\"", SchemaType.class));
     assertEquals("abi", SchemaType.ABI.jsonValue());
-    assertEquals(SchemaType.ABI, SchemaType.fromJson("ABI"));
+    for (final SchemaType type : SchemaType.values()) {
+      assertEquals(type, SchemaType.fromJson(type.jsonValue()));
+      assertEquals(type, SchemaType.fromJson(type.jsonValue().toUpperCase()));
+    }
     assertThrows(IllegalArgumentException.class, () -> SchemaType.fromJson("bogus"));
     assertThrows(IllegalArgumentException.class, () -> SchemaType.fromJson(null));
   }
@@ -52,7 +55,10 @@ class StateStoreTypesTest {
       assertEquals(t, MAPPER.readValue(MAPPER.writeValueAsString(t), StateLockType.class));
     }
     assertEquals("spend", StateLockType.SPEND.jsonValue());
-    assertEquals(StateLockType.CREATE, StateLockType.fromJson("CREATE"));
+    for (final StateLockType type : StateLockType.values()) {
+      assertEquals(type, StateLockType.fromJson(type.jsonValue()));
+      assertEquals(type, StateLockType.fromJson(type.jsonValue().toUpperCase()));
+    }
     assertThrows(IllegalArgumentException.class, () -> StateLockType.fromJson("bogus"));
     assertThrows(IllegalArgumentException.class, () -> StateLockType.fromJson(null));
   }

--- a/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
+++ b/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/statestore/StateStoreTypesTest.java
@@ -196,4 +196,33 @@ class StateStoreTypesTest {
     assertTrue(serialized.indexOf("confirmed") < 0);
     assertTrue(serialized.indexOf("contractAddress") < 0);
   }
+
+  @Test
+  void stateStatusQualifierResolvesEveryStandardToken() {
+    assertEquals(StateStatusQualifier.CONFIRMED, StateStatusQualifier.fromString("confirmed"));
+    assertEquals(StateStatusQualifier.UNCONFIRMED, StateStatusQualifier.fromString("UNCONFIRMED"));
+    assertEquals(StateStatusQualifier.ALL, StateStatusQualifier.fromString("All"));
+    assertEquals(StateStatusQualifier.AVAILABLE, StateStatusQualifier.fromString("available"));
+    assertEquals(StateStatusQualifier.SPENT, StateStatusQualifier.fromString("spent"));
+  }
+
+  @Test
+  void stateRecordsAreEqualToThemselves() {
+    final UUID txId = UUID.fromString(TX);
+    final StateConfirmRecord confirmed = new StateConfirmRecord(txId);
+    final StateReadRecord read = new StateReadRecord(txId);
+    final StateSpendRecord spent = new StateSpendRecord(txId);
+    final StateLock lock = new StateLock(txId, StateLockType.CREATE);
+    final StateNullifier nullifier = new StateNullifier(HexBytes.fromString("0xbb"), spent);
+
+    assertEquals(confirmed, confirmed);
+    assertEquals(read, read);
+    assertEquals(spent, spent);
+    assertEquals(lock, lock);
+    assertEquals(nullifier, nullifier);
+
+    assertNotEquals(lock, new StateLock(txId, StateLockType.SPEND));
+    assertNotEquals(nullifier, new StateNullifier(HexBytes.fromString("0xcc"), spent));
+    assertNotEquals(confirmed, new StateConfirmRecord(UUID.randomUUID()));
+  }
 }

--- a/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/transaction/TransactionEnumsTest.java
+++ b/sdk/java/core/src/test/java/org/lfdt/paladin/sdk/core/transaction/TransactionEnumsTest.java
@@ -37,8 +37,18 @@ class TransactionEnumsTest {
   }
 
   @Test
+  void transactionTypeMapsEveryToken() {
+    for (final TransactionType type : TransactionType.values()) {
+      assertEquals(type, TransactionType.fromJson(type.jsonValue()));
+      assertEquals(type, TransactionType.fromJson(type.jsonValue().toUpperCase()));
+    }
+  }
+
+  @Test
   void transactionTypeRejectsUnknownToken() {
     assertThrows(Exception.class, () -> MAPPER.readValue("\"hybrid\"", TransactionType.class));
+    assertThrows(IllegalArgumentException.class, () -> TransactionType.fromJson("hybrid"));
+    assertThrows(IllegalArgumentException.class, () -> TransactionType.fromJson(null));
   }
 
   @Test
@@ -56,7 +66,17 @@ class TransactionEnumsTest {
   }
 
   @Test
+  void submitModeMapsEveryToken() {
+    for (final SubmitMode mode : SubmitMode.values()) {
+      assertEquals(mode, SubmitMode.fromJson(mode.jsonValue()));
+      assertEquals(mode, SubmitMode.fromJson(mode.jsonValue().toUpperCase()));
+    }
+  }
+
+  @Test
   void submitModeRejectsUnknownToken() {
     assertThrows(Exception.class, () -> MAPPER.readValue("\"manual\"", SubmitMode.class));
+    assertThrows(IllegalArgumentException.class, () -> SubmitMode.fromJson("manual"));
+    assertThrows(IllegalArgumentException.class, () -> SubmitMode.fromJson(null));
   }
 }


### PR DESCRIPTION
## What

Second PR toward #1239 (remaining RPC modules). Adds the state store namespace client on top of the existing async JSON-RPC transport, with its data models and unit tests.

- **`StateStoreClient`** (`pstate_*`) — all 7 methods: `listSchemas`, `storeState`, `queryStates`, `queryContractStates`, `queryNullifiers`, `queryContractNullifiers`, `transferPrivateState`.

Note the wire prefix is `pstate_`, not `statestore_`.

## Data models (in `core`, package `statestore`)

- `Schema`, `State`, `StateConfirmRecord`, `StateReadRecord`, `StateSpendRecord`, `StateLock`, `StateNullifier`
- `SchemaType`, `StateLockType` (enums)
- `StateStatusQualifier` — a value type covering the standard qualifiers (`available` / `confirmed` / `unconfirmed` / `spent` / `all`) or a transaction id via `forTransaction(UUID)`

## Behaviour note

`queryStates` and `queryContractNullifiers` **always send** the trailing `StateStatusQualifier` parameter, so the query is scoped correctly on the server. This is deliberate: all four query methods take and forward the qualifier. The tests assert the qualifier is present in the outgoing params.

`State` flattens Go's embedded `StateBase` fields (id, created, domain, schema, contractAddress, data) directly, consistent with the existing `TransactionInput` style.

## Testing

- Per-method client tests using the in-process `MockJsonRpcServer`, asserting both the deserialized result and the outgoing method name / params (including qualifier presence and position), plus an error-path test.
- Round-trip / equals / toString tests for every new data model, including the standard-value and UUID paths of `StateStatusQualifier`.
- `./gradlew :sdk:java:core:check :sdk:java:client:check` passes (tests, Checkstyle, JaCoCo ≥ 0.78, Javadoc doclint, Spotless).

## Scope

WebSocket subscriptions, pgroup, and the top-level client facade are out of scope here and land in the final PR under #1239.