### PR TITLE
Remove hash from predispatch requests

### DIFF
--- a/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch.go
@@ -18,13 +18,10 @@ import (
 	"context"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
-	"github.com/LFDT-Paladin/paladin/common/go/pkg/log"
 	"github.com/LFDT-Paladin/paladin/core/internal/msgs"
 	"github.com/LFDT-Paladin/paladin/core/internal/sequencer/common"
 	engineProto "github.com/LFDT-Paladin/paladin/core/pkg/proto/engine"
-	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/sha3"
 )
 
 func (t *coordinatorTransaction) completePreDispatchRequest(_ context.Context) error {
@@ -36,17 +33,11 @@ func (t *coordinatorTransaction) completePreDispatchRequest(_ context.Context) e
 func (t *coordinatorTransaction) sendPreDispatchRequest(ctx context.Context) error {
 
 	if t.pendingPreDispatchRequest == nil {
-		hash, err := t.hash(ctx)
-		if err != nil {
-			log.L(ctx).Debugf("error hashing transaction for dispatch confirmation request: %s", err)
-			return err
-		}
 		t.pendingPreDispatchRequest = common.NewIdempotentRequest(ctx, t.clock, t.requestTimeout, func(ctx context.Context, idempotencyKey uuid.UUID) error {
 			return t.transportWriter.SendPreDispatchRequest(ctx, t.originatorNode, &engineProto.PreDispatchRequest{
-				Id:               idempotencyKey.String(),
-				TransactionId:    t.pt.ID.String(),
-				ContractAddress:  t.pt.Address.HexString(),
-				PostAssembleHash: hash.Bytes(),
+				Id:              idempotencyKey.String(),
+				TransactionId:   t.pt.ID.String(),
+				ContractAddress: t.pt.Address.HexString(),
 			})
 		})
 		t.scheduleRequestTimeout(ctx)
@@ -55,34 +46,6 @@ func (t *coordinatorTransaction) sendPreDispatchRequest(ctx context.Context) err
 	sendErr := t.pendingPreDispatchRequest.Nudge(ctx)
 
 	return sendErr
-
-}
-
-// Hash method of Transaction
-func (t *coordinatorTransaction) hash(ctx context.Context) (*pldtypes.Bytes32, error) {
-	if t.pt == nil {
-		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "Cannot hash transaction without PrivateTransaction")
-	}
-	if t.pt.PostAssembly == nil {
-		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "Cannot hash transaction without PostAssembly")
-	}
-
-	// MRW TODO - MUST DO - this was relying on only signatures being present, but Pente contracts reject transactions that have both signatures and endorsements.
-	// if len(t.pt.PostAssembly.Signatures) == 0 {
-	// 	return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "Cannot hash transaction without at least one Signature")
-	// }
-
-	hash := sha3.NewLegacyKeccak256()
-
-	if len(t.pt.PostAssembly.AssembleResponse.GetSignatures()) != 0 {
-		for _, signature := range t.pt.PostAssembly.AssembleResponse.GetSignatures() {
-			hash.Write(signature.Payload)
-		}
-	}
-
-	var h32 pldtypes.Bytes32
-	_ = hash.Sum(h32[0:0])
-	return &h32, nil
 
 }
 

--- a/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
+++ b/core/go/internal/sequencer/coordinator/transaction/confirming_dispatch_test.go
@@ -149,18 +149,6 @@ func Test_ConfirmingDispatch_Timeout_TransitionsToPooled_AndClearsPendingRequest
 	assert.Nil(t, txn.pendingPreDispatchRequest)
 }
 
