### PR TITLE
Fix double-submission race on orchestrator swap

### DIFF
--- a/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_stage_controller.go
@@ -691,7 +691,19 @@ func (it *inFlightTransactionStageController) executeAsync(funcToExecute func(),
 	if it.testOnlyNoActionMode {
 		return
 	}
+	// Tracked on the owning orchestrator's WaitGroup so Stop() can block until this goroutine finishes -
+	// see orchestrator.asyncWG. This prevents a new orchestrator being created for the same signing address
+	// (once this one is removed from the pool) from ever running concurrently with this stage action.
+	it.asyncWG.Add(1)
 	go func() {
+		defer it.asyncWG.Done()
+		if ctx.Err() != nil {
+			// The owning orchestrator was stopped (idle/stale eviction, or swapped out under load) before
+			// this goroutine got to run. Do not sign/submit/persist on its behalf - a new orchestrator for
+			// this signing address may already be processing the same transaction.
+			log.L(ctx).Debugf("Skipping in-flight stage action for %s: orchestrator context cancelled", it.stateManager.GetSignerNonce())
+			return
+		}
 		stage := generation.GetStage(ctx)
 		defer func() {
 			if err := recover(); err != nil {

--- a/core/go/internal/publictxmgr/transaction_manager_loop_test.go
+++ b/core/go/internal/publictxmgr/transaction_manager_loop_test.go
@@ -16,6 +16,7 @@
 package publictxmgr
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -47,10 +48,13 @@ func TestNewEnginePollingStoppingAnOrchestratorForFairnessControl(t *testing.T) 
 	defer done()
 
 	// Fake an inflight orchestrator for signing address 1
+	ocCtx, ocCtxCancel := context.WithCancel(ctx)
 	existingOrchestrator := &orchestrator{
 		signingAddress:              *testSigningAddr1,
 		orchestratorBirthTime:       time.Now().Add(-1 * time.Hour),
 		pubTxManager:                ble,
+		ctx:                         ocCtx,
+		ctxCancel:                   ocCtxCancel,
 		orchestratorPollingInterval: ble.enginePollingInterval,
 		state:                       OrchestratorStateRunning,
 		stateEntryTime:              time.Now().Add(1 * time.Hour).Add(-1 * time.Minute),

--- a/core/go/internal/publictxmgr/transaction_orchestrator.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator.go
@@ -100,6 +100,17 @@ var AllOrchestratorStates = []string{
 type orchestrator struct {
 	*pubTxManager
 
+	// ctx/ctxCancel are scoped to this orchestrator instance (a child of pubTxManager.ctx), and shadow the
+	// embedded pubTxManager's ctx for all oc.ctx reads in this file. Stop() cancels ctxCancel so that any
+	// in-flight stage action (sign/submit/gas-price/persist) already running in a goroutine started via
+	// executeAsync observes cancellation, and asyncWG lets orchestratorLoop block until such goroutines have
+	// actually finished before the orchestrator is removed from the pool. Without this, a new orchestrator
+	// created for the same signing address (once this one is removed) can run concurrently with a zombie
+	// goroutine from this one, both driving signing/submission for the same nonce.
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	asyncWG   sync.WaitGroup
+
 	// in-flight transaction config
 	resubmitInterval        time.Duration
 	stageRetryTimeout       time.Duration
@@ -159,9 +170,12 @@ func NewOrchestrator(
 	conf *pldconf.PublicTxManagerConfig,
 ) *orchestrator {
 	ctx := ptm.ctx
+	ocCtx, ocCtxCancel := context.WithCancel(ctx)
 
 	newOrchestrator := &orchestrator{
 		pubTxManager:                ptm,
+		ctx:                         ocCtx,
+		ctxCancel:                   ocCtxCancel,
 		orchestratorBirthTime:       time.Now(),
 		orchestratorPollingInterval: confutil.DurationMin(conf.Orchestrator.Interval, veryShortMinimum, *pldconf.PublicTxManagerDefaults.Orchestrator.Interval),
 		maxInFlightTxs:              confutil.IntMin(conf.Orchestrator.MaxInFlight, 1, *pldconf.PublicTxManagerDefaults.Orchestrator.MaxInFlight),
@@ -221,6 +235,14 @@ func (oc *orchestrator) orchestratorLoop() {
 
 	if err := oc.initNextNonceFromDBRetry(ctx); err != nil {
 		log.L(ctx).Warnf("Context cancelled while obtaining highest nonce for %s: %s", oc.signingAddress, err)
+		// initNextNonceFromDBRetry uses an indefinite retry, so it only returns an error when a context was
+		// cancelled - either ours (Stop() was called before we even got here) or our parent's (manager
+		// shutdown). Either way we must still reach OrchestratorStateStopped, the same as the main loop's
+		// stopProcess/ctx.Done() exits below, so the engine loop's fairness/eviction bookkeeping and any
+		// caller waiting on our state (e.g. via poll()) see us as stopped rather than stuck in our prior state.
+		oc.asyncWG.Wait()
+		oc.setState(OrchestratorStateStopped)
+		oc.MarkInFlightOrchestratorsStale() // trigger engine loop for removal
 		return
 	}
 
@@ -232,10 +254,20 @@ func (oc *orchestrator) orchestratorLoop() {
 		case <-oc.InFlightTxsStale:
 		case <-ticker.C:
 		case <-ctx.Done():
+			// Stop() cancels oc.ctx and signals stopProcess together, so this case and the stopProcess case
+			// below race - select can wake on either one first. Both must therefore do the same cleanup:
+			// wait for any stage actions already launched via executeAsync (sign/submit/gas-price/persist)
+			// to finish, then reach OrchestratorStateStopped, before we let the engine loop remove us from
+			// the pool - otherwise a new orchestrator for this signing address could start while a zombie
+			// goroutine from this one is still signing/submitting, racing a resubmission for the same nonce.
 			log.L(ctx).Infof("Orchestrator loop exit due to canceled context, it processed %d transaction during its lifetime.", oc.totalCompleted)
+			oc.asyncWG.Wait()
+			oc.setState(OrchestratorStateStopped)
+			oc.MarkInFlightOrchestratorsStale() // trigger engine loop for removal
 			return
 		case <-oc.stopProcess:
 			log.L(ctx).Infof("Orchestrator loop process stopped, it processed %d transaction during its lifetime.", oc.totalCompleted)
+			oc.asyncWG.Wait()
 			oc.setState(OrchestratorStateStopped)
 			oc.MarkInFlightOrchestratorsStale() // trigger engine loop for removal
 			return
@@ -617,6 +649,11 @@ func (oc *orchestrator) Start(ctx context.Context) (done <-chan struct{}, err er
 
 // Stop the InFlight transaction process.
 func (oc *orchestrator) Stop() {
+	// Cancel our scoped context first, so any stage action already running in a goroutine started via
+	// executeAsync (for any of our in-flight transactions) observes cancellation as soon as possible -
+	// this bounds how long orchestratorLoop's asyncWG.Wait() blocks after processing the stop signal below.
+	// Safe to call multiple times (e.g. idle/stale timeout followed by a later explicit stop).
+	oc.ctxCancel()
 	// try to send an item in `stopProcess` channel, which has a buffer of 1
 	// if it already has an item in the channel, this function does nothing
 	select {


### PR DESCRIPTION
When a public tx orchestrator gets evicted (idle or stale timeout, or a pool-fairness swap under load), Stop() only signalled the polling loop to exit. It never cancelled the signing and submission goroutines that were already in flight. Once the orchestrator was removed from the pool, a fresh orchestrator for the same signing address could start right away and pick up the same pending transactions, so two goroutines could end up signing and submitting for the same nonce at the same time.

This gives each orchestrator its own cancellable context plus a WaitGroup that tracks in-flight stage actions. Stop() now cancels that context, and the loop waits for any outstanding action to actually finish before the orchestrator is marked stopped and removable. That way a new orchestrator for the same address can never run concurrently with a leftover goroutine from the old one.

## Test plan
- [x] `go test ./core/go/internal/publictxmgr/...` (including the real-DB end-to-end lifecycle test), run repeatedly
- [x] `go test -race ./core/go/internal/publictxmgr/...`