### PR TITLE
Page by seq not created

### DIFF
--- a/core/go/db/migrations/postgres/000038_transactions_seq.down.sql
+++ b/core/go/db/migrations/postgres/000038_transactions_seq.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX transactions_seq;
+ALTER TABLE transactions DROP COLUMN "seq";

--- a/core/go/db/migrations/postgres/000038_transactions_seq.up.sql
+++ b/core/go/db/migrations/postgres/000038_transactions_seq.up.sql
@@ -1,0 +1,5 @@
+-- when transactions are insterted in batches, created is not unique. An incrementing
+-- seq column ensures that we can order within a batch, which is necessary for correct
+-- submission ordering of chained transactions.
+ALTER TABLE transactions ADD "seq" BIGINT GENERATED ALWAYS AS IDENTITY;
+CREATE UNIQUE INDEX transactions_seq ON transactions("seq");

--- a/core/go/db/migrations/sqlite/000038_transactions_seq.down.sql
+++ b/core/go/db/migrations/sqlite/000038_transactions_seq.down.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS transactions;
+CREATE TABLE transactions (
+  "id"                        UUID            NOT NULL,
+  "idempotency_key"           TEXT,
+  "created"                   BIGINT          NOT NULL,
+  "type"                      TEXT            NOT NULL,
+  "submit_mode"               VARCHAR         NOT NULL,
+  "abi_ref"                   TEXT            NOT NULL,
+  "function"                  TEXT,
+  "domain"                    TEXT,
+  "from"                      TEXT            NOT NULL,
+  "to"                        TEXT,
+  "data"                      TEXT,
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("abi_ref") REFERENCES abis ("hash") ON DELETE CASCADE
+);
+CREATE INDEX transactions_created ON transactions("created", "submit_mode");
+CREATE INDEX transactions_domain ON transactions("domain");
+CREATE UNIQUE INDEX transactions_idempotency_key ON transactions("idempotency_key");