-func Test_hash_NilPrivateTransaction_ReturnsError(t *testing.T) {
-	ctx := t.Context()
-	txn, _ := NewTransactionBuilderForTesting(t, State_Confirming_Dispatchable).Build()
-	txn.pt = nil
-
-	hash, err := txn.hash(ctx)
-
-	require.Error(t, err)
-	assert.Nil(t, hash)
-	assert.Contains(t, err.Error(), "Cannot hash transaction without PrivateTransaction")
-}
-
 func Test_sendPreDispatchRequest_RequestTimeoutSchedulesTimer_QueueEventCalled(t *testing.T) {
 	ctx := t.Context()
 	timeoutEventReceived := false
@@ -192,27 +180,4 @@ func Test_sendPreDispatchRequest_RequestTimeoutSchedulesTimer_QueueEventCalled(t
 	require.NoError(t, err)
 
 	assert.True(t, timeoutEventReceived, "queueEventForCoordinator should have been called with RequestTimeoutIntervalEvent")
-}
-
-func Test_hash_NilPostAssembly_ReturnsError(t *testing.T) {
-	ctx := t.Context()
-	txn, _ := NewTransactionBuilderForTesting(t, State_Confirming_Dispatchable).Build()
-	txn.pt.PostAssembly = nil
-
-	hash, err := txn.hash(ctx)
-
-	require.Error(t, err)
-	assert.Nil(t, hash)
-	assert.Contains(t, err.Error(), "Cannot hash transaction without PostAssembly")
-}
-
-func Test_sendPreDispatchRequest_HashError_WhenPostAssemblyNil(t *testing.T) {
-	ctx := t.Context()
-	txn, _ := NewTransactionBuilderForTesting(t, State_Confirming_Dispatchable).Build()
-	txn.pt.PostAssembly = nil
-
-	err := txn.sendPreDispatchRequest(ctx)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Cannot hash transaction without PostAssembly")
 }

--- a/core/go/internal/sequencer/coordinator/transaction/endorsing.go
+++ b/core/go/internal/sequencer/coordinator/transaction/endorsing.go
@@ -44,10 +44,6 @@ func (t *coordinatorTransaction) applyEndorsement(ctx context.Context, endorseme
 	delete(t.pendingEndorsementRequests[endorsement.Name], endorsement.Verifier.Lookup)
 	t.pt.PostAssembly.CollectedEndorsements = append(t.pt.PostAssembly.CollectedEndorsements, endorsement)
 
-	// MRW TODO - Hashing the TX for dispatch confirmation requires that there is > 0 signatures. Need to follow up where an endorsed TX populates the signatures. Temporarily put this workaround in.
-	// log.L(ctx).Infof("Applying endorsement. Appending %+v to list of endorsements received for transaction %s from %s", endorsement, t.pt.ID, endorsement.Verifier.Lookup)
-	// t.pt.PostAssembly.Signatures = append(t.pt.PostAssembly.Signatures, endorsement)
-
 	// Log complete list of current endorsements
 	for _, endorsement := range t.pt.PostAssembly.CollectedEndorsements {
 		log.L(ctx).Debugf("completed endorsement: %+v", endorsement)

--- a/core/go/internal/sequencer/originator/originator_test.go
+++ b/core/go/internal/sequencer/originator/originator_test.go
@@ -68,7 +68,7 @@ func TestOriginator_SingleTransactionLifecycle(t *testing.T) {
 	// Start by creating a transaction with the originator
 	transactionBuilder := testutil.NewPrivateTransactionBuilderForTesting().Address(builder.GetContractAddress()).Originator(originatorLocator).NumberOfRequiredEndorsers(1)
 	txn := transactionBuilder.BuildSparse()
-	postAssembly, postAssemblyHash := transactionBuilder.BuildPostAssemblyAndHash()
+	postAssembly := transactionBuilder.BuildPostAssembly()
 	mocks.EngineIntegration.On(
 		"Assemble",
 		mock.Anything,
@@ -96,7 +96,7 @@ func TestOriginator_SingleTransactionLifecycle(t *testing.T) {
 	// Simulate the coordinator sending a dispatch confirmation
 	o.QueueEvent(ctx, &transaction.PreDispatchRequestReceivedEvent{
 		BaseEvent: transaction.BaseEvent{TransactionID: txn.ID},
-		RequestID: assembleRequestIdempotencyKey, Coordinator: coordinatorNode, PostAssemblyHash: postAssemblyHash,
+		RequestID: assembleRequestIdempotencyKey, Coordinator: coordinatorNode,
 	})
 	sync = statemachine.NewSyncEvent()
 	o.QueueEvent(ctx, sync)
@@ -256,12 +256,10 @@ func Test_propagateEventToTransaction_UnknownTransaction_PreDispatchRequestSends
 	builder := NewOriginatorBuilderForTesting(t, State_Observing)
 	o, mocks := builder.Build()
 	unknownTxID := uuid.New()
-	postAssemblyHash := pldtypes.RandBytes32()
 	event := &transaction.PreDispatchRequestReceivedEvent{
-		BaseEvent:        transaction.BaseEvent{TransactionID: unknownTxID},
-		Coordinator:      coordinatorLocator,
-		PostAssemblyHash: &postAssemblyHash,
-		RequestID:        uuid.New(),
+		BaseEvent:   transaction.BaseEvent{TransactionID: unknownTxID},
+		Coordinator: coordinatorLocator,
+		RequestID:   uuid.New(),
 	}
 	require.NoError(t, o.stateMachineEventLoop.ProcessEvent(ctx, event))
 	assert.True(t, mocks.SentMessageRecorder.HasSentPreDispatchRejection(), "SendPreDispatchRejection should be called for unknown transaction")

--- a/core/go/internal/sequencer/originator/transaction/delegated.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated.go
@@ -100,16 +100,6 @@ func validator_PreDispatchRequestFromCurrentDelegate(ctx context.Context, txn *o
 		log.L(ctx).Debugf("DispatchConfirmationRequest invalid for transaction %s. Expected coordinator %s, got %s", txn.pt.ID.String(), txn.currentDelegate, preDispatchRequestEvent.Coordinator)
 		return false, nil
 	}
-	txnHash, err := txn.hashInternal(ctx)
-	if err != nil {
-		log.L(ctx).Errorf("error hashing transaction: %s", err)
-		return false, err
-	}
-	if !txnHash.Equals(preDispatchRequestEvent.PostAssemblyHash) {
-		// TODO: Should be be rejecting the dispatch here rather than leaving it to time out on the coordinator?
-		log.L(ctx).Debugf("DispatchConfirmationRequest invalid for transaction %s. Transaction hash does not match.", txn.pt.ID.String())
-		return false, nil
-	}
 	return true, nil
 }
 

--- a/core/go/internal/sequencer/originator/transaction/delegated_test.go
+++ b/core/go/internal/sequencer/originator/transaction/delegated_test.go
@@ -245,25 +245,19 @@ func TestValidator_PreDispatchRequestMatchesAssembledDelegation_Success(t *testi
 		},
 	}
 
-	// Get the transaction hash
-	txnHash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, txnHash)
-
 	requestID := uuid.New()
 	event := &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      coordinator,
-		PostAssemblyHash: txnHash,
-		RequestID:        requestID,
+		Coordinator: coordinator,
+		RequestID:   requestID,
 	}
 
 	matches, err := validator_PreDispatchRequestFromCurrentDelegate(ctx, txn, event)
 
 	assert.NoError(t, err)
-	assert.True(t, matches, "Should return true when coordinator and hash match")
+	assert.True(t, matches, "Should return true when the request is from the current delegate")
 	// Note: request ID is stored by action_PreDispatchRequestReceived (first action) when the event is processed via HandleEvent
 }
 
@@ -288,71 +282,18 @@ func TestValidator_PreDispatchRequestFromCurrentDelegate_WrongCoordinator(t *tes
 		},
 	}
 
