### PR TITLE
use sync channels not eventually statements

### DIFF
--- a/core/go/pkg/blockindexer/block_indexer.go
+++ b/core/go/pkg/blockindexer/block_indexer.go
@@ -113,6 +113,7 @@ type blockIndexer struct {
 	dispatcherDone             chan struct{}
 	rpcModule                  *rpcserver.RPCModule
 	ignoredTransactionTypes    []int64
+	eventStreamsStarted        chan struct{} // Notified each time the event streams have been (re)started
 }
 
 func NewBlockIndexer(ctx context.Context, config *pldconf.BlockIndexerConfig, wsConfig *pldconf.WSClientConfig, persistence persistence.Persistence) (_ BlockIndexer, err error) {
@@ -143,6 +144,7 @@ func newBlockIndexer(ctx context.Context, conf *pldconf.BlockIndexerConfig, pers
 		esBlockDispatchQueueLength: confutil.IntMin(conf.EventStreams.BlockDispatchQueueLength, 0, *pldconf.BlockIndexerDefaults.EventStreams.BlockDispatchQueueLength),
 		esCatchUpQueryPageSize:     confutil.IntMin(conf.EventStreams.CatchUpQueryPageSize, 0, *pldconf.BlockIndexerDefaults.EventStreams.CatchUpQueryPageSize),
 		dispatcherTap:              make(chan struct{}, 1),
+		eventStreamsStarted:        make(chan struct{}, 1),
 		ignoredTransactionTypes:    confutil.Int64Slice(conf.IgnoredTransactionTypes, pldconf.BlockIndexerDefaults.IgnoredTransactionTypes),
 	}
 	bi.highestConfirmedBlock.Store(&ConfirmedBlockMetadata{Number: -1, Timestamp: -1})

--- a/core/go/pkg/blockindexer/block_indexer_test.go
+++ b/core/go/pkg/blockindexer/block_indexer_test.go
@@ -893,11 +893,10 @@ func TestBlockIndexerResetsAfterHashLookupFail(t *testing.T) {
 	assert.True(t, sentFail)
 
 	// Check that the event stream goroutines are now running
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		es := bi.eventStreams[eventStream.Definition().ID]
-		assert.NotNil(c, es.detectorDone, "Event stream detector should be started after reset")
-		assert.NotNil(c, es.dispatcherDone, "Event stream dispatcher should be started after reset")
-	}, testTimeout(t), 100*time.Millisecond, "Event streams should be started after reset")
+	<-bi.eventStreamsStarted
+	es = bi.eventStreams[eventStream.Definition().ID]
+	require.NotNil(t, es.detectorDone, "Event stream detector should be started after reset")
+	require.NotNil(t, es.dispatcherDone, "Event stream dispatcher should be started after reset")
 }
 
 func TestBlockIndexerResetsAfterReceiptIntegrityFail(t *testing.T) {
@@ -955,11 +954,10 @@ func TestBlockIndexerResetsAfterReceiptIntegrityFail(t *testing.T) {
 
 	assert.True(t, sentFail)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		es := bi.eventStreams[eventStream.Definition().ID]
-		assert.NotNil(c, es.detectorDone, "Event stream detector should be started after reset")
-		assert.NotNil(c, es.dispatcherDone, "Event stream dispatcher should be started after reset")
-	}, testTimeout(t), 100*time.Millisecond, "Event streams should be started after reset")
+	<-bi.eventStreamsStarted
+	es = bi.eventStreams[eventStream.Definition().ID]
+	require.NotNil(t, es.detectorDone, "Event stream detector should be started after reset")
+	require.NotNil(t, es.dispatcherDone, "Event stream dispatcher should be started after reset")
 }
 
 func TestBlockIndexerDispatcherFallsBehindHead(t *testing.T) {

--- a/core/go/pkg/blockindexer/event_streams.go
+++ b/core/go/pkg/blockindexer/event_streams.go
@@ -38,27 +38,28 @@ import (
 )
 
 type eventStream struct {
-	ctx               context.Context
-	cancelCtx         context.CancelFunc
-	bi                *blockIndexer
-	definition        *EventStreamDefinition
-	signatures        map[string]bool
-	signatureList     []pldtypes.Bytes32
-	batchSize         int
-	batchTimeout      time.Duration
-	blocks            chan *eventStreamBlock
-	dispatch          chan *detectorMsg
-	useNOTXHandler    bool
-	handlerDBTX       InternalStreamCallbackDBTX
-	handlerNOTX       InternalStreamCallbackNOTX
-	serializer        *abi.Serializer
-	detectorDone      chan struct{}
-	detectorStarted   chan struct{}
-	dispatcherDone    chan struct{}
-	dispatcherStarted chan struct{}
-	fromBlock         *ethtypes.HexUint64 // nil == latest
-	checkpoint        atomic.Int64        // set after we persist checkpoint
-	catchup           atomic.Bool
+	ctx                 context.Context
+	cancelCtx           context.CancelFunc
+	bi                  *blockIndexer
+	definition          *EventStreamDefinition
+	signatures          map[string]bool
+	signatureList       []pldtypes.Bytes32
+	batchSize           int
+	batchTimeout        time.Duration
+	blocks              chan *eventStreamBlock
+	dispatch            chan *detectorMsg
+	useNOTXHandler      bool
+	handlerDBTX         InternalStreamCallbackDBTX
+	handlerNOTX         InternalStreamCallbackNOTX
+	serializer          *abi.Serializer
+	detectorDone        chan struct{}
+	detectorStarted     chan struct{}
+	dispatcherDone      chan struct{}
+	dispatcherStarted   chan struct{}
+	fromBlock           *ethtypes.HexUint64 // nil == latest
+	checkpoint          atomic.Int64        // set after we persist checkpoint
+	catchup             atomic.Bool
+	checkpointCommitted chan int64
 }
 
 type eventBatch struct {
@@ -255,12 +256,13 @@ func (bi *blockIndexer) initEventStream(ctx context.Context, definition *EventSt
 		es.definition.Config = definition.Config
 	} else {
 		es = &eventStream{
-			bi:         bi,
-			definition: definition,
-			signatures: make(map[string]bool),
-			blocks:     make(chan *eventStreamBlock, bi.esBlockDispatchQueueLength),
-			dispatch:   make(chan *detectorMsg, batchSize),
-			serializer: definition.Format.GetABISerializerIgnoreErrors(ctx),
+			bi:                  bi,
+			definition:          definition,
+			signatures:          make(map[string]bool),
+			blocks:              make(chan *eventStreamBlock, bi.esBlockDispatchQueueLength),
+			dispatch:            make(chan *detectorMsg, batchSize),
+			serializer:          definition.Format.GetABISerializerIgnoreErrors(ctx),
+			checkpointCommitted: make(chan int64, 1),
 		}
 	}
 
@@ -391,6 +393,10 @@ func (bi *blockIndexer) startEventStreams() {
 			// no possibility of error if not updating DB
 			_ = es.start(false)
 		}
+	}
+	select {
+	case bi.eventStreamsStarted <- struct{}{}:
+	default: // nobody is listening, or a previous start is still unread
 	}
 }
 