--- a/core/go/db/migrations/sqlite/000038_transactions_seq.down.sql
+++ b/core/go/db/migrations/sqlite/000038_transactions_seq.down.sql
@@ -1,5 +1,9 @@
-DROP TABLE IF EXISTS transactions;
-CREATE TABLE transactions (
+-- Reverse of the up migration: rebuild the table without "seq", restoring "id" as the PRIMARY KEY.
+-- Same procedure and the same requirement that PRAGMA foreign_keys is off.
+--
+-- The copy is ordered by "seq" so that rows are written back in the order the dropped column
+-- recorded, which is the best that "created" alone can then represent.
+CREATE TABLE transactions_old (
   "id"                        UUID            NOT NULL,
   "idempotency_key"           TEXT,
   "created"                   BIGINT          NOT NULL,
@@ -14,6 +18,16 @@ CREATE TABLE transactions (
   PRIMARY KEY ("id"),
   FOREIGN KEY ("abi_ref") REFERENCES abis ("hash") ON DELETE CASCADE
 );
+
+INSERT INTO transactions_old
+  ("id", "idempotency_key", "created", "type", "submit_mode", "abi_ref", "function", "domain", "from", "to", "data")
+  SELECT
+   "id", "idempotency_key", "created", "type", "submit_mode", "abi_ref", "function", "domain", "from", "to", "data"
+  FROM transactions ORDER BY "seq";
+
+DROP TABLE transactions;
+ALTER TABLE transactions_old RENAME TO transactions;
+
 CREATE INDEX transactions_created ON transactions("created", "submit_mode");
 CREATE INDEX transactions_domain ON transactions("domain");
 CREATE UNIQUE INDEX transactions_idempotency_key ON transactions("idempotency_key");

--- a/core/go/db/migrations/sqlite/000038_transactions_seq.up.sql
+++ b/core/go/db/migrations/sqlite/000038_transactions_seq.up.sql
@@ -1,0 +1,27 @@
+-- when transactions are insterted in batches, created is not unique. An incrementing
+-- seq column ensures that we can order within a batch, which is necessary for correct
+-- submission ordering of chained transactions.
+--
+-- SQLite cannot add an auto-incrementing column with ALTER TABLE: AUTOINCREMENT is only available
+-- on an INTEGER PRIMARY KEY. So the table is rebuilt, with "id" moving from PRIMARY KEY to a
+-- UNIQUE index to make room.
+DROP TABLE IF EXISTS transactions;
+CREATE TABLE transactions (
+  "seq"                       INTEGER         PRIMARY KEY AUTOINCREMENT,
+  "id"                        UUID            NOT NULL,
+  "idempotency_key"           TEXT,
+  "created"                   BIGINT          NOT NULL,
+  "type"                      TEXT            NOT NULL,
+  "submit_mode"               VARCHAR         NOT NULL,
+  "abi_ref"                   TEXT            NOT NULL,
+  "function"                  TEXT,
+  "domain"                    TEXT,
+  "from"                      TEXT            NOT NULL,
+  "to"                        TEXT,
+  "data"                      TEXT,
+  FOREIGN KEY ("abi_ref") REFERENCES abis ("hash") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX transactions_id ON transactions("id");
+CREATE INDEX transactions_created ON transactions("created", "submit_mode");
+CREATE INDEX transactions_domain ON transactions("domain");
+CREATE UNIQUE INDEX transactions_idempotency_key ON transactions("idempotency_key");

--- a/core/go/db/migrations/sqlite/000038_transactions_seq.up.sql
+++ b/core/go/db/migrations/sqlite/000038_transactions_seq.up.sql
@@ -3,10 +3,23 @@
 -- submission ordering of chained transactions.
 --
 -- SQLite cannot add an auto-incrementing column with ALTER TABLE: AUTOINCREMENT is only available
--- on an INTEGER PRIMARY KEY. So the table is rebuilt, with "id" moving from PRIMARY KEY to a
--- UNIQUE index to make room.
-DROP TABLE IF EXISTS transactions;
-CREATE TABLE transactions (
+-- on an INTEGER PRIMARY KEY. So the table is rebuilt following the procedure in
+-- https://sqlite.org/lang_altertable.html#otheralter - copy into a new table, drop the old one,
+-- rename the new one into its place - with "id" moving from PRIMARY KEY to a UNIQUE index to make
+-- room. The UNIQUE index keeps "id" a valid parent key for the four tables whose foreign keys
+-- reference transactions("id").
+--
+-- The copy is ordered by "created" so existing rows get sequences in the closest approximation of
+-- write order the old schema can express. That is only approximate for rows sharing a timestamp -
+-- exactly the ambiguity this column exists to remove - which is acceptable because it applies only
+-- to rows written before the migration. The indexes are recreated after the rename because index
+-- names are unique across the schema, so the old table's must be dropped with it first.
+--
+-- Requires PRAGMA foreign_keys to be off, as the procedure above documents, otherwise dropping the
+-- old table cascades deletes into its dependants. Paladin never enables it (see sqlite.go), and it
+-- cannot be set here in any case - golang-migrate wraps each migration in a transaction, and SQLite
+-- silently ignores the pragma inside one.
+CREATE TABLE transactions_new (
   "seq"                       INTEGER         PRIMARY KEY AUTOINCREMENT,
   "id"                        UUID            NOT NULL,
   "idempotency_key"           TEXT,
@@ -21,6 +34,16 @@ CREATE TABLE transactions (
   "data"                      TEXT,
   FOREIGN KEY ("abi_ref") REFERENCES abis ("hash") ON DELETE CASCADE
 );
+
+INSERT INTO transactions_new
+  ("id", "idempotency_key", "created", "type", "submit_mode", "abi_ref", "function", "domain", "from", "to", "data")
+  SELECT
+   "id", "idempotency_key", "created", "type", "submit_mode", "abi_ref", "function", "domain", "from", "to", "data"
+  FROM transactions ORDER BY "created";
+
+DROP TABLE transactions;
+ALTER TABLE transactions_new RENAME TO transactions;
+
 CREATE UNIQUE INDEX transactions_id ON transactions("id");
 CREATE INDEX transactions_created ON transactions("created", "submit_mode");
 CREATE INDEX transactions_domain ON transactions("domain");

--- a/core/go/internal/components/txmgr.go
+++ b/core/go/internal/components/txmgr.go
@@ -130,7 +130,7 @@ type TXManager interface {
 	GetPublicTransactionByNonce(ctx context.Context, from pldtypes.EthAddress, nonce pldtypes.HexUint64) (*pldapi.PublicTxWithBinding, error)
 	GetPublicTransactionByHash(ctx context.Context, hash pldtypes.Bytes32) (*pldapi.PublicTxWithBinding, error)
 	QueryTransactions(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*pldapi.Transaction, error)
-	QueryTransactionsResolved(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*ResolvedTransaction, error)
+	QueryTransactionsResolved(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) (txns []*ResolvedTransaction, lastSequence int64, err error)
 	QueryTransactionsFull(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) (results []*pldapi.TransactionFull, err error)
 	QueryTransactionsFullTx(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*pldapi.TransactionFull, error)
 	QueryTransactionReceipts(ctx context.Context, jq *query.QueryJSON) ([]*pldapi.TransactionReceipt, error)

--- a/core/go/internal/sequencer/sequencer.go
+++ b/core/go/internal/sequencer/sequencer.go
@@ -158,7 +158,7 @@ func (sMgr *sequencerManager) resumeIncompleteTransactions(ctx context.Context) 
 	}
 
 	resumedTransactions := 0
-	var lastCreatedTime int64
+	var lastSequence int64
 
 	for maxTransactions > 0 && resumedTransactions < maxTransactions {
 		limit := pageSize
@@ -166,18 +166,23 @@ func (sMgr *sequencerManager) resumeIncompleteTransactions(ctx context.Context) 
 			limit = maxTransactions - resumedTransactions
 		}
 
-		query := query.NewQueryBuilder().
+		// Page on the database's write sequence, not created. created is not unique -
+		// insertTransactions() stamps a whole batch from a tight loop, so rows routinely share a
+		// nanosecond, and a cursor on created steps over every remaining row sharing the boundary
+		// timestamp so those transactions are never resumed. The sequence is unique and follows
+		// write order, so the scan visits every row exactly once and in the order written.
+		qb := query.NewQueryBuilder().
 			Limit(limit).
-			Sort("created")
-		if lastCreatedTime > 0 {
-			log.L(ctx).Debugf("Retrieving the next %d incomplete transactions to resume from timestamp %d", limit, lastCreatedTime)
-			query.GreaterThan("created", lastCreatedTime)
+			Sort("sequence")
+		if lastSequence > 0 {
+			log.L(ctx).Debugf("Retrieving the next %d incomplete transactions to resume from sequence %d", limit, lastSequence)
+			qb.GreaterThan("sequence", lastSequence)
 		} else {
 			log.L(ctx).Debugf("Retrieving the next %d incomplete transactions to resume", limit)
 		}
-		q := query.Query()
 
-		pendingTx, err := sMgr.components.TxManager().QueryTransactionsResolved(ctx, q, sMgr.components.Persistence().NOTX(), true)
+		pendingTx, nextSequence, err := sMgr.components.TxManager().QueryTransactionsResolved(ctx,
+			qb.Query(), sMgr.components.Persistence().NOTX(), true)
 		if err != nil {
 			log.L(ctx).Errorf("Error querying pending transactions to resume incomplete ones: %s", err)
 			break
@@ -194,7 +199,7 @@ func (sMgr *sequencerManager) resumeIncompleteTransactions(ctx context.Context) 
 			}
 		}
 		if len(pendingTx) > 0 {
-			lastCreatedTime = int64(pendingTx[len(pendingTx)-1].Transaction.Created)
+			lastSequence = nextSequence
 		}
 		if len(pendingTx) < pageSize {
 			break

--- a/core/go/internal/sequencer/sequencer_lifecycle_test.go
+++ b/core/go/internal/sequencer/sequencer_lifecycle_test.go
@@ -986,7 +986,7 @@ func TestSequencerManager_Start_Success(t *testing.T) {
 	allComponents.EXPECT().TxManager().Return(txManager).Maybe()
 	allComponents.EXPECT().Persistence().Return(persistence).Maybe()
 	persistence.EXPECT().NOTX().Return(nil).Maybe()
-	txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*components.ResolvedTransaction{}, nil).Maybe()
+	txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*components.ResolvedTransaction{}, 0, nil).Maybe()
 
 	// Call Start
 	err = sMgr.Start()

--- a/core/go/internal/sequencer/sequencer_test.go
+++ b/core/go/internal/sequencer/sequencer_test.go
@@ -1162,7 +1162,7 @@ func TestSequencerManager_resumeIncompleteTransactions_MaxTransactionsOverride(t
 		},
 	).Once()
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).RunAndReturn(
-		func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, error) {
+		func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, int64, error) {
 			callCount++
 			if callCount == 1 {
 				return []*components.ResolvedTransaction{
@@ -1173,9 +1173,9 @@ func TestSequencerManager_resumeIncompleteTransactions_MaxTransactionsOverride(t
 							To: pldtypes.RandAddress(),
 						},
 					}},
-				}, nil
+				}, 1, nil
 			}
-			return nil, nil
+			return nil, 0, nil
 		},
 	).Twice()
 	mocks.txManager.EXPECT().BlockedByDependencies(mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
@@ -1197,7 +1197,7 @@ func TestSequencerManager_resumeIncompleteTransactions_Pagination(t *testing.T) 
 		},
 	).Once()
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).RunAndReturn(
-		func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, error) {
+		func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, int64, error) {
 			callCount++
 			if callCount == 1 {
 				return []*components.ResolvedTransaction{
@@ -1208,9 +1208,9 @@ func TestSequencerManager_resumeIncompleteTransactions_Pagination(t *testing.T) 
 							To: pldtypes.RandAddress(),
 						},
 					}},