-	// Get the transaction hash
-	txnHash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, txnHash)
-
 	event := &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      differentCoordinator,
-		PostAssemblyHash: txnHash,
-		RequestID:        uuid.New(),
+		Coordinator: differentCoordinator,
+		RequestID:   uuid.New(),
 	}
 
 	matches, err := validator_PreDispatchRequestFromCurrentDelegate(ctx, txn, event)
 
 	assert.NoError(t, err)
 	assert.False(t, matches, "Should return false when coordinator does not match")
-	assert.Equal(t, uuid.Nil, txn.latestPreDispatchRequestID, "Should not store request ID when validation fails")
-}
-
-func TestValidator_PreDispatchRequestMatchesAssembledDelegation_WrongHash(t *testing.T) {
-	// Test that validator_PreDispatchRequestFromCurrentDelegate returns false when hash does not match
-	ctx := context.Background()
-	builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering)
-	txn, _ := builder.BuildWithMocks()
-
-	coordinator := "coordinator@node1"
-	txn.currentDelegate = coordinator
-	txn.pt.PostAssembly = &components.TransactionPostAssembly{
-		AssembleResponse: &prototk.TransactionPostAssembly{
-			AssemblyResult: prototk.AssembleTransactionResponse_OK,
-			Signatures: []*prototk.AttestationResult{
-				{
-					Payload: []byte("test signature"),
-				},
-			},
-		},
-	}
-
-	// Get the transaction hash
-	txnHash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, txnHash)
-
-	// Create a different hash
-	differentHash := ptrTo(pldtypes.RandBytes32())
-	// Ensure it's different
-	for differentHash.Equals(txnHash) {
-		differentHash = ptrTo(pldtypes.RandBytes32())
-	}
-
-	event := &PreDispatchRequestReceivedEvent{
-		BaseEvent: BaseEvent{
-			TransactionID: txn.GetID(),
-		},
-		Coordinator:      coordinator,
-		PostAssemblyHash: differentHash,
-		RequestID:        uuid.New(),
-	}
-
-	matches, err := validator_PreDispatchRequestFromCurrentDelegate(ctx, txn, event)
-
-	assert.NoError(t, err)
-	assert.False(t, matches, "Should return false when hash does not match")
 	assert.Equal(t, uuid.Nil, txn.latestPreDispatchRequestID, "Should not store request ID when validation fails")
 }
 
