### PR TITLE
Public tx mgr logging

### DIFF
--- a/common/go/pkg/log/log.go
+++ b/common/go/pkg/log/log.go
@@ -241,6 +241,10 @@ func IsDebugEnabled() bool {
 	return atomLevel.Enabled(zapcore.DebugLevel)
 }
 
+func IsInfoEnabled() bool {
+	return atomLevel.Enabled(zapcore.InfoLevel)
+}
+
 func IsTraceEnabled() bool {
 	return atomLevel.Enabled(LevelTrace)
 }

--- a/common/go/pkg/log/log_test.go
+++ b/common/go/pkg/log/log_test.go
@@ -233,6 +233,7 @@ func TestSettingTraceLevel(t *testing.T) {
 func TestSettingInfoLevel(t *testing.T) {
 	SetLevel("info")
 	assert.False(t, IsDebugEnabled())
+	assert.True(t, IsInfoEnabled())
 	assert.Equal(t, "info", GetLevel())
 }
 

--- a/core/go/internal/publictxmgr/balance_manager.go
+++ b/core/go/internal/publictxmgr/balance_manager.go
@@ -72,9 +72,9 @@ func (af *BalanceManagerWithInMemoryTracking) GetAddressBalance(ctx context.Cont
 		af.retrieveAddressBalanceMap[address] = false
 	} else {
 		addressBalance = *cachedAddressBalance
-		log.L(ctx).Tracef("Retrieved balance for address %s from cache: %s", address, addressBalance.String())
+		log.L(ctx).Tracef("Retrieved balance for address %s from cache: %s", address, &addressBalance)
 	}
-	log.L(ctx).Debugf("Retrieved balance for address %s: %s", address, addressBalance.String())
+	log.L(ctx).Debugf("Retrieved balance for address %s: %s", address, &addressBalance)
 
 	return &AddressAccount{
 		Address: address,

--- a/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
@@ -143,7 +143,9 @@ func (it *inFlightTransactionStageController) MarkTime(eventName string) {
 		it.txTimeline[len(it.txTimeline)-1].tillNextEvent = time.Since(it.txTimeline[len(it.txTimeline)-1].timestamp)
 		if len(it.txTimeline) == it.timeLineLoggingMaxEntries {
 			// the array is full, we need to print the timeline and reset it
-			it.PrintTimeline()
+			if log.IsInfoEnabled() {
+				log.L(it.ctx).Infof("Timeline for %s: %s", it.privateTXID, it.PrintTimeline())
+			}
 			it.txTimeline = make([]PointOfTime, 0, it.timeLineLoggingMaxEntries)
 		}
 		it.txTimeline = append(it.txTimeline, PointOfTime{

--- a/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
@@ -576,7 +576,7 @@ func (it *inFlightTransactionStageController) startNewStage(ctx context.Context,
 	//    from the node but it is flaky behaviour that we have observed and should guard against
 	lastSubmitTime := it.stateManager.GetLastSubmitTime()
 	if lastSubmitTime != nil && time.Since(lastSubmitTime.Time()) > it.resubmitInterval {
-		log.L(ctx).Debugf("Transaction with ID %s entering retrieve gas price as exceeded resubmit interval of %s.", it.stateManager.GetSignerNonce(), it.resubmitInterval.String())
+		log.L(ctx).Debugf("Transaction with ID %s entering retrieve gas price as exceeded resubmit interval of %s.", it.stateManager.GetSignerNonce(), it.resubmitInterval)
 		it.TriggerNewStageRun(ctx, InFlightTxStageRetrieveGasPrice, BaseTxSubStatusStale)
 		return
 	}

--- a/core/go/internal/publictxmgr/in_flight_transaction_state_manager.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_state_manager.go
@@ -77,23 +77,23 @@ func (iftxs *inFlightTransactionState) CanBeRemoved(ctx context.Context) bool {
 }
 
 func (iftxs *inFlightTransactionState) CanSubmit(ctx context.Context, cost *big.Int, signerNonce string) bool {
-	log.L(ctx).Tracef("ProcessInFlightTransaction transaction entry, transaction orchestrator context: %+v, cost: %s", iftxs.orchestratorContext, cost.String())
+	log.L(ctx).Tracef("ProcessInFlightTransaction transaction entry, transaction orchestrator context: %+v, cost: %s", iftxs.orchestratorContext, cost)
 	if iftxs.orchestratorContext.AvailableToSpend == nil {
 		log.L(ctx).Tracef("ProcessInFlightTransaction transaction can be submitted for zero gas price chain, orchestrator context: %+v", iftxs.orchestratorContext)
 		return true
 	}
 	if cost != nil {
 		if iftxs.orchestratorContext.PreviousNonceCostUnknown {
-			log.L(ctx).Warnf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s, previous nonce cost unknown", signerNonce, iftxs.orchestratorContext, cost.String())
+			log.L(ctx).Warnf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s, previous nonce cost unknown", signerNonce, iftxs.orchestratorContext, cost)
 			return false
 		}
 		sufficientFunds := iftxs.orchestratorContext.AvailableToSpend.Cmp(cost) != -1
 		if !sufficientFunds {
-			log.L(ctx).Warnf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s, insufficient funds", signerNonce, iftxs.orchestratorContext, cost.String())
+			log.L(ctx).Warnf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s, insufficient funds", signerNonce, iftxs.orchestratorContext, cost)
 		}
 		return sufficientFunds
 	}
-	log.L(ctx).Debugf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s", signerNonce, iftxs.orchestratorContext, cost.String())
+	log.L(ctx).Debugf("ProcessInFlightTransaction cannot submit transaction %s, transaction orchestrator context: %+v, cost: %s", signerNonce, iftxs.orchestratorContext, cost)
 	return false
 }
 

--- a/core/go/internal/publictxmgr/transaction_manager_loop.go
+++ b/core/go/internal/publictxmgr/transaction_manager_loop.go
@@ -128,7 +128,7 @@ func (ptm *pubTxManager) poll(ctx context.Context) (polled int, total int) {
 		// Note not controlled by mutex, as only modified on this routine.
 		for signingAddress, pausedUntil := range ptm.signingAddressesPausedUntil {
 			if time.Now().Before(pausedUntil) {
-				log.L(ctx).Debugf("Engine excluded orchestrator for signing address %s from polling as it's paused util %s", signingAddress, pausedUntil.String())
+				log.L(ctx).Debugf("Engine excluded orchestrator for signing address %s from polling as it's paused util %s", signingAddress, pausedUntil)
 				stateCounts[string(OrchestratorStatePaused)] = stateCounts[string(OrchestratorStatePaused)] + 1
 				inFlightSigningAddresses = append(inFlightSigningAddresses, signingAddress)
 			}

--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -403,7 +403,9 @@ func (oc *orchestrator) pollAndProcess(ctx context.Context) (polled int, total i
 			oc.totalCompleted = oc.totalCompleted + 1
 			queueUpdated = true
 			log.L(ctx).Debugf("Orchestrator poll and process, marking %s as complete after: %s", p.stateManager.GetSignerNonce(), time.Since(p.stateManager.GetCreatedTime().Time()))
-			p.PrintTimeline()
+			if p.timeLineLoggingMaxEntries > 0 && log.IsInfoEnabled() {
+				log.L(ctx).Infof("Timeline for %s: %s", p.stateManager.GetSignerNonce(), p.PrintTimeline())
+			}
 		} else {
 			log.L(ctx).Debugf("Orchestrator poll and process, continuing tx %s after: %s", p.stateManager.GetSignerNonce(), time.Since(p.stateManager.GetCreatedTime().Time()))
 			newInFlight = append(newInFlight, p)

--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -553,11 +553,10 @@ func (oc *orchestrator) ProcessInFlightTransactions(ctx context.Context, its []*
 	waitingForBalance = false
 	var addressAccount *AddressAccount
 	skipBalanceCheck := oc.hasZeroGasPrice
-	now := time.Now()
-	log.L(ctx).Debugf("%s ProcessInFlightTransaction entry for signing address %s", now.String(), oc.signingAddress)
+	log.L(ctx).Debugf("ProcessInFlightTransaction entry for signing address %s", oc.signingAddress)
 
 	if !skipBalanceCheck {
-		log.L(ctx).Debugf("%s: ProcessInFlightTransaction checking balance for %s", now.String(), oc.signingAddress)
+		log.L(ctx).Debugf("ProcessInFlightTransaction checking balance for %s", oc.signingAddress)
 
 		addressAccount, err = oc.balanceManager.GetAddressBalance(oc.ctx, oc.signingAddress)
 		if err != nil {
@@ -579,7 +578,7 @@ func (oc *orchestrator) ProcessInFlightTransactions(ctx context.Context, its []*
 
 	previousNonceCostUnknown := false
 	for i, it := range its {
-		log.L(ctx).Debugf("%s ProcessInFlightTransaction for signing address %s processing transaction with ID: %s, index: %d", now.String(), oc.signingAddress, it.stateManager.GetSignerNonce(), i)
+		log.L(ctx).Debugf("ProcessInFlightTransaction for signing address %s processing transaction with ID: %s, index: %d", oc.signingAddress, it.stateManager.GetSignerNonce(), i)
 		var availableToSpend *big.Int
 		if !skipBalanceCheck {
 			availableToSpend = addressAccount.GetAvailableToSpend(ctx)
@@ -603,7 +602,7 @@ func (oc *orchestrator) ProcessInFlightTransactions(ctx context.Context, its []*
 		}
 	}
 
-	log.L(ctx).Debugf("%s ProcessInFlightTransaction exit for signing address: %s", now.String(), oc.signingAddress)
+	log.L(ctx).Debugf("ProcessInFlightTransaction exit for signing address: %s", oc.signingAddress)
 	log.L(ctx).Debugf("Orchestrator process loop took %s", time.Since(processStart))
 	return waitingForBalance, nil
 }


### PR DESCRIPTION
All these log lines are on very hot paths that get called multiple times per transaction so small numbers of unnecessary allocs per line can drive a lot of GC.

* Stop calling `.String()` on format arguments - let the formatter do this _only_ if the log is included at the current level
* Stop including time arguments - these drive allocs even if not passed with `.String()` and we get a timestamp included in the log already. These are a carry over from an earlier version of code where I think they contributed to performance analysis, but at debug level the same data would be better derived from metrics
* Fix a bug where timelines were built but never actually printed (not perf related)