-				}, nil
+				}, 1, nil
 			}
-			return nil, nil
+			return nil, 0, nil
 		},
 	).Twice()
 	mocks.txManager.EXPECT().BlockedByDependencies(mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
@@ -1224,7 +1224,7 @@ func TestSequencerManager_resumeIncompleteTransactions_QueryError(t *testing.T) 
 	mocks := newSequencerLifecycleTestMocks(t)
 	sm := newSequencerManagerForTesting(t, mocks)
 
-	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).Return(nil, errors.New("query failed")).Once()
+	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).Return(nil, 0, errors.New("query failed")).Once()
 
 	sm.resumeIncompleteTransactions(ctx)
 }
@@ -1261,9 +1261,9 @@ func TestSequencerManager_pollForIncompleteTransactions_ContextCancelDuringTicke
 	// Reading the channel twice confirms both the initial resume call and at least one tick.
 	calls := make(chan struct{}, 100)
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-		func(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*components.ResolvedTransaction, error) {
+		func(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*components.ResolvedTransaction, int64, error) {
 			calls <- struct{}{}
-			return nil, nil
+			return nil, 0, nil
 		},
 	).Maybe()
 
@@ -1336,7 +1336,7 @@ func TestSequencerManager_resumeIncompleteTransactions_HandleTxResumeError(t *te
 	mocks.persistence.EXPECT().Transaction(mock.Anything, mock.Anything).Return(errors.New("tx wrapper failed")).Once()
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).Return([]*components.ResolvedTransaction{{
 		Transaction: &pldapi.Transaction{ID: confutil.P(uuid.New()), Created: pldtypes.Timestamp(time.Now().UnixNano()), TransactionBase: pldapi.TransactionBase{To: pldtypes.RandAddress()}},
-	}}, nil).Once()
+	}}, 1, nil).Once()
 	sm.resumeIncompleteTransactions(ctx)
 }
 