@@ -377,34 +318,6 @@ func TestValidator_PreDispatchRequestMatchesAssembledDelegation_WrongEventType(t
 
 	assert.NoError(t, err)
 	assert.False(t, matches, "Should return false when event type is wrong")
-}
-
-func TestValidator_PreDispatchRequestMatchesAssembledDelegation_HashError(t *testing.T) {
-	// Test that validator_PreDispatchRequestFromCurrentDelegate returns error when Hash() fails
-	ctx := context.Background()
-	builder := NewTransactionBuilderForTesting(t, State_Delegated)
-	txn, _ := builder.BuildWithMocks()
-
-	coordinator := "coordinator@node1"
-	txn.currentDelegate = coordinator
-
-	// Set PostAssembly to nil to cause Hash() to fail
-	txn.pt.PostAssembly = nil
-
-	event := &PreDispatchRequestReceivedEvent{
-		BaseEvent: BaseEvent{
-			TransactionID: txn.GetID(),
-		},
-		Coordinator:      coordinator,
-		PostAssemblyHash: ptrTo(pldtypes.RandBytes32()),
-		RequestID:        uuid.New(),
-	}
-
-	matches, err := validator_PreDispatchRequestFromCurrentDelegate(ctx, txn, event)
-
-	assert.Error(t, err, "Should return error when Hash() fails")
-	assert.False(t, matches, "Should return false when there's an error")
-	assert.Contains(t, err.Error(), "cannot hash transaction without PostAssembly", "Error should indicate missing PostAssembly")
 }
 
 func Test_action_ResetDelegationState_ClearsAssemblyAndDispatchState(t *testing.T) {
@@ -526,10 +439,9 @@ func TestAction_SendPreDispatchRejectionNotCurrentDelegate_Success(t *testing.T)
 	txn.currentDelegate = "coordinator@node1"
 	reqID := uuid.New()
 	event := &PreDispatchRequestReceivedEvent{
-		BaseEvent:        BaseEvent{TransactionID: txn.GetID()},
-		Coordinator:      "other@node2",
-		PostAssemblyHash: ptrTo(pldtypes.RandBytes32()),
-		RequestID:        reqID,
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: "other@node2",
+		RequestID:   reqID,
 	}
 
 	mocks.TransportWriter.EXPECT().
@@ -552,10 +464,9 @@ func TestAction_SendPreDispatchRejectionNotCurrentDelegate_TransportError_LogsWa
 	txn.currentDelegate = "coordinator@node1"
 	reqID := uuid.New()
 	event := &PreDispatchRequestReceivedEvent{
-		BaseEvent:        BaseEvent{TransactionID: txn.GetID()},
-		Coordinator:      "other@node2",
-		PostAssemblyHash: ptrTo(pldtypes.RandBytes32()),
-		RequestID:        reqID,
+		BaseEvent:   BaseEvent{TransactionID: txn.GetID()},
+		Coordinator: "other@node2",
+		RequestID:   reqID,
 	}
 
 	mocks.TransportWriter.EXPECT().

--- a/core/go/internal/sequencer/originator/transaction/events.go
+++ b/core/go/internal/sequencer/originator/transaction/events.go
@@ -237,9 +237,8 @@ func (*AssembleErrorEvent) TypeString() string {
 
 type PreDispatchRequestReceivedEvent struct {
 	BaseEvent
-	RequestID        uuid.UUID
-	Coordinator      string
-	PostAssemblyHash *pldtypes.Bytes32
+	RequestID   uuid.UUID
+	Coordinator string
 }
 
 func (*PreDispatchRequestReceivedEvent) Type() EventType {

--- a/core/go/internal/sequencer/originator/transaction/events_test.go
+++ b/core/go/internal/sequencer/originator/transaction/events_test.go
@@ -270,20 +270,17 @@ func TestPreDispatchRequestReceivedEvent_Fields(t *testing.T) {
 	txID := uuid.New()
 	requestID := uuid.New()
 	coordinator := "coordinator@testNode"
-	postAssemblyHash := pldtypes.RandBytes32()
 
 	event := &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txID,
 		},
-		RequestID:        requestID,
-		Coordinator:      coordinator,
-		PostAssemblyHash: &postAssemblyHash,
+		RequestID:   requestID,
+		Coordinator: coordinator,
 	}
 	assert.Equal(t, txID, event.GetTransactionID())
 	assert.Equal(t, requestID, event.RequestID)
 	assert.Equal(t, coordinator, event.Coordinator)
-	assert.Equal(t, &postAssemblyHash, event.PostAssemblyHash)
 }
 
 func TestDispatchedEvent_Type(t *testing.T) {

--- a/core/go/internal/sequencer/originator/transaction/prepared_test.go
+++ b/core/go/internal/sequencer/originator/transaction/prepared_test.go
@@ -120,10 +120,9 @@ func Test_action_PreDispatchRequestReceived_SetsRequestID(t *testing.T) {
 	txn, _ := builder.BuildWithMocks()
 	requestID := uuid.New()
 	event := &PreDispatchRequestReceivedEvent{
-		BaseEvent:        BaseEvent{TransactionID: txn.pt.ID},
-		RequestID:        requestID,
-		Coordinator:      "coord@node1",
-		PostAssemblyHash: nil,
+		BaseEvent:   BaseEvent{TransactionID: txn.pt.ID},
+		RequestID:   requestID,
+		Coordinator: "coord@node1",
 	}
 	err := action_PreDispatchRequestReceived(ctx, txn, event)
 	require.NoError(t, err)

--- a/core/go/internal/sequencer/originator/transaction/signing.go
+++ b/core/go/internal/sequencer/originator/transaction/signing.go
@@ -110,9 +110,9 @@ func (txn *originatorTransaction) handleSign(ctx context.Context, txID uuid.UUID
 	})
 }
 
-// action_SignSuccess records the collected signatures on the local PostAssembly so they contribute to the
-// transaction hash and are available to action_SendSignResponse, mirroring how action_AssembleSuccess
-// records the PostAssembly before action_SendAssembleSuccessResponse reads it.
+// action_SignSuccess records the collected signatures on the local PostAssembly so they are available to
+// action_SendSignResponse, mirroring how action_AssembleSuccess records the PostAssembly before
+// action_SendAssembleSuccessResponse reads it.
 func action_SignSuccess(_ context.Context, t *originatorTransaction, event common.Event) error {
 	e := event.(*SignSuccessEvent)
 	t.pt.PostAssembly.AssembleResponse.Signatures = append(t.pt.PostAssembly.AssembleResponse.Signatures, e.Results...)

--- a/core/go/internal/sequencer/originator/transaction/state_machine_test.go
+++ b/core/go/internal/sequencer/originator/transaction/state_machine_test.go
@@ -1135,15 +1135,11 @@ func TestOriginatorTransaction_Endorsement_Gathering_ToPrepared_OnDispatchConfir
 	builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering)
 	txn, mocks := builder.BuildWithMocks()
 
-	hash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-
-	err = txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
+	err := txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      builder.GetCoordinator(),
-		PostAssemblyHash: hash,
+		Coordinator: builder.GetCoordinator(),
 	})
 	assert.NoError(t, err)
 