@@ -761,8 +767,21 @@ func (es *eventStream) updateCheckpoint(ctx context.Context, dbTX persistence.DB
 		Error
 	if err == nil {
 		es.checkpoint.Store(blockNumber)
+		if dbTX.FullTransaction() {
+			dbTX.AddPostCommit(func(txCtx context.Context) { es.notifyCheckpointCommitted(blockNumber) })
+		} else {
+			// The statement above is the whole transaction, so it is already committed
+			es.notifyCheckpointCommitted(blockNumber)
+		}
 	}
 	return err
+}
+
+func (es *eventStream) notifyCheckpointCommitted(blockNumber int64) {
+	select {
+	case es.checkpointCommitted <- blockNumber:
+	default: // nobody is listening, or a previous update is still unread
+	}
 }
 
 func (es *eventStream) runBatch(batch *eventBatch) error {

--- a/core/go/pkg/blockindexer/event_streams_test.go
+++ b/core/go/pkg/blockindexer/event_streams_test.go
@@ -217,6 +217,9 @@ func TestInternalEventStreamDeliveryCatchUp(t *testing.T) {
 
 	// Set up our handler, even though it won't be driven with anything yet
 	eventCollector := make(chan *pldapi.EventWithData)
+	// Notified with the block of the last event in each batch, once that batch (including its
+	// checkpoint update) has committed. Buffered so the dispatcher is never held up by us.
+	batchCommitted := make(chan int64, len(blocks))
 	var esID string
 	handler := func(ctx context.Context, dbTX persistence.DBTX, batch *EventDeliveryBatch) error {
 		if esID == "" {
@@ -233,6 +236,8 @@ func TestInternalEventStreamDeliveryCatchUp(t *testing.T) {
 			case <-ctx.Done():
 			}
 		}
+		lastBlock := batch.Events[len(batch.Events)-1].BlockNumber
+		dbTX.AddPostCommit(func(txCtx context.Context) { batchCommitted <- lastBlock })
 		return nil
 	}
 
@@ -301,14 +306,19 @@ func TestInternalEventStreamDeliveryCatchUp(t *testing.T) {
 		}
 	}
 
-	// Wait for checkpoint
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		es := bi.eventStreams[uuid.MustParse(esID)]
-		baseBlock, err := es.readDBCheckpoint()
-		assert.NoError(t, err)
-		assert.NotNil(t, baseBlock)
-		assert.Equal(t, int64(14), *baseBlock, "Checkpoint block should be 14")
-	}, testTimeout(t), 10*time.Millisecond, "Checkpoint not written")
+	// Wait for the batch carrying the last event of the final block to commit - at that point
+	// the checkpoint for that block is durable
+	for committedBlock := range batchCommitted {
+		if committedBlock >= int64(len(blocks)-1) {
+			break
+		}
+	}
+
+	es := bi.eventStreams[uuid.MustParse(esID)]
+	baseBlock, err := es.readDBCheckpoint()
+	require.NoError(t, err)
+	require.NotNil(t, baseBlock)
+	require.Equal(t, int64(14), *baseBlock, "Checkpoint block should be 14")
 
 	// Stop and restart
 	bi.Stop()