@@ -1376,9 +1376,9 @@ func TestSequencerManager_pollForIncompleteTransactions_BlockIndexerRetryTimer(t
 
 	resumed := make(chan struct{})
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		RunAndReturn(func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, error) {
+		RunAndReturn(func(_ context.Context, _ *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, int64, error) {
 			close(resumed)
-			return nil, nil
+			return nil, 0, nil
 		}).Once()
 
 	go sm.pollForIncompleteTransactions(ctx, time.Hour)
@@ -1400,7 +1400,7 @@ func TestSequencerManager_resumeIncompleteTransactions_LimitTrim(t *testing.T) {
 	).Twice()
 	mocks.txManager.EXPECT().BlockedByDependencies(mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Twice()
 	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).RunAndReturn(
-		func(_ context.Context, q *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, error) {
+		func(_ context.Context, q *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, int64, error) {
 			queryCount++
 			if queryCount == 1 {
 				return []*components.ResolvedTransaction{
@@ -1414,11 +1414,16 @@ func TestSequencerManager_resumeIncompleteTransactions_LimitTrim(t *testing.T) {
 						Created:         pldtypes.Timestamp(time.Now().UnixNano() + 1),
 						TransactionBase: pldapi.TransactionBase{To: pldtypes.RandAddress()},
 					}},
-				}, nil
+				}, 2, nil
 			}
+			// maxTransactions is 3 and the first page returned 2, so the second page is trimmed.
 			require.NotNil(t, q.Limit)
 			require.Equal(t, 1, *q.Limit)
-			return nil, nil
+			// And it resumes from the sequence the first page ended on.
+			require.Len(t, q.GT, 1)
+			require.Equal(t, "sequence", q.GT[0].Field)
+			require.JSONEq(t, "2", q.GT[0].Value.String())
+			return nil, 0, nil
 		},
 	).Times(2)
 
@@ -1637,4 +1642,65 @@ func TestSequencerManager_CallPrivateSmartContract_GetSmartContractError(t *test
 	mocks.domainManager.EXPECT().GetSmartContractByAddress(ctx, nil, *contractAddr).Return(nil, errors.New("not found")).Once()
 	_, err := sm.CallPrivateSmartContract(ctx, call)
 	require.Error(t, err)
+}
+
+// TestSequencerManager_resumeIncompleteTransactions_SequenceCursor proves the scan pages on the
+// database write sequence, carrying the cursor from one page to the next.
+//
+// created is not unique - insertTransactions() stamps a whole batch from a tight loop, so rows
+// routinely share a nanosecond, and a cursor on created steps over every remaining row sharing
+// the boundary timestamp so those transactions are never resumed. The losslessness this buys is
+// only observable against a real database, which TestResumePaginationBySequence covers; here we
+// check the scan asks for the right page.
+func TestSequencerManager_resumeIncompleteTransactions_SequenceCursor(t *testing.T) {
+	ctx := context.Background()
+	mocks := newSequencerLifecycleTestMocks(t)
+	sm := newSequencerManagerForTesting(t, mocks)
+	sm.config.TransactionResumePageSize = confutil.P(1)
+
+	const firstSeq int64 = 41
+
+	callCount := 0
+	var secondPageQuery *query.QueryJSON
+	mocks.persistence.EXPECT().Transaction(mock.Anything, mock.Anything).RunAndReturn(
+		func(txCtx context.Context, fn func(context.Context, persistence.DBTX) error) error {
+			return fn(txCtx, persistencemocks.NewDBTX(t))
+		},
+	).Once()
+	mocks.txManager.EXPECT().QueryTransactionsResolved(mock.Anything, mock.Anything, nil, true).RunAndReturn(
+		func(_ context.Context, q *query.QueryJSON, _ persistence.DBTX, _ bool) ([]*components.ResolvedTransaction, int64, error) {
+			callCount++
+			if callCount == 1 {
+				// Sorted on sequence, and starting from the beginning rather than a stale cursor.
+				assert.Equal(t, []string{"sequence"}, q.Sort)
+				assert.Empty(t, q.GT)
+				return []*components.ResolvedTransaction{
+					{Transaction: &pldapi.Transaction{
+						ID:      confutil.P(uuid.New()),
+						Created: pldtypes.Timestamp(time.Now().UnixNano()),
+						TransactionBase: pldapi.TransactionBase{
+							To: pldtypes.RandAddress(),
+						},
+					}},
+				}, firstSeq, nil
+			}
+			secondPageQuery = q
+			return nil, 0, nil
+		},
+	).Twice()
+	mocks.txManager.EXPECT().BlockedByDependencies(mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Once()
+
+	sm.resumeIncompleteTransactions(ctx)
+	require.Equal(t, 2, callCount)
+	require.NotNil(t, secondPageQuery)
+
+	// Sorted on sequence - unique and in write order - so the order cannot differ between pages.
+	assert.Equal(t, []string{"sequence"}, secondPageQuery.Sort)
+
+	// A single-key cursor on the sequence the first page ended at: no row is visited twice and,
+	// critically, none is stepped over. Nothing on created, and no OR branch needed.
+	require.Len(t, secondPageQuery.GT, 1)
+	assert.Equal(t, "sequence", secondPageQuery.GT[0].Field)
+	assert.JSONEq(t, "41", secondPageQuery.GT[0].Value.String())
+	assert.Empty(t, secondPageQuery.Or)
 }

--- a/core/go/internal/txmgr/transaction_query.go
+++ b/core/go/internal/txmgr/transaction_query.go
@@ -40,6 +40,7 @@ var transactionFilters = filters.FieldMap{
 	"idempotencyKey": filters.StringField("idempotency_key"),
 	"submitMode":     filters.StringField("submit_mode"),
 	"created":        filters.TimestampField("created"),
+	"sequence":       filters.Int64Field("seq"),
 	"abiReference":   filters.TimestampField("abi_ref"),
 	"functionName":   filters.StringField("fn_name"),
 	"domain":         filters.StringField(`"transactions"."domain"`),
@@ -190,8 +191,11 @@ func (tm *txManager) QueryTransactionsFull(ctx context.Context, jq *query.QueryJ
 	return tm.QueryTransactionsFullTx(ctx, jq, dbTX, pending)
 }
 
-func (tm *txManager) QueryTransactionsResolved(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*components.ResolvedTransaction, error) {
+func (tm *txManager) QueryTransactionsResolved(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*components.ResolvedTransaction, int64, error) {
 	ctx = log.WithComponent(ctx, "txmanager")
+	// Sequence of the final row in the returned order, for callers paginating with a cursor.
+	// MapResult runs once per row in result order, so the last assignment wins.
+	var lastSequence int64
 	qw := &filters.QueryWrapper[persistedTransaction, components.ResolvedTransaction]{
 		P:           tm.p,
 		Table:       "transactions",
@@ -210,14 +214,19 @@ func (tm *txManager) QueryTransactionsResolved(ctx context.Context, jq *query.Qu
 			return q
 		},
 		MapResult: func(pt *persistedTransaction) (*components.ResolvedTransaction, error) {
+			lastSequence = pt.Seq
 			return tm.mapPersistedTXResolved(pt), nil
 		},
 	}
 	ptxs, err := qw.Run(ctx, dbTX)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return tm.resolveABIReferencesAndCache(ctx, dbTX, ptxs)
+	ptxs, err = tm.resolveABIReferencesAndCache(ctx, dbTX, ptxs)
+	if err != nil {
+		return nil, 0, err
+	}
+	return ptxs, lastSequence, nil
 }
 
 func (tm *txManager) QueryTransactionsFullTx(ctx context.Context, jq *query.QueryJSON, dbTX persistence.DBTX, pending bool) ([]*pldapi.TransactionFull, error) {
@@ -394,7 +403,7 @@ func (tm *txManager) getResolvedTransactionByIDWithinTX(ctx context.Context, id 
 	}
 
 	// Do the query - this function also does the caching (so individual TXs get cached from paginated queries)
-	rtxs, err := tm.QueryTransactionsResolved(ctx, query.NewQueryBuilder().Limit(1).Equal("id", id).Query(), dbTX, false)
+	rtxs, _, err := tm.QueryTransactionsResolved(ctx, query.NewQueryBuilder().Limit(1).Equal("id", id).Query(), dbTX, false)
 	if len(rtxs) == 0 || err != nil {
 		return nil, err
 	}

--- a/core/go/internal/txmgr/transaction_query_test.go
+++ b/core/go/internal/txmgr/transaction_query_test.go
@@ -657,3 +657,48 @@ func TestIsConstructorSignatureWithNonConstructorEntry(t *testing.T) {
 	}, "()")
 	assert.True(t, result)
 }
+
+func TestQueryTransactionsResolvedFailNoCursor(t *testing.T) {
+	ctx, txm, done := newTestTransactionManager(t, false,
+		mockEmptyReceiptListeners,
+		func(conf *pldconf.TxManagerConfig, mc *mockComponents) {
+			mc.db.ExpectQuery("SELECT.*transactions").WillReturnError(fmt.Errorf("pop"))
+		})
+	defer done()
+
+	txns, lastSequence, err := txm.QueryTransactionsResolved(ctx,
+		query.NewQueryBuilder().Limit(10).Sort("sequence").Query(), txm.p.NOTX(), true)
+	assert.Regexp(t, "pop", err)
+	assert.Nil(t, txns)
+	// The cursor must not advance on a failed page, or the resume scan would skip the rows it
+	// never managed to read.
+	assert.Zero(t, lastSequence)
+}
+
+func TestQueryTransactionsResolvedABIFailNoCursor(t *testing.T) {
+	abiRef := pldtypes.RandBytes32()
+	ctx, txm, done := newTestTransactionManager(t, false,
+		mockEmptyReceiptListeners,
+		func(conf *pldconf.TxManagerConfig, mc *mockComponents) {
+			// The two dependency preloads run their own queries between the main select and the
+			// ABI lookup, and their relative order is gorm's business - match out of order rather
+			// than encoding an assumption about it.
+			mc.db.MatchExpectationsInOrder(false)
+			mc.db.ExpectQuery("SELECT.*transactions").WillReturnRows(sqlmock.NewRows(
+				[]string{"id", "abi_ref", "seq"},
+			).AddRow(uuid.New(), abiRef, 1))
+			mc.db.ExpectQuery(`SELECT.*"transaction_deps"`).WillReturnRows(sqlmock.NewRows(
+				[]string{"transaction", "depends_on"}))
+			mc.db.ExpectQuery(`SELECT.*"transaction_chained_deps"`).WillReturnRows(sqlmock.NewRows(
+				[]string{"transaction", "depends_on"}))
+			mc.db.ExpectQuery("SELECT.*abis").WillReturnError(fmt.Errorf("pop"))
+		})
+	defer done()
+
+	txns, lastSequence, err := txm.QueryTransactionsResolved(ctx,
+		query.NewQueryBuilder().Limit(10).Sort("sequence").Query(), txm.p.NOTX(), true)
+	assert.Regexp(t, "pop", err)
+	assert.Nil(t, txns)
+	// The cursor must not advance when the page could not be fully resolved.
+	assert.Zero(t, lastSequence)
+}

--- a/core/go/internal/txmgr/transaction_submission.go
+++ b/core/go/internal/txmgr/transaction_submission.go
@@ -43,6 +43,7 @@ import (
 // with this, so we have a separation of concerns on the GORM annotations and data serialization format
 type persistedTransaction struct {
 	ID                     uuid.UUID                             `gorm:"column:id;primaryKey"`
+	Seq                    int64                                 `gorm:"column:seq;<-:false"`
 	IdempotencyKey         *string                               `gorm:"column:idempotency_key"`
 	SubmitMode             pldtypes.Enum[pldapi.SubmitMode]      `gorm:"column:submit_mode"`
 	Type                   pldtypes.Enum[pldapi.TransactionType] `gorm:"column:type"`

--- a/core/go/internal/txmgr/transaction_submission_test.go
+++ b/core/go/internal/txmgr/transaction_submission_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -1205,7 +1206,7 @@ func TestChainedPrivateTXInsertWithIdempotencyKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check we can get each back
-	idemQueryKeys := make([]any, len(fifteenTxns))
+	idemQueryKeys := make([]any, 0, len(fifteenTxns))
 	for _, expected := range fifteenTxns {
 		tx, err := txm.GetTransactionByID(ctx, *expected.NewTransaction.Transaction.ID)
 		require.NoError(t, err)
@@ -1220,7 +1221,7 @@ func TestChainedPrivateTXInsertWithIdempotencyKeys(t *testing.T) {
 	}
 
 	// Check we can query them in bulk (as we would to poll the DB to perform TX management)
-	rtxs, err := txm.QueryTransactionsResolved(ctx, query.NewQueryBuilder().Limit(15).In("idempotencyKey", idemQueryKeys).Sort("created").Query(), txm.p.NOTX(), true)
+	rtxs, _, err := txm.QueryTransactionsResolved(ctx, query.NewQueryBuilder().Limit(15).In("idempotencyKey", idemQueryKeys).Sort("sequence").Query(), txm.p.NOTX(), true)
 	require.NoError(t, err)
 	require.Len(t, rtxs, 15)
 	for i, rtx := range rtxs {
@@ -1695,3 +1696,150 @@ func TestResolveUpdatedTransactionSuccess(t *testing.T) {
 	assert.Equal(t, "60fe47b1000000000000000000000000000000000000000000000000000000000000002e", hex.EncodeToString(validatedTransaction.PublicTxData))
 }
 
+// TestKeysetPaginationOverTiedCreated proves a (created, id) keyset cursor visits every row
+// exactly once when created is not unique, and that a bare "created >" cursor does not.
+//
+// insertTransactions() stamps created from a tight loop, so a batch routinely contains rows
+// sharing a nanosecond. The sequencer's resume scan pages through pending transactions with this
+// cursor - if a page boundary falls inside a tied group, a bare "created >" skips the rest of that
+// group and those transactions are never resumed. This is only observable against a real DB, since
+// the ordering of tied rows is the database's choice.
+// TestResumePaginationBySequence exercises the query the sequencer's resume scan uses, proving the
+// write sequence gives pending transactions a total order that both preserves the order they were
+// written within a batch and lets the scan page through them without skipping any - neither of
+// which created can do.
+//
+// insertTransactions() stamps created for a whole batch from a tight loop, so rows routinely share
+// a nanosecond. This test sets those collisions explicitly rather than relying on the clock, since
+// whether a tight loop actually produces them depends on the machine's timer granularity.
+func TestResumePaginationBySequence(t *testing.T) {
+	ctx, txm, done := newTestTransactionManager(t, true,
+		mockDomainContractResolve(t, "domain1"),
+		func(conf *pldconf.TxManagerConfig, mc *mockComponents) {
+			mc.sequencerMgr.On("HandleNewTx", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		},
+	)
+	defer done()
+
+	exampleABI := abi.ABI{{Type: abi.Function, Name: "doIt"}}
+	callData, err := exampleABI[0].EncodeCallDataJSON([]byte(`[]`))
+	require.NoError(t, err)
+	contractAddr := pldtypes.MustEthAddress(pldtypes.RandHex(20))
+	parentTxnID, err := txm.sendTransactionNewDBTX(ctx, &pldapi.TransactionInput{
+		TransactionBase: pldapi.TransactionBase{
+			Type:     pldapi.TransactionTypePrivate.Enum(),
+			Function: exampleABI[0].FunctionSelectorBytes().String(),
+			From:     "sender1",
+			To:       contractAddr,
+			Data:     pldtypes.JSONString(pldtypes.HexBytes(callData)),
+		},
+		ABI: exampleABI,
+	})
+	require.NoError(t, err)
+
+	const total = 15
+	txns := make([]*components.ChainedPrivateTransaction, total)
+	keys := make([]any, 0, total)
+	wantOrder := make([]string, 0, total)
+	err = txm.p.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) (err error) {
+		for i := range txns {
+			tx := newTestInternalTransaction(fmt.Sprintf("tx_%.3d", i))
+			txns[i], err = txm.PrepareChainedPrivateTransaction(ctx, dbTX, "", *parentTxnID, "domain1", contractAddr, tx, pldapi.SubmitModeAuto)
+			require.NoError(t, err)
+			keys = append(keys, txns[i].NewTransaction.Transaction.IdempotencyKey)
+			wantOrder = append(wantOrder, txns[i].NewTransaction.Transaction.IdempotencyKey)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	// One batch, so the rows are written in wantOrder and get consecutive sequence values.
+	err = txm.p.Transaction(ctx, func(ctx context.Context, dbTX persistence.DBTX) error {
+		return txm.ChainPrivateTransactions(ctx, dbTX, txns)
+	})
+	require.NoError(t, err)
+
+	// Pair the rows up on identical created values so created carries no usable order, leaving the
+	// write sequence untouched.
+	const base int64 = 1700000000000000000
+	for i, chained := range txns {
+		err = txm.p.NOTX().DB(ctx).Exec(
+			`UPDATE transactions SET "created" = ? WHERE "id" = ?`,
+			base+int64(i/2), *chained.NewTransaction.Transaction.ID).Error
+		require.NoError(t, err)
+	}
+
+	// Walk the pages exactly as the resume scan does, through the production query. Page size 1
+	// puts a boundary between every row, so every tied-created pair is exercised.
+	seen := make(map[uuid.UUID]int)
+	gotOrder := make([]string, 0, total)
+	var lastSequence int64
+	for {
+		qb := query.NewQueryBuilder().Limit(1).Sort("sequence")
+		if lastSequence > 0 {
+			qb.GreaterThan("sequence", lastSequence)
+		}
+		page, next, err := txm.QueryTransactionsResolved(ctx, qb.Query(), txm.p.NOTX(), true)
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+		require.Greater(t, next, lastSequence, "the cursor must advance")
+		for _, r := range page {
+			seen[*r.Transaction.ID]++
+			// The resume path rejects a transaction with no resolved function, so the paging query
+			// has to resolve the ABI reference like the non-paged one does.
+			require.NotNil(t, r.Function, "resumed transaction must have its function resolved")
+			require.NotNil(t, r.Function.Definition)
+			if strings.HasPrefix(r.Transaction.IdempotencyKey, "tx_") {
+				gotOrder = append(gotOrder, r.Transaction.IdempotencyKey)
+			}
+		}
+		lastSequence = next
+	}
+
+	// Every pending row visited exactly once. The parent transaction has no receipt either, so
+	// there is one more than the batch we built.
+	require.Len(t, seen, total+1, "the sequence cursor must visit every pending row")
+	for id, count := range seen {
+		require.Equal(t, 1, count, "row %s visited more than once", id)
+	}
+
+	// The batch came back in the order it was written - what created cannot give us because its
+	// values are tied, and what a random tiebreaker such as id could not give us either.
+	require.Equal(t, wantOrder, gotOrder, "sequence must preserve the order rows were written in the batch")
+
+	// Confirm created really is tied, so the comparison below means something.
+	byCreated, _, err := txm.QueryTransactionsResolved(ctx,
+		query.NewQueryBuilder().Limit(total).Sort("created", "idempotencyKey").In("idempotencyKey", keys).Query(),
+		txm.p.NOTX(), false)
+	require.NoError(t, err)
+	require.Len(t, byCreated, total)
+	ties := 0
+	for i := 1; i < len(byCreated); i++ {
+		if byCreated[i].Transaction.Created == byCreated[i-1].Transaction.Created {
+			ties++
+		}
+	}
+	require.Equal(t, 7, ties, "expected the created collisions this test sets up")
+
+	// The same walk on created loses a row per tied pair: one row of each pair is returned and the
+	// strict cursor then steps past its partner. This is what the resume scan used to do.
+	bareSeen := make(map[uuid.UUID]struct{})
+	var lastCreated int64
+	for {
+		qb := query.NewQueryBuilder().Limit(1).Sort("created").In("idempotencyKey", keys)
+		if lastCreated > 0 {
+			qb.GreaterThan("created", lastCreated)
+		}
+		page, _, err := txm.QueryTransactionsResolved(ctx, qb.Query(), txm.p.NOTX(), false)
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+		for _, r := range page {
+			bareSeen[*r.Transaction.ID] = struct{}{}
+		}
+		lastCreated = int64(page[len(page)-1].Transaction.Created)
+	}
+	require.Len(t, bareSeen, total-ties, "a created-only cursor should skip one row per tied pair")
+}


### PR DESCRIPTION
Adds an auto incrementing `seq` column to transactions.

Paging by created does not guarantee ordering since transactions created in the same batch insert will have the same created time stamp. This is most likely to occur with dispatched chained transactions, now that dispatches are performed in batches, and also has the most serious impact for chained transactions, since the dependency on a previous transaction can only be established if ordering is preserved. If ordering is lost, there is no way to distinguish between "prereq transaction not yet resumed" (condition which should never occur), and "prereq transaction already confirmed with receipt" (common and correct condition). Ordering is still guaranteed by the base ledger, meaning this will result in cascading reverts through dependency chains.

Ordering by created also means that if a group of transactions with the same created time crosses a page boundary, the transactions on the new page will be skipped from the scan (similar to #1338) since pagination resumes from greater than this timestamp (although they will likely be included in the next scan when page boundaries have changed).

The SQLite migration fully recreates the transactions table and changes the primary key as the only way to support the auto-incrementing seq column. This means we have an asymmetry between the two database types, but the unique index on ID ensures that this asymmetry is invisible to consumers.