@@ -1157,35 +1153,11 @@ func TestOriginatorTransaction_Endorsement_Gathering_NoTransition_OnDispatchConf
 	builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering)
 	txn, mocks := builder.BuildWithMocks()
 
-	hash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-
-	err = txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
-		BaseEvent: BaseEvent{
-			TransactionID: txn.GetID(),
-		},
-		Coordinator:      uuid.New().String(),
-		PostAssemblyHash: hash,
-	})
-	assert.NoError(t, err)
-
-	assert.False(t, mocks.SentMessageRecorder.HasSentPreDispatchResponse(), "dispatch confirmation response was unexpectedly sent back to coordinator")
-	assert.Equal(t, State_Endorsement_Gathering, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
-}
-
-func TestOriginatorTransaction_Endorsement_Gathering_NoTransition_OnDispatchConfirmationRequestReceivedIfNotMatches_WrongHash(t *testing.T) {
-	ctx := context.Background()
-	builder := NewTransactionBuilderForTesting(t, State_Endorsement_Gathering)
-	txn, mocks := builder.BuildWithMocks()
-
-	hash := pldtypes.Bytes32(pldtypes.RandBytes(32))
-
 	err := txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      builder.GetCoordinator(),
-		PostAssemblyHash: &hash,
+		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
 
@@ -1327,15 +1299,11 @@ func TestOriginatorTransaction_Prepared_NoTransition_Do_Resend_OnDispatchConfirm
 	builder := NewTransactionBuilderForTesting(t, State_Prepared)
 	txn, mocks := builder.BuildWithMocks()
 
-	hash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-
-	err = txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
+	err := txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      builder.GetCoordinator(),
-		PostAssemblyHash: hash,
+		Coordinator: builder.GetCoordinator(),
 	})
 	assert.NoError(t, err)
 
@@ -1348,35 +1316,11 @@ func TestOriginatorTransaction_Prepared_Ignore_OnDispatchConfirmationRequestRece
 	builder := NewTransactionBuilderForTesting(t, State_Prepared)
 	txn, mocks := builder.BuildWithMocks()
 