@@ -325,7 +335,7 @@ func TestInternalEventStreamDeliveryCatchUp(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check it's back to the checkpoint we expect
-	es := bi.eventStreams[uuid.MustParse(esID)]
+	es = bi.eventStreams[uuid.MustParse(esID)]
 	cp, err := es.processCheckpoint()
 	require.NoError(t, err)
 	require.NotNil(t, cp)
@@ -670,6 +680,10 @@ func TestStartStopEventStream(t *testing.T) {
 	defer done()
 	esID := uuid.New()
 
+	// The detector runs its startup queries on its own routine, so they do not have a
+	// deterministic order against the start/stop updates we drive from this routine
+	p.Mock.MatchExpectationsInOrder(false)
+
 	// doesn't exist
 	err := bi.StartEventStream(ctx, esID)
 	require.ErrorContains(t, err, "PD011312")
@@ -722,10 +736,8 @@ func TestStartStopEventStream(t *testing.T) {
 	p.Mock.ExpectExec("UPDATE.*event_streams").WillReturnError(errors.New("pop"))
 	p.Mock.ExpectExec("UPDATE.*event_streams").WillReturnResult(sqlmock.NewResult(1, 1))
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		err = bi.StopEventStream(ctx, esID)
-		assert.ErrorContains(c, err, "pop")
-	}, testTimeout(t), 1*time.Millisecond)
+	err = bi.StopEventStream(ctx, esID)
+	require.ErrorContains(t, err, "pop")
 	// Failed DB update must not flip in-memory started status
 	require.NotNil(t, eventStream.definition.Started)
 	assert.True(t, *eventStream.definition.Started)
@@ -1138,11 +1150,12 @@ func TestDispatcherBlockConfirmedCheckpoint(t *testing.T) {
 			ID:   esID,
 			Type: EventStreamTypeInternal.Enum(),
 		},
-		batchSize:         10,
-		batchTimeout:      1 * time.Second,
-		dispatch:          make(chan *detectorMsg, 5),
-		dispatcherDone:    make(chan struct{}),
-		dispatcherStarted: make(chan struct{}),
+		batchSize:           10,
+		batchTimeout:        1 * time.Second,
+		dispatch:            make(chan *detectorMsg, 5),
+		dispatcherDone:      make(chan struct{}),
+		dispatcherStarted:   make(chan struct{}),
+		checkpointCommitted: make(chan int64, 1),
 	}
 
 	// Expect one DB write for block 5; block 3 is below the checkpoint so it should be skipped.
@@ -1156,8 +1169,8 @@ func TestDispatcherBlockConfirmedCheckpoint(t *testing.T) {
 	// Advance checkpoint to block 5 — expect a DB write.
 	es.dispatch <- &detectorMsg{confirmed: &blockConfirmed{blockNumber: 5}}
 
-	// Wait until the checkpoint has been stored in memory before sending the stale one.
-	require.Eventually(t, func() bool { return es.checkpoint.Load() == 5 }, testTimeout(t), time.Millisecond)
+	// Wait for that checkpoint write to be committed before checking the in-memory value
+	require.Equal(t, int64(5), <-es.checkpointCommitted)
 	assert.Equal(t, int64(5), es.checkpoint.Load())
 
 	cancelCtx()
@@ -1391,13 +1404,6 @@ func TestNOTXHandler(t *testing.T) {
 	err = es.runBatch(&eventBatch{})
 	assert.NoError(t, err)
 	assert.False(t, returnErr)
-}
-
-func testTimeout(t *testing.T) time.Duration {
-	if deadline, hasDeadline := t.Deadline(); hasDeadline {
-		return time.Until(deadline) - time.Second // Subtract a small buffer to ensure test cleanup
-	}
-	return 30 * time.Second // Default timeout if no deadline is set
 }
 
 func TestEventStreamGetters(t *testing.T) {


### PR DESCRIPTION
Factor eventually statements out of block indexer tests and replace with synchronisation channels. This stops us from having to give a timeout to each statement. It means the tests will run faster in most cases, and where there is an unexpected wait (e.g. runner contention but only briefly) stops spurious test failures.