### PR TITLE
Fix nil pointer panic in PrepareTransaction

### DIFF
--- a/core/go/internal/domainmgr/private_smart_contract.go
+++ b/core/go/internal/domainmgr/private_smart_contract.go
@@ -425,6 +425,9 @@ func (dc *domainContract) PrepareTransaction(ctx context.Context, dqc components
 	if err != nil {
 		return err
 	}
+	if res.Transaction == nil {
+		return i18n.NewError(ctx, msgs.MsgDomainRespIncompletePrepareTransaction)
+	}
 
 	var functionABI abi.Entry
 	if err := json.Unmarshal(([]byte)(res.Transaction.FunctionAbiJson), &functionABI); err != nil {
@@ -676,6 +679,9 @@ func (dc *domainContract) WrapPrivacyGroupEVMTX(ctx context.Context, pg *pldapi.
 	})
 	if err != nil {
 		return nil, err
+	}
+	if res.Transaction == nil {
+		return nil, i18n.NewError(ctx, msgs.MsgDomainRespIncompletePrepareTransaction)
 	}
 
 	// Function returned must be private

--- a/core/go/internal/domainmgr/private_smart_contract_test.go
+++ b/core/go/internal/domainmgr/private_smart_contract_test.go
@@ -1146,6 +1146,24 @@ func TestPrepareTransactionFail(t *testing.T) {
 	assert.Regexp(t, "pop", err)
 }
 
+func TestPrepareTransactionNilTransaction(t *testing.T) {
+	td, done := newTestDomain(t, false, goodDomainConf(), mockSchemas(), mockHighestBlock)
+	defer done()
+
+	psc, tx := doDomainInitAssembleTransactionOK(t, td)
+	tx.Signer = "signer1"
+
+	// A domain plugin can return a nil error alongside a response that omits the
+	// (optional, per proto3) Transaction field - e.g. a buggy or partially-implemented
+	// PrepareTransaction handler. This must not panic when dereferenced.
+	td.tp.Functions.PrepareTransaction = func(ctx context.Context, ptr *prototk.PrepareTransactionRequest) (*prototk.PrepareTransactionResponse, error) {
+		return &prototk.PrepareTransactionResponse{}, nil
+	}
+
+	err := psc.PrepareTransaction(td.ctx, td.c.dqc, td.c.dbTX, tx)
+	assert.Regexp(t, "PD011668", err)
+}
+
 func TestPrepareTransactionABIInvalid(t *testing.T) {
 	td, done := newTestDomain(t, false, goodDomainConf(), mockSchemas(), mockHighestBlock)
 	defer done()

--- a/core/go/internal/msgs/en_errors.go
+++ b/core/go/internal/msgs/en_errors.go
@@ -309,6 +309,7 @@ var (
 	MsgDomainInvalidPGroupTxTypeNotPrivate    = pde("PD011665", "Resulting wrapped function call for privacy group must be a private transaction (type=%s)")
 	MsgDomainInvalidPGroupTxCannotRedirect    = pde("PD011666", "Resulting wrapped function call must target the same smart contract (contract=%s,addr=%s)")
 	MsgDomainUnsupportedStateQualifier        = pde("PD011667", "Unsupported state qualifier '%s'")
+	MsgDomainRespIncompletePrepareTransaction = pde("PD011668", "Response is incomplete for phase PrepareTransaction")
 
 	// Entrypoint PD0117XX
 	MsgEntrypointUnknownRunMode = pde("PD011700", "Unknown run mode '%s'")


### PR DESCRIPTION
The Transaction field on a domain plugin's PrepareTransactionResponse is optional in the proto, so a plugin can return no error and still leave it unset. We were dereferencing it right away without checking, which panics. Since this runs on the coordinator's event loop with nothing recovering panics there, it takes down the whole node, not just the one transaction.

Added a nil check that returns a normal error instead, in both places that read this field (PrepareTransaction and WrapPrivacyGroupEVMTX).

Also added a test that mocks a plugin returning an empty response and checks we get an error back instead of a crash.

Test plan:
- go test ./internal/domainmgr/... passes, including the new test