-	hash, err := txn.GetHash(ctx)
-	require.NoError(t, err)
-
-	err = txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
-		BaseEvent: BaseEvent{
-			TransactionID: txn.GetID(),
-		},
-		Coordinator:      uuid.New().String(),
-		PostAssemblyHash: hash,
-	})
-	assert.NoError(t, err)
-
-	assert.False(t, mocks.SentMessageRecorder.HasSentPreDispatchResponse(), "dispatch confirmation response was unexpectedly sent back to coordinator")
-	assert.Equal(t, State_Prepared, txn.GetCurrentState(), "current state is %s", txn.GetCurrentState().String())
-}
-
-func TestOriginatorTransaction_Prepared_Ignore_OnDispatchConfirmationRequestReceivedIfNotMatches_WrongHash(t *testing.T) {
-	ctx := context.Background()
-	builder := NewTransactionBuilderForTesting(t, State_Prepared)
-	txn, mocks := builder.BuildWithMocks()
-
-	hash := pldtypes.Bytes32(pldtypes.RandBytes(32))
-
 	err := txn.HandleEvent(ctx, &PreDispatchRequestReceivedEvent{
 		BaseEvent: BaseEvent{
 			TransactionID: txn.GetID(),
 		},
-		Coordinator:      builder.GetCoordinator(),
-		PostAssemblyHash: &hash,
+		Coordinator: uuid.New().String(),
 	})
 	assert.NoError(t, err)
 

--- a/core/go/internal/sequencer/originator/transaction/transaction.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction.go
@@ -30,7 +30,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/sdk/go/pkg/pldtypes"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/prototk"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/sha3"
 )
 
 type assembleRequestFromCoordinator struct {
@@ -177,38 +176,6 @@ func (t *originatorTransaction) GetStatus(ctx context.Context) components.Privat
 		Endorsements: t.getEndorsementStatus(ctx),
 		Transaction:  t.pt,
 	}
-}
-
-func (t *originatorTransaction) GetHash(ctx context.Context) (*pldtypes.Bytes32, error) {
-	t.RLock()
-	defer t.RUnlock()
-	return t.hashInternal(ctx)
-}
-
-// hashInternal contains the hashing logic; used internally and by the public Hash.
-func (t *originatorTransaction) hashInternal(ctx context.Context) (*pldtypes.Bytes32, error) {
-	if t.pt == nil {
-		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "cannot hash transaction without PrivateTransaction")
-	}
-	if t.pt.PostAssembly == nil {
-		return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, "cannot hash transaction without PostAssembly")
-	}
-
-	log.L(ctx).Debugf("hashing transaction %s with %d signatures and %d endorsements", t.pt.ID.String(), len(t.pt.PostAssembly.AssembleResponse.GetSignatures()), len(t.pt.PostAssembly.AssembleResponse.GetEndorsements()))
-
-	// MRW TODO MUST DO - it's not clear is a originator transaction hash if valid without any signatures or endorsements.
-	// After assemble a Pente TX can have just the assembler's endorsement (not everyone else's), so comparing hashes with > 1 endorsements will fail
-	// if len(t.pt.PostAssembly.AssemblyResponse.GetSignatures()) == 0 {
-	// 	return nil, i18n.NewError(ctx, msgs.MsgSequencerInternalError, " cannot hash transaction without at least one Signature")
-	// }
-
-	hash := sha3.NewLegacyKeccak256()
-	for _, signature := range t.pt.PostAssembly.AssembleResponse.GetSignatures() {
-		hash.Write(signature.Payload)
-	}
-	var h32 pldtypes.Bytes32
-	_ = hash.Sum(h32[0:0])
-	return &h32, nil
 }
 
 func (t *originatorTransaction) getEndorsementStatus(ctx context.Context) []components.PrivateTxEndorsementStatus {

--- a/core/go/internal/sequencer/originator/transaction/transaction_test.go
+++ b/core/go/internal/sequencer/originator/transaction/transaction_test.go
@@ -197,40 +197,6 @@ func TestTransaction_GetFirstDelegatedTime_ReturnsSetTime(t *testing.T) {
 	assert.Equal(t, txn.firstDelegatedTime, firstDelegatedTime, "GetFirstDelegatedTime should return the recorded first-delegation time")
 }
 
-func TestTransaction_Hash_ErrorWhenPrivateTransactionIsNil(t *testing.T) {
-	// Test that Hash returns an error when PrivateTransaction is nil
-	ctx := context.Background()
-
-	// Create a transaction with nil PrivateTransaction by manually constructing it
-	txn := &originatorTransaction{
-		pt: nil,
-	}
-
-	hash, err := txn.GetHash(ctx)
-
-	assert.Error(t, err, "Hash should return an error when PrivateTransaction is nil")
-	assert.Nil(t, hash, "Hash should return nil hash when PrivateTransaction is nil")
-	assert.Contains(t, err.Error(), "cannot hash transaction without PrivateTransaction", "Error message should indicate the validation failure")
-}
-
-func TestTransaction_Hash_ErrorWhenPostAssemblyIsNil(t *testing.T) {
-	// Test that Hash returns an error when PostAssembly is nil
-	ctx := context.Background()
-
-	// Create a transaction with a PrivateTransaction that has nil PostAssembly
-	builder := NewTransactionBuilderForTesting(t, State_Initial)
-	txn, _ := builder.BuildWithMocks()
-
-	// Set PostAssembly to nil to test the error case
-	txn.pt.PostAssembly = nil
-
-	hash, err := txn.GetHash(ctx)
-
-	assert.Error(t, err, "Hash should return an error when PostAssembly is nil")
-	assert.Nil(t, hash, "Hash should return nil hash when PostAssembly is nil")
-	assert.Contains(t, err.Error(), "cannot hash transaction without PostAssembly", "Error message should indicate the validation failure")
-}
-
 func TestTransaction_GetCurrentState_ReturnsInitialState(t *testing.T) {
 	// Test that GetCurrentState returns the initial state for a newly created transaction
 	builder := NewTransactionBuilderForTesting(t, State_Initial)

--- a/core/go/internal/sequencer/testutil/private_transaction.go
+++ b/core/go/internal/sequencer/testutil/private_transaction.go
@@ -29,7 +29,6 @@ import (
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/signpayloads"
 	"github.com/LFDT-Paladin/paladin/toolkit/pkg/verifiers"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/sha3"
 )
 
 type identityForTesting struct {
@@ -400,17 +399,6 @@ func (b *PrivateTransactionBuilderForTesting) BuildEndorsement(endorserIndex int
 }
 
 // Function BuildPostAssembly creates a new PostAssembly with all fields populated as per the builder's configuration using defaults unless explicitly set
-func (b *PrivateTransactionBuilderForTesting) BuildPostAssemblyAndHash() (*components.TransactionPostAssembly, *pldtypes.Bytes32) {
-	postAssembly := b.BuildPostAssembly()
-	hash := sha3.NewLegacyKeccak256()
-	for _, signature := range postAssembly.AssembleResponse.GetSignatures() {
-		hash.Write(signature.Payload)
-	}
-	var h32 pldtypes.Bytes32
-	_ = hash.Sum(h32[0:0])
-	return postAssembly, &h32
-}
-
 func (b *PrivateTransactionBuilderForTesting) BuildPostAssembly() *components.TransactionPostAssembly {
 
 	if b.revertReason != nil {

--- a/core/go/internal/sequencer/transport/transport_writer_test.go
+++ b/core/go/internal/sequencer/transport/transport_writer_test.go
@@ -421,12 +421,11 @@ func testHeartbeatMsg(from string, contractAddress *pldtypes.EthAddress, coordin
 	}, nil
 }
 
-func testPreDispatchRequestMsg(idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, contractAddress *pldtypes.EthAddress, hash *pldtypes.Bytes32) *engineProto.PreDispatchRequest {
+func testPreDispatchRequestMsg(idempotencyKey uuid.UUID, transactionSpecification *prototk.TransactionSpecification, contractAddress *pldtypes.EthAddress) *engineProto.PreDispatchRequest {
 	return &engineProto.PreDispatchRequest{
-		Id:               idempotencyKey.String(),
-		TransactionId:    transactionSpecification.TransactionId,
-		ContractAddress:  contractAddress.HexString(),
-		PostAssembleHash: hash.Bytes(),
+		Id:              idempotencyKey.String(),
+		TransactionId:   transactionSpecification.TransactionId,
+		ContractAddress: contractAddress.HexString(),
 	}
 }
 
@@ -2820,8 +2819,6 @@ func TestSendPreDispatchRequest_Success(t *testing.T) {
 	transactionSpecification := &prototk.TransactionSpecification{
 		TransactionId: txID.String(),
 	}
-	hashVal := pldtypes.MustParseBytes32("0x00000000000000000000000000000000000000000000000000000000000000ab")
-	hash := &hashVal
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
@@ -2850,9 +2847,6 @@ func TestSendPreDispatchRequest_Success(t *testing.T) {
 		if dispatchRequest.ContractAddress != contractAddress.HexString() {
 			return false
 		}
-		if len(dispatchRequest.PostAssembleHash) != 32 {
-			return false
-		}
 		return true
 	})).Return(nil)
 
@@ -2863,7 +2857,7 @@ func TestSendPreDispatchRequest_Success(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -2876,8 +2870,6 @@ func TestSendPreDispatchRequest_SendError(t *testing.T) {
 	transactionSpecification := &prototk.TransactionSpecification{
 		TransactionId: txID.String(),
 	}
-	hashVal := pldtypes.MustParseBytes32("0x00000000000000000000000000000000000000000000000000000000000000ab")
-	hash := &hashVal
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
@@ -2891,7 +2883,7 @@ func TestSendPreDispatchRequest_SendError(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 }
 
@@ -2904,8 +2896,6 @@ func TestSendPreDispatchRequest_Loopback(t *testing.T) {
 	transactionSpecification := &prototk.TransactionSpecification{
 		TransactionId: txID.String(),
 	}
-	hashVal := pldtypes.MustParseBytes32("0x00000000000000000000000000000000000000000000000000000000000000ab")
-	hash := &hashVal
 
 	mockTransportManager := componentsmocks.NewTransportManager(t)
 	mockLoopbackTransport := sequencertransportmocks.NewLoopbackTransportManager(t)
@@ -2921,7 +2911,7 @@ func TestSendPreDispatchRequest_Loopback(t *testing.T) {
 		contractAddress:   contractAddress,
 	}
 
-	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress, hash))
+	err := tw.SendPreDispatchRequest(ctx, originatorNode, testPreDispatchRequestMsg(idempotencyKey, transactionSpecification, contractAddress))
 	require.NoError(t, err)
 
 	// Verify message was sent to loopback queue
@@ -2936,7 +2926,6 @@ func TestSendPreDispatchRequest_Loopback(t *testing.T) {
 		assert.Equal(t, idempotencyKey.String(), dispatchRequest.Id)
 		assert.Equal(t, transactionSpecification.TransactionId, dispatchRequest.TransactionId)
 		assert.Equal(t, contractAddress.HexString(), dispatchRequest.ContractAddress)
-		assert.Equal(t, hash.Bytes(), dispatchRequest.PostAssembleHash)
 	default:
 		t.Fatal("Expected message in loopback queue")
 	}

--- a/core/go/internal/sequencer/transport_client.go
+++ b/core/go/internal/sequencer/transport_client.go
@@ -608,12 +608,9 @@ func (sMgr *sequencerManager) handlePreDispatchRequest(ctx context.Context, mess
 		return
 	}
 
-	postAssemblyHash := pldtypes.NewBytes32FromSlice(preDispatchRequest.PostAssembleHash)
-
 	preDispatchRequestReceivedEvent := &originatorTransaction.PreDispatchRequestReceivedEvent{
-		RequestID:        requestID,
-		Coordinator:      message.FromNode,
-		PostAssemblyHash: &postAssemblyHash,
+		RequestID:   requestID,
+		Coordinator: message.FromNode,
 	}
 	preDispatchRequestReceivedEvent.TransactionID = transactionID
 	preDispatchRequestReceivedEvent.EventTime = time.Now()

--- a/core/go/internal/sequencer/transport_client_test.go
+++ b/core/go/internal/sequencer/transport_client_test.go
@@ -821,13 +821,11 @@ func TestHandlePreDispatchRequest_Success(t *testing.T) {
 
 	txID := uuid.New()
 	requestID := uuid.New()
-	hash := pldtypes.RandBytes32()
 
 	preDispatchRequest := &engineProto.PreDispatchRequest{
-		Id:               requestID.String(),
-		TransactionId:    txID.String(),
-		ContractAddress:  contractAddr.String(),
-		PostAssembleHash: hash[:],
+		Id:              requestID.String(),
+		TransactionId:   txID.String(),
+		ContractAddress: contractAddr.String(),
 	}
 	payload, _ := proto.Marshal(preDispatchRequest)
 

--- a/core/go/pkg/proto/engine.proto
+++ b/core/go/pkg/proto/engine.proto
@@ -252,7 +252,6 @@ message PreDispatchRequest {
     string id = 1;
     string transaction_id = 2;
     string contract_address = 3;
-    bytes post_assemble_hash = 4;
 }
 
 message PreDispatchResponse {


### PR DESCRIPTION
Addresses #942 

This PR makes the decision to stop calculating the hash and remove it from the predispatch request.

The hash was blurring the line between two different stages of transaction processing:

- Endorsement- approval of the transaction that is **_cryptographically verifiable_** on chain
- Predispatch request - **_courtesy_** request to the originator that may help avoid base ledger submissions that revert

A coordinator could be modified to not send a predispatch request, or ignore the originators response to it - i.e. a predispatch request does not protect against a bad actor. 

Current examples of utility that a predispatch request provides are:
* the originator doesn't know about the transaction anymore- it is likely already confirmed and another submission would revert on chain
* in a domain like Pente where well functioning nodes nodes may not have agreed on who is the  active coordinator, but ultimately care about getting transactions successfully to chain rather than who performs the actual submission, in reaching consensus on who is the active coordinator. Two active coordinators would be trying to spend the same states causing base ledger reverts

