### PR TITLE
HexUint256 and HexInt256 fixes

### DIFF
--- a/common/go/pkg/pldmsgs/en_errors.go
+++ b/common/go/pkg/pldmsgs/en_errors.go
@@ -54,6 +54,9 @@ var (
 	MsgBigIntParseFailed                     = pde("PD020024", "Failed to parse JSON value '%s' into BigInt")
 	MsgBigIntTooLarge                        = pde("PD020025", "Byte length of serialized integer is too large %d (max=%d)")
 	MsgTypeRestoreFailed                     = pde("PD020026", "Failed to restore type '%T' into '%T'")
+	MsgTypesUint256Negative                  = pde("PD020027", "Negative value invalid for a uint256: %s")
+	MsgTypesUint256TooLarge                  = pde("PD020028", "Integer too large for a uint256: %s")
+	MsgTypesInt256OutOfRange                 = pde("PD020029", "Integer outside the range of an int256 (-2^255 to 2^255-1): %s")
 
 	// Inflight PD0201XX
 	MsgInflightRequestCancelled = pde("PD020100", "Request cancelled after %s")

--- a/common/go/pkg/pldmsgs/en_errors.go
+++ b/common/go/pkg/pldmsgs/en_errors.go
@@ -57,6 +57,7 @@ var (
 	MsgTypesUint256Negative                  = pde("PD020027", "Negative value invalid for a uint256: %s")
 	MsgTypesUint256TooLarge                  = pde("PD020028", "Integer too large for a uint256: %s")
 	MsgTypesInt256OutOfRange                 = pde("PD020029", "Integer outside the range of an int256 (-2^255 to 2^255-1): %s")
+	MsgTypesHexIntBufferTooSmall             = pde("PD020030", "Buffer of %d characters is too small for the %d character encoding of the integer")
 
 	// Inflight PD0201XX
 	MsgInflightRequestCancelled = pde("PD020100", "Request cancelled after %s")

--- a/core/go/internal/filters/field_int256.go
+++ b/core/go/internal/filters/field_int256.go
@@ -42,5 +42,5 @@ func (sf Int256Field) SQLValue(ctx context.Context, jsonValue pldtypes.RawJSON) 
 	if err != nil {
 		return "", err
 	}
-	return pldtypes.Int256To65CharDBSafeSortableString(bi), nil
+	return pldtypes.Int256To65CharDBSafeSortableString(ctx, bi)
 }

--- a/core/go/internal/filters/field_int256_test.go
+++ b/core/go/internal/filters/field_int256_test.go
@@ -36,15 +36,25 @@ func TestInt256Field(t *testing.T) {
 	_, err = Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`[]`))
 	assert.Regexp(t, "FF22091", err)
 
-	vBigNeg, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"-0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`))
-	require.NoError(t, err)
-	assert.Equal(t, "00000000000000000000000000000000000000000000000000000000000000001", vBigNeg)
-	assert.Len(t, vBigNeg, 65)
+	// Values outside the range of an int256 are rejected. Encoding them would wrap the two's
+	// complement body modulo 2^256 while taking the sign character from the original value, so
+	// -(2^256-1) would encode as a negative-signed +1, and 2^256-1 as a positive-signed -1
+	_, err = Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"-0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`))
+	assert.Regexp(t, "PD020029", err)
 
-	vBigPos, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`))
+	_, err = Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`))
+	assert.Regexp(t, "PD020029", err)
+
+	// The extremes of the range still encode
+	vMin, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"-0x8000000000000000000000000000000000000000000000000000000000000000"`))
 	require.NoError(t, err)
-	assert.Equal(t, "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", vBigPos)
-	assert.Len(t, vBigPos, 65)
+	assert.Equal(t, "08000000000000000000000000000000000000000000000000000000000000000", vMin)
+	assert.Len(t, vMin, 65)
+
+	vMax, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"`))
+	require.NoError(t, err)
+	assert.Equal(t, "17fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", vMax)
+	assert.Len(t, vMax, 65)
 
 	vZero, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`0`))
 	require.NoError(t, err)
@@ -61,13 +71,13 @@ func TestInt256Field(t *testing.T) {
 	assert.Equal(t, "10000000000000000000000000000000000000000000000000000000000003039", vSmallPos)
 	assert.Len(t, vSmallPos, 65)
 
-	assert.Equal(t, -1, strings.Compare(vBigNeg.(string), vBigPos.(string)))
-	assert.Equal(t, 1, strings.Compare(vBigPos.(string), vBigNeg.(string)))
-	assert.Equal(t, -1, strings.Compare(vBigNeg.(string), vZero.(string)))
-	assert.Equal(t, -1, strings.Compare(vBigNeg.(string), vSmallNeg.(string)))
+	assert.Equal(t, -1, strings.Compare(vMin.(string), vMax.(string)))
+	assert.Equal(t, 1, strings.Compare(vMax.(string), vMin.(string)))
+	assert.Equal(t, -1, strings.Compare(vMin.(string), vZero.(string)))
+	assert.Equal(t, -1, strings.Compare(vMin.(string), vSmallNeg.(string)))
 	assert.Equal(t, 1, strings.Compare(vSmallPos.(string), vZero.(string)))
-	assert.Equal(t, 1, strings.Compare(vBigPos.(string), vZero.(string)))
-	assert.Equal(t, 1, strings.Compare(vBigPos.(string), vSmallPos.(string)))
+	assert.Equal(t, 1, strings.Compare(vMax.(string), vZero.(string)))
+	assert.Equal(t, 1, strings.Compare(vMax.(string), vSmallPos.(string)))
 
 	nv, err := Int256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`null`))
 	require.NoError(t, err)

--- a/core/go/internal/filters/field_uint256.go
+++ b/core/go/internal/filters/field_uint256.go
@@ -43,10 +43,13 @@ func (sf Uint256Field) SQLValue(ctx context.Context, jsonValue pldtypes.RawJSON)
 	if err != nil {
 		return "", err
 	}
-	return Uint256ToFilterString(ctx, bi), nil
+	return Uint256ToFilterString(ctx, bi)
 }
 
-func Uint256ToFilterString(ctx context.Context, bi *big.Int) string {
-	zeroPaddedUint256 := pldtypes.PadHexBigUint(bi, make([]byte, 64))
-	return (string)(zeroPaddedUint256)
+func Uint256ToFilterString(ctx context.Context, bi *big.Int) (string, error) {
+	zeroPaddedUint256, err := pldtypes.PadHexBigUint(ctx, bi, make([]byte, 64))
+	if err != nil {
+		return "", err
+	}
+	return (string)(zeroPaddedUint256), nil
 }

--- a/core/go/internal/filters/field_uint256_test.go
+++ b/core/go/internal/filters/field_uint256_test.go
@@ -50,6 +50,14 @@ func TestUint256Field(t *testing.T) {
 	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000003039", vSmallPos)
 	assert.Len(t, vSmallPos, 64)
 
+	// Values outside the range of a uint256 are rejected. Encoding a negative would silently
+	// use its absolute value, and one of more than 256 bits would lose its leading digits
+	_, err = Uint256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`-1`))
+	assert.Regexp(t, "PD020027", err)
+
+	_, err = Uint256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`"0x10000000000000000000000000000000000000000000000000000000000000000"`))
+	assert.Regexp(t, "PD020028", err)
+
 	nv, err := Uint256Field("test").SQLValue(ctx, (pldtypes.RawJSON)(`null`))
 	require.NoError(t, err)
 	assert.Nil(t, nv)

--- a/core/go/internal/filters/query_traverser_inline_eval_test.go
+++ b/core/go/internal/filters/query_traverser_inline_eval_test.go
@@ -316,7 +316,7 @@ func TestEvalQueryMatchNullDoesNotMatch(t *testing.T) {
 	assert.False(t, match)
 
 	// uint256 test
-	err = json.Unmarshal([]byte(`{"eq": [{"field": "uint256Field", "value": "-11223344"}]}`), &qf)
+	err = json.Unmarshal([]byte(`{"eq": [{"field": "uint256Field", "value": "11223344"}]}`), &qf)
 	require.NoError(t, err)
 	match, err = EvalQuery(context.Background(), qf, allTypesFieldMap, ResolvingValueSet{})
 	require.NoError(t, err)

--- a/core/go/internal/groupmgr/groupmgr_rpc_test.go
+++ b/core/go/internal/groupmgr/groupmgr_rpc_test.go
@@ -241,7 +241,7 @@ func TestPrivacyGroupRPCLifecycleRealDB(t *testing.T) {
 			To:       nil, // simulate is a deploy inside the privacy group
 			Function: &abi.Entry{Type: abi.Constructor, Inputs: abi.ParameterArray{{Type: "string", Name: "input1"}}},
 			Gas:      confutil.P(pldtypes.HexUint64(12345)),
-			Value:    pldtypes.Int64ToInt256(123456789),
+			Value:    pldtypes.Uint64ToUint256(123456789),
 			Input:    pldtypes.RawJSON(`{"input1": "value1"}`),
 			Bytecode: pldtypes.MustParseHexBytes(`0xfeedbeef`),
 		},

--- a/core/go/internal/publictxmgr/in_flight_transaction_stage_controller_test_retrieve_gas_test.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_stage_controller_test_retrieve_gas_test.go
@@ -67,8 +67,8 @@ func TestProduceLatestInFlightStageContextRetrieveGas(t *testing.T) {
 
 	currentGeneration := it.stateManager.GetCurrentGeneration(ctx).(*inFlightTransactionStateGeneration)
 	retrievedGasPrice := &pldapi.PublicTxGasPricing{
-		MaxFeePerGas:         pldtypes.Int64ToInt256(10),
-		MaxPriorityFeePerGas: pldtypes.Int64ToInt256(1),
+		MaxFeePerGas:         pldtypes.Uint64ToUint256(10),
+		MaxPriorityFeePerGas: pldtypes.Uint64ToUint256(1),
 	}
 	// succeed retrieving gas price
 	currentGeneration.bufferedStageOutputs = make([]*StageOutput, 0)

--- a/core/go/internal/publictxmgr/in_flight_transaction_state_generation_test.go
+++ b/core/go/internal/publictxmgr/in_flight_transaction_state_generation_test.go
@@ -191,8 +191,8 @@ func TestStateManagerStageOutputManagement(t *testing.T) {
 		for i := 0; i < expectedNumberOfGasPriceSuccessOutput; i++ {
 			go func() {
 				version.AddGasPriceOutput(ctx, &pldapi.PublicTxGasPricing{
-					MaxFeePerGas:         pldtypes.Int64ToInt256(100),
-					MaxPriorityFeePerGas: pldtypes.Int64ToInt256(10),
+					MaxFeePerGas:         pldtypes.Uint64ToUint256(100),
+					MaxPriorityFeePerGas: pldtypes.Uint64ToUint256(10),
 				}, nil)
 				countChanel <- true
 			}()

--- a/core/go/internal/publictxmgr/transaction_orchestrator_test.go
+++ b/core/go/internal/publictxmgr/transaction_orchestrator_test.go
@@ -187,8 +187,8 @@ func TestOrchestratorWaitingForBalance(t *testing.T) {
 	txState.ApplyInMemoryUpdates(ctx, &BaseTXUpdates{
 		NewValues: BaseTXUpdateNewValues{
 			GasPricing: &pldapi.PublicTxGasPricing{
-				MaxFeePerGas:         pldtypes.Int64ToInt256(1000),
-				MaxPriorityFeePerGas: pldtypes.Int64ToInt256(100),
+				MaxFeePerGas:         pldtypes.Uint64ToUint256(1000),
+				MaxPriorityFeePerGas: pldtypes.Uint64ToUint256(100),
 			},
 		},
 	})

--- a/core/go/internal/statemgr/abi_schema.go
+++ b/core/go/internal/statemgr/abi_schema.go
@@ -215,7 +215,10 @@ func (as *abiSchema) mapValueToLabel(ctx context.Context, fieldName string, labe
 			return nil, nil, i18n.NewError(ctx, msgs.MsgStateLabelFieldUnexpectedValue, fieldName, f.Value, new(big.Int))
 		}
 		// Otherwise we fall back to encoding as a fixed-width hex string - with a leading sign character
-		filterString := pldtypes.Int256To65CharDBSafeSortableString(bigIntVal)
+		filterString, err := pldtypes.Int256To65CharDBSafeSortableString(ctx, bigIntVal)
+		if err != nil {
+			return nil, nil, err
+		}
 		return &pldapi.StateLabel{Label: fieldName, Value: filterString}, nil, nil
 	case labelTypeUint256:
 		bigIntVal, ok := f.Value.(*big.Int)
@@ -223,7 +226,10 @@ func (as *abiSchema) mapValueToLabel(ctx context.Context, fieldName string, labe
 			return nil, nil, i18n.NewError(ctx, msgs.MsgStateLabelFieldUnexpectedValue, fieldName, f.Value, new(big.Int))
 		}
 		bigIntVal = bigIntVal.Abs(bigIntVal)
-		filterString := filters.Uint256ToFilterString(ctx, bigIntVal)
+		filterString, err := filters.Uint256ToFilterString(ctx, bigIntVal)
+		if err != nil {
+			return nil, nil, err
+		}
 		return &pldapi.StateLabel{Label: fieldName, Value: filterString}, nil, nil
 	case labelTypeBytes:
 		byteValue, ok := f.Value.([]byte)

--- a/core/go/internal/statemgr/abi_schema_test.go
+++ b/core/go/internal/statemgr/abi_schema_test.go
@@ -800,4 +800,15 @@ func TestABISchemaMapValueToLabelTypeErrors(t *testing.T) {
 	_, _, err = as.mapValueToLabel(ctx, "", labelTypeBytes, cv)
 	assert.Regexp(t, "PD010109", err)
 
+	// The ABI parse of a value only range checks it when encoding to ABI bytes, so a value
+	// outside the range of the label's type reaches the label encoders and is rejected there
+	cv, err = tc.ParseExternal("0x10000000000000000000000000000000000000000000000000000000000000000") // 2^256
+	require.NoError(t, err)
+
+	_, _, err = as.mapValueToLabel(ctx, "", labelTypeInt256, cv)
+	assert.Regexp(t, "PD020029", err)
+
+	_, _, err = as.mapValueToLabel(ctx, "", labelTypeUint256, cv)
+	assert.Regexp(t, "PD020028", err)
+
 }

--- a/domains/integration-test/helpers/noto_helper.go
+++ b/domains/integration-test/helpers/noto_helper.go
@@ -98,43 +98,43 @@ func DeployNotoImplementation(ctx context.Context, t *testing.T, rpc rpcclient.C
 	}
 }
 
-func (n *NotoHelper) Mint(ctx context.Context, to string, amount int64) *DomainTransactionHelper {
+func (n *NotoHelper) Mint(ctx context.Context, to string, amount uint64) *DomainTransactionHelper {
 	fn := types.NotoABI.Functions()["mint"]
 	return NewDomainTransactionHelper(ctx, n.t, n.rpc, n.Address, fn, toJSON(n.t, &types.MintParams{
 		To:     to,
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}))
 }
 
-func (n *NotoHelper) Transfer(ctx context.Context, to string, amount int64) *DomainTransactionHelper {
+func (n *NotoHelper) Transfer(ctx context.Context, to string, amount uint64) *DomainTransactionHelper {
 	fn := types.NotoABI.Functions()["transfer"]
 	return NewDomainTransactionHelper(ctx, n.t, n.rpc, n.Address, fn, toJSON(n.t, &types.TransferParams{
 		To:     to,
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}))
 }
 
-func (n *NotoHelper) TransferFrom(ctx context.Context, from, to string, amount int64) *DomainTransactionHelper {
+func (n *NotoHelper) TransferFrom(ctx context.Context, from, to string, amount uint64) *DomainTransactionHelper {
 	fn := types.NotoABI.Functions()["transferFrom"]
 	return NewDomainTransactionHelper(ctx, n.t, n.rpc, n.Address, fn, toJSON(n.t, &types.TransferFromParams{
 		From:   from,
 		To:     to,
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}))
 }
 
-func (n *NotoHelper) Burn(ctx context.Context, amount int64) *DomainTransactionHelper {
+func (n *NotoHelper) Burn(ctx context.Context, amount uint64) *DomainTransactionHelper {
 	fn := types.NotoABI.Functions()["burn"]
 	return NewDomainTransactionHelper(ctx, n.t, n.rpc, n.Address, fn, toJSON(n.t, &types.BurnParams{
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}))
 }
 
-func (n *NotoHelper) BurnFrom(ctx context.Context, from string, amount int64) *DomainTransactionHelper {
+func (n *NotoHelper) BurnFrom(ctx context.Context, from string, amount uint64) *DomainTransactionHelper {
 	fn := types.NotoABI.Functions()["burnFrom"]
 	return NewDomainTransactionHelper(ctx, n.t, n.rpc, n.Address, fn, toJSON(n.t, &types.BurnFromParams{
 		From:   from,
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}))
 }
 

--- a/domains/integration-test/helpers/zeto_helper.go
+++ b/domains/integration-test/helpers/zeto_helper.go
@@ -223,17 +223,17 @@ func (z *ZetoHelper) ApproveERC20(ctx context.Context, tb testbed.Testbed, erc20
 	assert.NoError(z.t, err)
 }
 
-func (z *ZetoHelper) Deposit(ctx context.Context, amount int64) *DomainTransactionHelper {
+func (z *ZetoHelper) Deposit(ctx context.Context, amount uint64) *DomainTransactionHelper {
 	params := &types.DepositParams{
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}
 	fn := types.ZetoFungibleABI.Functions()["deposit"]
 	return NewDomainTransactionHelper(ctx, z.t, z.rpc, z.Address, fn, toJSON(z.t, &params))
 }
 
-func (z *ZetoHelper) Withdraw(ctx context.Context, amount int64) *DomainTransactionHelper {
+func (z *ZetoHelper) Withdraw(ctx context.Context, amount uint64) *DomainTransactionHelper {
 	params := &types.WithdrawParams{
-		Amount: pldtypes.Int64ToInt256(amount),
+		Amount: pldtypes.Uint64ToUint256(amount),
 	}
 	fn := types.ZetoFungibleABI.Functions()["withdraw"]
 	return NewDomainTransactionHelper(ctx, z.t, z.rpc, z.Address, fn, toJSON(z.t, &params))

--- a/domains/integration-test/noto_test.go
+++ b/domains/integration-test/noto_test.go
@@ -177,7 +177,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			Function: "mint",
 			Data: toJSON(t, &types.MintParams{
 				To:     notaryName,
-				Amount: pldtypes.Int64ToInt256(100),
+				Amount: pldtypes.Uint64ToUint256(100),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -211,7 +211,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			Function: "mint",
 			Data: toJSON(t, &types.MintParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(100),
+				Amount: pldtypes.Uint64ToUint256(100),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -230,7 +230,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			Function: "transfer",
 			Data: toJSON(t, &types.TransferParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(150),
+				Amount: pldtypes.Uint64ToUint256(150),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -249,7 +249,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			Function: "transfer",
 			Data: toJSON(t, &types.TransferParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -283,7 +283,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			Function: "transfer",
 			Data: toJSON(t, &types.TransferParams{
 				To:     recipient2Name,
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -316,7 +316,7 @@ func (s *notoTestSuite) testNoto(version string, variant string) {
 			To:       noto.Address,
 			Function: "burn",
 			Data: toJSON(t, &types.BurnParams{
-				Amount: pldtypes.Int64ToInt256(25),
+				Amount: pldtypes.Uint64ToUint256(25),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -387,7 +387,7 @@ func (s *notoTestSuite) testNotoLock(version, variant string) {
 			Function: "mint",
 			Data: toJSON(t, &types.MintParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(100),
+				Amount: pldtypes.Uint64ToUint256(100),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -411,7 +411,7 @@ func (s *notoTestSuite) testNotoLock(version, variant string) {
 			To:       noto.Address,
 			Function: "lock",
 			Data: toJSON(t, &types.LockParams{
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -442,7 +442,7 @@ func (s *notoTestSuite) testNotoLock(version, variant string) {
 			Function: "transfer",
 			Data: toJSON(t, &types.TransferParams{
 				To:     recipient2Name,
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -480,7 +480,7 @@ func (s *notoTestSuite) testNotoLock(version, variant string) {
 					From:   recipient1Name,
 					Recipients: []*types.UnlockRecipient{{
 						To:     recipient2Name,
-						Amount: pldtypes.Int64ToInt256(50),
+						Amount: pldtypes.Uint64ToUint256(50),
 					}},
 					Data: prepareTxData,
 				},
@@ -674,7 +674,7 @@ func (s *notoTestSuite) TestNotoCreateMintLock() {
 				Recipients: []*types.UnlockRecipient{
 					{
 						To:     recipient1Name,
-						Amount: pldtypes.Int64ToInt256(50),
+						Amount: pldtypes.Uint64ToUint256(50),
 					},
 				},
 				Data: pldtypes.HexBytes{},
@@ -760,7 +760,7 @@ func (s *notoTestSuite) TestNotoCreateBurnLock() {
 			Function: "mint",
 			Data: toJSON(t, &types.MintParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(100),
+				Amount: pldtypes.Uint64ToUint256(100),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -782,7 +782,7 @@ func (s *notoTestSuite) TestNotoCreateBurnLock() {
 			Function: "createBurnLock",
 			Data: toJSON(t, &types.CreateBurnLockParams{
 				From:   recipient1Name,
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 				Data:   pldtypes.HexBytes{},
 			}),
 		},
@@ -879,7 +879,7 @@ func (s *notoTestSuite) TestNotoPrepareMintUnlock() {
 			To:       noto.Address,
 			Function: "lock",
 			Data: toJSON(t, &types.LockParams{
-				Amount: pldtypes.Int64ToInt256(0),
+				Amount: pldtypes.Uint64ToUint256(0),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -909,7 +909,7 @@ func (s *notoTestSuite) TestNotoPrepareMintUnlock() {
 				Recipients: []*types.UnlockRecipient{
 					{
 						To:     recipient1Name,
-						Amount: pldtypes.Int64ToInt256(50),
+						Amount: pldtypes.Uint64ToUint256(50),
 					},
 				},
 				Data: pldtypes.HexBytes{},
@@ -1003,7 +1003,7 @@ func (s *notoTestSuite) TestNotoPrepareBurnUnlock() {
 			Function: "mint",
 			Data: toJSON(t, &types.MintParams{
 				To:     recipient1Name,
-				Amount: pldtypes.Int64ToInt256(100),
+				Amount: pldtypes.Uint64ToUint256(100),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -1021,7 +1021,7 @@ func (s *notoTestSuite) TestNotoPrepareBurnUnlock() {
 			To:       noto.Address,
 			Function: "lock",
 			Data: toJSON(t, &types.LockParams{
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 			}),
 		},
 		ABI: types.NotoABI,
@@ -1055,7 +1055,7 @@ func (s *notoTestSuite) TestNotoPrepareBurnUnlock() {
 			Data: toJSON(t, &types.PrepareBurnUnlockParams{
 				LockID: lockReceipt.LockInfo.LockID,
 				From:   recipient1Name,
-				Amount: pldtypes.Int64ToInt256(50),
+				Amount: pldtypes.Uint64ToUint256(50),
 				Data:   pldtypes.HexBytes{},
 			}),
 		},

--- a/domains/integration-test/pvp_test.go
+++ b/domains/integration-test/pvp_test.go
@@ -174,16 +174,16 @@ func (s *pvpTestSuite) pvpNotoNoto(withHooks bool) {
 	swap := helpers.DeploySwap(ctx, t, tb, pld, alice, &helpers.TradeRequestInput{
 		Holder1:       aliceKey.Verifier.Verifier,
 		TokenAddress1: notoGold.Address,
-		TokenValue1:   pldtypes.Int64ToInt256(1),
+		TokenValue1:   pldtypes.Uint64ToUint256(1),
 
 		Holder2:       bobKey.Verifier.Verifier,
 		TokenAddress2: notoSilver.Address,
-		TokenValue2:   pldtypes.Int64ToInt256(10),
+		TokenValue2:   pldtypes.Uint64ToUint256(10),
 	})
 
 	log.L(ctx).Infof("Prepare the transfers")
 	notoGoldLock := notoGold.Lock(ctx, &nototypes.LockParams{
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}).SignAndSend(alice).Wait()
 	notoGoldLockResult := decodeTransactionResult(t, notoGoldLock)
 	var goldLockReceipt nototypes.NotoDomainReceipt
@@ -193,7 +193,7 @@ func (s *pvpTestSuite) pvpNotoNoto(withHooks bool) {
 	require.NotEmpty(t, goldLockReceipt.LockInfo.LockID)
 
 	notoSilverLock := notoSilver.Lock(ctx, &nototypes.LockParams{
-		Amount: pldtypes.Int64ToInt256(10),
+		Amount: pldtypes.Uint64ToUint256(10),
 	}).SignAndSend(bob).Wait()
 	notoSilverLockResult := decodeTransactionResult(t, notoSilverLock)
 	var silverLockReceipt nototypes.NotoDomainReceipt
@@ -210,7 +210,7 @@ func (s *pvpTestSuite) pvpNotoNoto(withHooks bool) {
 			From:   alice,
 			Recipients: []*nototypes.UnlockRecipient{{
 				To:     bob,
-				Amount: pldtypes.Int64ToInt256(1),
+				Amount: pldtypes.Uint64ToUint256(1),
 			}},
 		},
 		UnlockData: pldtypes.MustParseHexBytes("0x9999"),
@@ -228,7 +228,7 @@ func (s *pvpTestSuite) pvpNotoNoto(withHooks bool) {
 			From:   bob,
 			Recipients: []*nototypes.UnlockRecipient{{
 				To:     alice,
-				Amount: pldtypes.Int64ToInt256(10),
+				Amount: pldtypes.Uint64ToUint256(10),
 			}},
 		},
 		UnlockData: pldtypes.MustParseHexBytes("0xfeedbeef"),
@@ -368,16 +368,16 @@ func (s *pvpTestSuite) TestNotoForZeto() {
 	swap := helpers.DeploySwap(ctx, t, tb, pld, alice, &helpers.TradeRequestInput{
 		Holder1:       aliceKey.Verifier.Verifier,
 		TokenAddress1: noto.Address,
-		TokenValue1:   pldtypes.Int64ToInt256(1),
+		TokenValue1:   pldtypes.Uint64ToUint256(1),
 
 		Holder2:       bobKey.Verifier.Verifier,
 		TokenAddress2: zeto.Address,
-		TokenValue2:   pldtypes.Int64ToInt256(1),
+		TokenValue2:   pldtypes.Uint64ToUint256(1),
 	})
 
 	log.L(ctx).Infof("Prepare the Noto transfer")
 	notoLock := noto.Lock(ctx, &nototypes.LockParams{
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}).SignAndSend(alice).Wait()
 	notoLockResult := decodeTransactionResult(t, notoLock)
 
@@ -394,7 +394,7 @@ func (s *pvpTestSuite) TestNotoForZeto() {
 			From:   alice,
 			Recipients: []*nototypes.UnlockRecipient{{
 				To:     bob,
-				Amount: pldtypes.Int64ToInt256(1),
+				Amount: pldtypes.Uint64ToUint256(1),
 			}},
 		},
 	}).SignAndSend(alice).Wait()

--- a/domains/noto/internal/noto/handler_balanceOf_test.go
+++ b/domains/noto/internal/noto/handler_balanceOf_test.go
@@ -204,7 +204,7 @@ func TestBalanceOfExecCall(t *testing.T) {
 		coin := &types.NotoCoin{
 			Salt:   pldtypes.RandBytes32(),
 			Owner:  (*pldtypes.EthAddress)(&aliceKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		}
 
 		mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -240,12 +240,12 @@ func TestBalanceOfExecCall(t *testing.T) {
 		coin1 := &types.NotoCoin{
 			Salt:   pldtypes.RandBytes32(),
 			Owner:  (*pldtypes.EthAddress)(&aliceKey.Address),
-			Amount: pldtypes.Int64ToInt256(75),
+			Amount: pldtypes.Uint64ToUint256(75),
 		}
 		coin2 := &types.NotoCoin{
 			Salt:   pldtypes.RandBytes32(),
 			Owner:  (*pldtypes.EthAddress)(&aliceKey.Address),
-			Amount: pldtypes.Int64ToInt256(25),
+			Amount: pldtypes.Uint64ToUint256(25),
 		}
 
 		mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -316,7 +316,7 @@ func TestBalanceOfExecCall(t *testing.T) {
 		coin := &types.NotoCoin{
 			Salt:   pldtypes.RandBytes32(),
 			Owner:  (*pldtypes.EthAddress)(&aliceKey.Address),
-			Amount: pldtypes.Int64ToInt256(0),
+			Amount: pldtypes.Uint64ToUint256(0),
 		}
 
 		mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_burn_test.go
+++ b/domains/noto/internal/noto/handler_burn_test.go
@@ -54,7 +54,7 @@ func TestBurn(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -285,7 +285,7 @@ func TestBurn_V0(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -528,7 +528,7 @@ func TestBurn_Nullifiers(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_create_burn_lock_test.go
+++ b/domains/noto/internal/noto/handler_create_burn_lock_test.go
@@ -44,7 +44,7 @@ func TestCreateBurnLock(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(150), // we'll have a remainder
+			Amount: pldtypes.Uint64ToUint256(150), // we'll have a remainder
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_create_mint_lock_test.go
+++ b/domains/noto/internal/noto/handler_create_mint_lock_test.go
@@ -336,7 +336,7 @@ func TestCreateMintLock(t *testing.T) {
 	require.NotNil(t, hookParams.Recipients[0].To)
 	assert.Equal(t, pldtypes.MustEthAddress("0x2000000000000000000000000000000000000000").String(), hookParams.Recipients[0].To.String())
 	require.NotNil(t, hookParams.Recipients[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(100).String(), hookParams.Recipients[0].Amount.String())
+	assert.Equal(t, pldtypes.Uint64ToUint256(100).String(), hookParams.Recipients[0].Amount.String())
 
 	// Verify prepared transaction
 	assert.Equal(t, pldtypes.MustEthAddress(contractAddress), hookParams.Prepared.ContractAddress)

--- a/domains/noto/internal/noto/handler_create_transfer_lock_test.go
+++ b/domains/noto/internal/noto/handler_create_transfer_lock_test.go
@@ -45,7 +45,7 @@ func TestCreateTransferLock(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(150), // we'll have a remainder
+			Amount: pldtypes.Uint64ToUint256(150), // we'll have a remainder
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -405,7 +405,7 @@ func TestCreateTransferLock(t *testing.T) {
 	require.NotNil(t, hookParams.Recipients[0].To)
 	assert.Equal(t, pldtypes.MustEthAddress("0x2000000000000000000000000000000000000000").String(), hookParams.Recipients[0].To.String())
 	require.NotNil(t, hookParams.Recipients[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(100).String(), hookParams.Recipients[0].Amount.String())
+	assert.Equal(t, pldtypes.Uint64ToUint256(100).String(), hookParams.Recipients[0].Amount.String())
 
 	// Verify prepared transaction
 	assert.Equal(t, pldtypes.MustEthAddress(contractAddress), hookParams.Prepared.ContractAddress)

--- a/domains/noto/internal/noto/handler_delegate_lock_test.go
+++ b/domains/noto/internal/noto/handler_delegate_lock_test.go
@@ -59,7 +59,7 @@ func TestDelegateLock(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	inputLockInfoSalt := pldtypes.RandBytes32()
@@ -356,7 +356,7 @@ func TestDelegateLock_V0(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_lock_test.go
+++ b/domains/noto/internal/noto/handler_lock_test.go
@@ -58,7 +58,7 @@ func TestLock(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -401,7 +401,7 @@ func TestLock_V0(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_prepare_burn_unlock_test.go
+++ b/domains/noto/internal/noto/handler_prepare_burn_unlock_test.go
@@ -59,7 +59,7 @@ func TestPrepareBurnUnlock(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	inputLockInfoSalt := pldtypes.RandBytes32()

--- a/domains/noto/internal/noto/handler_prepare_mint_unlock_test.go
+++ b/domains/noto/internal/noto/handler_prepare_mint_unlock_test.go
@@ -389,7 +389,7 @@ func TestPrepareMintUnlock(t *testing.T) {
 	require.NotNil(t, hookParams.Recipients[0].To)
 	assert.Equal(t, pldtypes.MustEthAddress("0x2000000000000000000000000000000000000000").String(), hookParams.Recipients[0].To.String())
 	require.NotNil(t, hookParams.Recipients[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(100).String(), hookParams.Recipients[0].Amount.String())
+	assert.Equal(t, pldtypes.Uint64ToUint256(100).String(), hookParams.Recipients[0].Amount.String())
 
 	// Verify prepared transaction
 	assert.Equal(t, pldtypes.MustEthAddress(contractAddress), hookParams.Prepared.ContractAddress)

--- a/domains/noto/internal/noto/handler_prepare_unlock_test.go
+++ b/domains/noto/internal/noto/handler_prepare_unlock_test.go
@@ -61,7 +61,7 @@ func TestPrepareUnlock(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	inputLockInfoSalt := pldtypes.RandBytes32()
@@ -432,7 +432,7 @@ func TestPrepareUnlock(t *testing.T) {
 	require.NotNil(t, hookParams.Recipients[0].To)
 	assert.Equal(t, pldtypes.MustEthAddress("0x2000000000000000000000000000000000000000").String(), hookParams.Recipients[0].To.String())
 	require.NotNil(t, hookParams.Recipients[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(100).String(), hookParams.Recipients[0].Amount.String())
+	assert.Equal(t, pldtypes.Uint64ToUint256(100).String(), hookParams.Recipients[0].Amount.String())
 
 	// Verify prepared transaction
 	assert.Equal(t, pldtypes.MustEthAddress(contractAddress), hookParams.Prepared.ContractAddress)
@@ -507,7 +507,7 @@ func TestPrepareUnlock_V0(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/handler_transfer_test.go
+++ b/domains/noto/internal/noto/handler_transfer_test.go
@@ -91,7 +91,7 @@ func TestTransfer(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -377,7 +377,7 @@ func TestTransfer_V0(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -655,7 +655,7 @@ func TestTransfer_Nullifiers(t *testing.T) {
 		ID: pldtypes.RandBytes32(),
 		Data: types.NotoCoin{
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {
@@ -904,7 +904,7 @@ func TestTransferAssembleMissingFrom(t *testing.T) {
 		DomainConfig:    notoBasicConfigV1,
 		Params: &types.TransferParams{
 			To:     "receiver@node2",
-			Amount: pldtypes.Int64ToInt256(75),
+			Amount: pldtypes.Uint64ToUint256(75),
 			Data:   pldtypes.MustParseHexBytes("0x1234"),
 		},
 	}
@@ -941,7 +941,7 @@ func TestTransferAssembleMissingTo(t *testing.T) {
 		DomainConfig:    notoBasicConfigV1,
 		Params: &types.TransferParams{
 			To:     "receiver@node2",
-			Amount: pldtypes.Int64ToInt256(75),
+			Amount: pldtypes.Uint64ToUint256(75),
 			Data:   pldtypes.MustParseHexBytes("0x1234"),
 		},
 	}

--- a/domains/noto/internal/noto/handler_unlock_test.go
+++ b/domains/noto/internal/noto/handler_unlock_test.go
@@ -62,7 +62,7 @@ func TestUnlock(t *testing.T) {
 			Salt:   pldtypes.RandBytes32(),
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	inputLockInfo := &prototk.StoredState{
@@ -332,7 +332,7 @@ func TestUnlock(t *testing.T) {
 	require.NotNil(t, hookParams.Recipients[0].To)
 	assert.Equal(t, pldtypes.MustEthAddress("0x2000000000000000000000000000000000000000").String(), hookParams.Recipients[0].To.String())
 	require.NotNil(t, hookParams.Recipients[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(100).String(), hookParams.Recipients[0].Amount.String())
+	assert.Equal(t, pldtypes.Uint64ToUint256(100).String(), hookParams.Recipients[0].Amount.String())
 
 	// Verify prepared transaction
 	assert.Equal(t, pldtypes.MustEthAddress(contractAddress), hookParams.Prepared.ContractAddress)
@@ -388,7 +388,7 @@ func TestUnlock_V0(t *testing.T) {
 		Data: types.NotoLockedCoin{
 			LockID: lockID,
 			Owner:  (*pldtypes.EthAddress)(&senderKey.Address),
-			Amount: pldtypes.Int64ToInt256(100),
+			Amount: pldtypes.Uint64ToUint256(100),
 		},
 	}
 	mockCallbacks.MockFindAvailableStates = func(ctx context.Context, req *prototk.FindAvailableStatesRequest) (*prototk.FindAvailableStatesResponse, error) {

--- a/domains/noto/internal/noto/receipts_test.go
+++ b/domains/noto/internal/noto/receipts_test.go
@@ -82,7 +82,7 @@ func TestReceiptTransfers(t *testing.T) {
 	assert.ElementsMatch(t, []*types.ReceiptTransfer{{
 		From:   nil,
 		To:     owner1,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}}, transfers)
 
 	// Simple burn
@@ -101,7 +101,7 @@ func TestReceiptTransfers(t *testing.T) {
 	assert.ElementsMatch(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     nil,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}}, transfers)
 
 	// Burn with returned remainder
@@ -127,7 +127,7 @@ func TestReceiptTransfers(t *testing.T) {
 	assert.ElementsMatch(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     nil,
-		Amount: pldtypes.Int64ToInt256(2),
+		Amount: pldtypes.Uint64ToUint256(2),
 	}}, transfers)
 
 	// Simple transfer
@@ -153,7 +153,7 @@ func TestReceiptTransfers(t *testing.T) {
 	assert.ElementsMatch(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     owner2,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}}, transfers)
 
 	// Unlock to multiple recipients, with locked remainder
@@ -200,11 +200,11 @@ func TestReceiptTransfers(t *testing.T) {
 	assert.ElementsMatch(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     owner2,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}, {
 		From:   owner1,
 		To:     owner3,
-		Amount: pldtypes.Int64ToInt256(2),
+		Amount: pldtypes.Uint64ToUint256(2),
 	}}, transfers)
 }
 

--- a/domains/zeto/internal/zeto/fungible/handler_deposit_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_deposit_test.go
@@ -27,8 +27,11 @@ func TestDepositValidateParams(t *testing.T) {
 	_, err = h.ValidateParams(ctx, config, "bad json")
 	require.ErrorContains(t, err, "PD210105: Failed to decode the deposit call.")
 
-	_, err = h.ValidateParams(ctx, config, "{\"amount\":-100}")
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":0}")
 	require.ErrorContains(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
+
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":-100}")
+	require.ErrorContains(t, err, "PD020027: Negative value invalid for a uint256: -100")
 }
 
 func TestDepositInit(t *testing.T) {

--- a/domains/zeto/internal/zeto/fungible/handler_lock_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_lock_test.go
@@ -70,8 +70,11 @@ func TestLockValidateParams(t *testing.T) {
 	_, err = h.ValidateParams(ctx, config, "{\"delegate\":\"0x1234567890123456789012345678901234567890\"}")
 	assert.ErrorContains(t, err, "PD210026: Parameter 'amount' is required (index=0)")
 
-	_, err = h.ValidateParams(ctx, config, "{\"amount\":-10,\"delegate\":\"0x1234567890123456789012345678901234567890\"}")
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":0,\"delegate\":\"0x1234567890123456789012345678901234567890\"}")
 	assert.ErrorContains(t, err, "PD210107: Total amount must be in the range (0, 2^100)")
+
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":-10,\"delegate\":\"0x1234567890123456789012345678901234567890\"}")
+	assert.ErrorContains(t, err, "PD020027: Negative value invalid for a uint256: -10")
 
 	amt1 := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(100), nil) // max allowed
 	amt1.Sub(amt1, big.NewInt(1))

--- a/domains/zeto/internal/zeto/fungible/handler_mint_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_mint_test.go
@@ -52,7 +52,7 @@ func TestMintValidateParams(t *testing.T) {
 	assert.EqualError(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
 
 	_, err = h.ValidateParams(ctx, nil, "{\"mints\":[{\"to\":\"0x1234567890123456789012345678901234567890\",\"amount\":-10}]}")
-	assert.EqualError(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
+	assert.EqualError(t, err, "PD020027: Negative value invalid for a uint256: -10")
 
 	max := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(100), nil).Text(10)
 	_, err = h.ValidateParams(ctx, nil, "{\"mints\":[{\"to\":\"0x1234567890123456789012345678901234567890\",\"amount\":"+max+"}]}")

--- a/domains/zeto/internal/zeto/fungible/handler_transferLocked_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_transferLocked_test.go
@@ -71,7 +71,7 @@ func TestTransferLockedValidateParams(t *testing.T) {
 	assert.EqualError(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
 
 	_, err = h.ValidateParams(ctx, nil, "{\"lockedInputs\":[\"0x0c3d1d2996e66d8512c7c3faa4b5f55180fee870190d589a911b6517dc578dba\"],\"delegate\":\"delegate1\",\"transfers\":[{\"to\":\"0x1234567890123456789012345678901234567890\",\"amount\":-10}]}")
-	assert.EqualError(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
+	assert.EqualError(t, err, "PD020027: Negative value invalid for a uint256: -10")
 
 	amt1 := big.NewInt(0).Exp(big.NewInt(2), big.NewInt(100), nil)
 	amt1.Sub(amt1, big.NewInt(1000))

--- a/domains/zeto/internal/zeto/fungible/handler_transfer_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_transfer_test.go
@@ -91,7 +91,7 @@ func TestTransferValidateParams(t *testing.T) {
 		{
 			name:        "Invalid 'amount' parameter (-10)",
 			input:       "{\"transfers\":[{\"to\":\"0x1234567890123456789012345678901234567890\",\"amount\":-10}]}",
-			expectedErr: "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)",
+			expectedErr: "PD020027: Negative value invalid for a uint256: -10",
 		},
 		{
 			name:        "Total amount exceeds range",

--- a/domains/zeto/internal/zeto/fungible/handler_withdraw_test.go
+++ b/domains/zeto/internal/zeto/fungible/handler_withdraw_test.go
@@ -29,8 +29,11 @@ func TestWithdrawValidateParams(t *testing.T) {
 	_, err = h.ValidateParams(ctx, config, "bad json")
 	require.ErrorContains(t, err, "PD210106: Failed to decode the withdraw call.")
 
-	_, err = h.ValidateParams(ctx, config, "{\"amount\":-100}")
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":0}")
 	require.ErrorContains(t, err, "PD210027: Parameter 'amount' must be in the range (0, 2^100) (index=0)")
+
+	_, err = h.ValidateParams(ctx, config, "{\"amount\":-100}")
+	require.ErrorContains(t, err, "PD020027: Negative value invalid for a uint256: -100")
 }
 
 func TestWithdrawInit(t *testing.T) {

--- a/domains/zeto/internal/zeto/receipts_test.go
+++ b/domains/zeto/internal/zeto/receipts_test.go
@@ -139,8 +139,8 @@ func TestBuildReceiptMint(t *testing.T) {
 	assert.Equal(t, pldtypes.MustParseBytes32(coinSchemaID), receipt.States.Outputs[0].Schema)
 	assert.Equal(t, pldtypes.MustParseHexBytes(stateID2), receipt.States.Outputs[1].ID)
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{To: owner1, Amount: pldtypes.Int64ToInt256(10), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
-		{To: owner1, Amount: pldtypes.Int64ToInt256(20), Data: pldtypes.MustParseHexBytes("0xfeedface")},
+		{To: owner1, Amount: pldtypes.Uint64ToUint256(10), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
+		{To: owner1, Amount: pldtypes.Uint64ToUint256(20), Data: pldtypes.MustParseHexBytes("0xfeedface")},
 	}, receipt.Transfers)
 }
 
@@ -174,8 +174,8 @@ func TestBuildReceiptTransferDataPerEntry(t *testing.T) {
 		},
 	})
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{From: owner1, To: owner2, Amount: pldtypes.Int64ToInt256(40), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
-		{From: owner1, To: owner3, Amount: pldtypes.Int64ToInt256(60), Data: pldtypes.MustParseHexBytes("0xfeedface")},
+		{From: owner1, To: owner2, Amount: pldtypes.Uint64ToUint256(40), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
+		{From: owner1, To: owner3, Amount: pldtypes.Uint64ToUint256(60), Data: pldtypes.MustParseHexBytes("0xfeedface")},
 	}, receipt.Transfers)
 }
 
@@ -193,7 +193,7 @@ func TestBuildReceiptChangeCarriesNoData(t *testing.T) {
 		},
 	})
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{From: owner1, To: owner2, Amount: pldtypes.Int64ToInt256(40), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
+		{From: owner1, To: owner2, Amount: pldtypes.Uint64ToUint256(40), Data: pldtypes.MustParseHexBytes("0xdeadbeef")},
 	}, receipt.Transfers)
 }
 
@@ -227,7 +227,7 @@ func TestBuildReceiptBurn(t *testing.T) {
 	assert.Equal(t, pldtypes.MustParseHexBytes(stateID1), receipt.States.Inputs[0].ID)
 	assert.Equal(t, []*types.ReceiptTransfer{{
 		From:   owner1,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}}, receipt.Transfers)
 }
 
@@ -244,7 +244,7 @@ func TestBuildReceiptBurnWithRemainder(t *testing.T) {
 	require.Len(t, receipt.States.Outputs, 1)
 	assert.Equal(t, []*types.ReceiptTransfer{{
 		From:   owner1,
-		Amount: pldtypes.Int64ToInt256(2),
+		Amount: pldtypes.Uint64ToUint256(2),
 	}}, receipt.Transfers)
 }
 
@@ -264,7 +264,7 @@ func TestBuildReceiptTransferWithChange(t *testing.T) {
 	assert.Equal(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     owner2,
-		Amount: pldtypes.Int64ToInt256(25),
+		Amount: pldtypes.Uint64ToUint256(25),
 	}}, receipt.Transfers)
 }
 
@@ -287,9 +287,9 @@ func TestBuildReceiptTransferReportsEachCoinSeparately(t *testing.T) {
 		},
 	})
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{From: owner1, To: owner2, Amount: pldtypes.Int64ToInt256(30), Data: pldtypes.MustParseHexBytes("0x01")},
-		{From: owner1, To: owner2, Amount: pldtypes.Int64ToInt256(20), Data: pldtypes.MustParseHexBytes("0x02")},
-		{From: owner1, To: owner3, Amount: pldtypes.Int64ToInt256(50), Data: pldtypes.MustParseHexBytes("0x03")},
+		{From: owner1, To: owner2, Amount: pldtypes.Uint64ToUint256(30), Data: pldtypes.MustParseHexBytes("0x01")},
+		{From: owner1, To: owner2, Amount: pldtypes.Uint64ToUint256(20), Data: pldtypes.MustParseHexBytes("0x02")},
+		{From: owner1, To: owner3, Amount: pldtypes.Uint64ToUint256(50), Data: pldtypes.MustParseHexBytes("0x03")},
 	}, receipt.Transfers)
 }
 
@@ -333,7 +333,7 @@ func TestBuildReceiptTransferLocked(t *testing.T) {
 	assert.Equal(t, []*types.ReceiptTransfer{{
 		From:   owner1,
 		To:     owner2,
-		Amount: pldtypes.Int64ToInt256(5),
+		Amount: pldtypes.Uint64ToUint256(5),
 	}}, receipt.Transfers)
 }
 
@@ -536,7 +536,7 @@ func TestUnmarshalInfo(t *testing.T) {
 func TestUnmarshalCoin(t *testing.T) {
 	coin, err := unmarshalCoin(fmt.Sprintf(`{"amount":"100","owner":"%s","locked":true}`, owner1))
 	require.NoError(t, err)
-	assert.Equal(t, pldtypes.Int64ToInt256(100), coin.Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(100), coin.Amount)
 	assert.Equal(t, owner1, coin.Owner)
 	assert.True(t, coin.Locked)
 
@@ -587,8 +587,8 @@ func TestBuildFungibleTransfersMultipleSenders(t *testing.T) {
 	// what moved rather than reporting something misleading
 	inputs := &parsedCoins{
 		coins: []*types.ZetoCoin{
-			{Owner: owner1, Amount: pldtypes.Int64ToInt256(100)},
-			{Owner: owner2, Amount: pldtypes.Int64ToInt256(50)},
+			{Owner: owner1, Amount: pldtypes.Uint64ToUint256(100)},
+			{Owner: owner2, Amount: pldtypes.Uint64ToUint256(50)},
 		},
 	}
 	assert.Nil(t, buildFungibleTransfers(context.Background(), inputs, &parsedCoins{}, nil))
@@ -599,39 +599,39 @@ func TestBuildFungibleTransfersZeroAmount(t *testing.T) {
 	inputs := &parsedCoins{}
 	outputs := &parsedCoins{
 		coins: []*types.ZetoCoin{
-			{Owner: owner1, Amount: pldtypes.Int64ToInt256(100)},
-			{Owner: owner2, Amount: pldtypes.Int64ToInt256(0)},
+			{Owner: owner1, Amount: pldtypes.Uint64ToUint256(100)},
+			{Owner: owner2, Amount: pldtypes.Uint64ToUint256(0)},
 		},
 	}
 	transfers := buildFungibleTransfers(context.Background(), inputs, outputs, nil)
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{To: owner1, Amount: pldtypes.Int64ToInt256(100)},
+		{To: owner1, Amount: pldtypes.Uint64ToUint256(100)},
 	}, transfers)
 }
 
 func TestBuildFungibleTransfersDoesNotMutateCoins(t *testing.T) {
 	outputs := &parsedCoins{
 		coins: []*types.ZetoCoin{
-			{Owner: owner1, Amount: pldtypes.Int64ToInt256(30)},
-			{Owner: owner1, Amount: pldtypes.Int64ToInt256(20)},
+			{Owner: owner1, Amount: pldtypes.Uint64ToUint256(30)},
+			{Owner: owner1, Amount: pldtypes.Uint64ToUint256(20)},
 		},
 	}
 	transfers := buildFungibleTransfers(context.Background(), &parsedCoins{}, outputs, nil)
 	require.Len(t, transfers, 2)
-	assert.Equal(t, pldtypes.Int64ToInt256(30), transfers[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(20), transfers[1].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(30), outputs.coins[0].Amount)
-	assert.Equal(t, pldtypes.Int64ToInt256(20), outputs.coins[1].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(30), transfers[0].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(20), transfers[1].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(30), outputs.coins[0].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(20), outputs.coins[1].Amount)
 }
 
 func TestBuildFungibleTransfersLockedCoinsKeepEntryPositions(t *testing.T) {
 	// Locked and unlocked coins share one ordered list, so a locked output does not shift the entry
 	// positions the data is matched on
-	inputs := &parsedCoins{coins: []*types.ZetoCoin{{Owner: owner1, Amount: pldtypes.Int64ToInt256(100)}}}
+	inputs := &parsedCoins{coins: []*types.ZetoCoin{{Owner: owner1, Amount: pldtypes.Uint64ToUint256(100)}}}
 	outputs := &parsedCoins{
 		coins: []*types.ZetoCoin{
-			{Owner: owner2, Amount: pldtypes.Int64ToInt256(40), Locked: true},
-			{Owner: owner3, Amount: pldtypes.Int64ToInt256(60)},
+			{Owner: owner2, Amount: pldtypes.Uint64ToUint256(40), Locked: true},
+			{Owner: owner3, Amount: pldtypes.Uint64ToUint256(60)},
 		},
 	}
 	entryData := []pldtypes.HexBytes{
@@ -639,8 +639,8 @@ func TestBuildFungibleTransfersLockedCoinsKeepEntryPositions(t *testing.T) {
 		pldtypes.MustParseHexBytes("0x02"),
 	}
 	assert.Equal(t, []*types.ReceiptTransfer{
-		{From: owner1, To: owner2, Amount: pldtypes.Int64ToInt256(40), Data: pldtypes.MustParseHexBytes("0x01")},
-		{From: owner1, To: owner3, Amount: pldtypes.Int64ToInt256(60), Data: pldtypes.MustParseHexBytes("0x02")},
+		{From: owner1, To: owner2, Amount: pldtypes.Uint64ToUint256(40), Data: pldtypes.MustParseHexBytes("0x01")},
+		{From: owner1, To: owner3, Amount: pldtypes.Uint64ToUint256(60), Data: pldtypes.MustParseHexBytes("0x02")},
 	}, buildFungibleTransfers(context.Background(), inputs, outputs, entryData))
 }
 
@@ -693,9 +693,9 @@ func TestParseCoinList(t *testing.T) {
 	// Locked and unlocked coins share one ordered list, so that a coin's position still identifies
 	// the transfer entry that produced it
 	require.Len(t, result.coins, 2)
-	assert.Equal(t, pldtypes.Int64ToInt256(100), result.coins[0].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(100), result.coins[0].Amount)
 	assert.False(t, result.coins[0].Locked)
-	assert.Equal(t, pldtypes.Int64ToInt256(50), result.coins[1].Amount)
+	assert.Equal(t, pldtypes.Uint64ToUint256(50), result.coins[1].Amount)
 	assert.True(t, result.coins[1].Locked)
 	require.Len(t, result.nfts, 1)
 	assert.Equal(t, pldtypes.MustParseHexUint256("0xdeadbeef"), result.nfts[0].TokenID)

--- a/domains/zeto/internal/zeto/zeto_test.go
+++ b/domains/zeto/internal/zeto/zeto_test.go
@@ -741,7 +741,7 @@ func TestSign(t *testing.T) {
 	fakeCoin := types.ZetoCoin{
 		Salt:   (*pldtypes.HexUint256)(salt),
 		Owner:  pldtypes.MustParseHexBytes(alicePubKey),
-		Amount: pldtypes.Int64ToInt256(12345),
+		Amount: pldtypes.Uint64ToUint256(12345),
 	}
 	req = &pb.SignRequest{
 		Algorithm:   z.getAlgoZetoSnarkBJJ(),

--- a/sdk/go/pkg/pldtypes/hex_int256.go
+++ b/sdk/go/pkg/pldtypes/hex_int256.go
@@ -40,9 +40,9 @@ var (
 
 // checkInt256Range enforces the range of the type. The DB serialization is exactly 32 bytes of
 // two's complement, so the same check covers both parsing a value and persisting one.
-func checkInt256Range(ctx context.Context, bi *big.Int, desc string) error {
+func checkInt256Range(ctx context.Context, bi *big.Int) error {
 	if bi.Cmp(int256Min) < 0 || bi.Cmp(int256Max) > 0 {
-		return i18n.NewError(ctx, pldmsgs.MsgTypesInt256OutOfRange, desc)
+		return i18n.NewError(ctx, pldmsgs.MsgTypesInt256OutOfRange, bi.Text(10))
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func ParseHexInt256(ctx context.Context, s string) (*HexInt256, error) {
 	if !ok {
 		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesInvalidHexInteger, s)
 	}
-	if err := checkInt256Range(ctx, bi, s); err != nil {
+	if err := checkInt256Range(ctx, bi); err != nil {
 		return nil, err
 	}
 	return (*HexInt256)(bi), nil
@@ -126,11 +126,11 @@ func (hi *HexInt256) Value() (driver.Value, error) {
 	if hi == nil {
 		return nil, nil
 	}
-	bi := (*big.Int)(hi)
-	if err := checkInt256Range(context.Background(), bi, bi.Text(10)); err != nil {
+	s, err := Int256To65CharDBSafeSortableString(context.Background(), (*big.Int)(hi))
+	if err != nil {
 		return nil, err
 	}
-	return Int256To65CharDBSafeSortableString(bi), nil
+	return s, nil
 }
 
 func (hi *HexInt256) Scan(src interface{}) error {
@@ -155,30 +155,48 @@ func (hi *HexInt256) Scan(src interface{}) error {
 	}
 }
 
-func Int256To65CharDBSafeSortableString(bi *big.Int) string {
+func Int256To65CharDBSafeSortableString(ctx context.Context, bi *big.Int) (string, error) {
 	sign := bi.Sign()
-	signPlusZeroPaddedInt256 := PadHexBigIntTwosComplement(bi, make([]byte, 65))
+	signPlusZeroPaddedInt256, err := PadHexBigIntTwosComplement(ctx, bi, make([]byte, 65))
+	if err != nil {
+		return "", err
+	}
 	if sign < 0 {
 		signPlusZeroPaddedInt256[0] = '0'
 	} else {
 		// Zero or positive get a "1" in the first string position, which makes them
 		signPlusZeroPaddedInt256[0] = '1'
 	}
-	return (string)(signPlusZeroPaddedInt256)
+	return (string)(signPlusZeroPaddedInt256), nil
 }
 
-// PadHexBigIntTwosComplement returns the supplied buffer, with all the bytes to the left of
-// the two's complement formatted string set to 0
-func PadHexBigIntTwosComplement(bi *big.Int, buff []byte) []byte {
+// PadHexBigIntTwosComplement returns the supplied buffer, containing the two's complement
+// formatted string sign-extended to the left - with 'f' for a negative integer, and '0' for
+// zero or a positive one. The supplied integer is not modified.
+//
+// The integer must be in the range of an int256, and its encoding must fit within the supplied
+// buffer. Both are errors, rather than the silently wrapped or truncated - and so incorrect -
+// encoding that an out of range value would otherwise produce
+func PadHexBigIntTwosComplement(ctx context.Context, bi *big.Int, buff []byte) ([]byte, error) {
+	if err := checkInt256Range(ctx, bi); err != nil {
+		return nil, err
+	}
 	twosComplement := abi.SerializeInt256TwosComplementBytes(bi)
 	unPadded := hex.EncodeToString(twosComplement)
 	boundary := len(buff) - len(unPadded)
+	if boundary < 0 {
+		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesHexIntBufferTooSmall, len(buff), len(unPadded))
+	}
+	signExtend := byte('0')
+	if bi.Sign() < 0 {
+		signExtend = 'f'
+	}
 	for i := 0; i < len(buff); i++ {
 		if i >= boundary {
 			buff[i] = unPadded[i-boundary]
 		} else {
-			buff[i] = 'f'
+			buff[i] = signExtend
 		}
 	}
-	return buff
+	return buff, nil
 }

--- a/sdk/go/pkg/pldtypes/hex_int256.go
+++ b/sdk/go/pkg/pldtypes/hex_int256.go
@@ -29,8 +29,23 @@ import (
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 )
 
-// HexInt256 is any integer (signed or unsigned) up to 256 bits in size, serialized to the DB using a 65 sortable string (a 0/1 sign character, followed by 32 hex bytes)
+// HexInt256 is a signed integer in the range -2^255 to 2^255-1, serialized to the DB using a
+// 65 character sortable string (a 0/1 sign character, followed by 32 hex bytes of two's complement)
 type HexInt256 big.Int
+
+var (
+	int256Min = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255))
+	int256Max = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+)
+
+// checkInt256Range enforces the range of the type. The DB serialization is exactly 32 bytes of
+// two's complement, so the same check covers both parsing a value and persisting one.
+func checkInt256Range(ctx context.Context, bi *big.Int, desc string) error {
+	if bi.Cmp(int256Min) < 0 || bi.Cmp(int256Max) > 0 {
+		return i18n.NewError(ctx, pldmsgs.MsgTypesInt256OutOfRange, desc)
+	}
+	return nil
+}
 
 func Int64ToInt256(v int64) *HexUint256 {
 	return (*HexUint256)(new(big.Int).SetInt64(v))
@@ -41,6 +56,9 @@ func ParseHexInt256(ctx context.Context, s string) (*HexInt256, error) {
 	bi, ok := new(big.Int).SetString(s, 0)
 	if !ok {
 		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesInvalidHexInteger, s)
+	}
+	if err := checkInt256Range(ctx, bi, s); err != nil {
+		return nil, err
 	}
 	return (*HexInt256)(bi), nil
 }
@@ -108,7 +126,11 @@ func (hi *HexInt256) Value() (driver.Value, error) {
 	if hi == nil {
 		return nil, nil
 	}
-	return Int256To65CharDBSafeSortableString((*big.Int)(hi)), nil
+	bi := (*big.Int)(hi)
+	if err := checkInt256Range(context.Background(), bi, bi.Text(10)); err != nil {
+		return nil, err
+	}
+	return Int256To65CharDBSafeSortableString(bi), nil
 }
 
 func (hi *HexInt256) Scan(src interface{}) error {

--- a/sdk/go/pkg/pldtypes/hex_int256.go
+++ b/sdk/go/pkg/pldtypes/hex_int256.go
@@ -47,8 +47,8 @@ func checkInt256Range(ctx context.Context, bi *big.Int, desc string) error {
 	return nil
 }
 
-func Int64ToInt256(v int64) *HexUint256 {
-	return (*HexUint256)(new(big.Int).SetInt64(v))
+func Int64ToInt256(v int64) *HexInt256 {
+	return (*HexInt256)(new(big.Int).SetInt64(v))
 }
 
 // Parse a string

--- a/sdk/go/pkg/pldtypes/hex_int256_test.go
+++ b/sdk/go/pkg/pldtypes/hex_int256_test.go
@@ -17,8 +17,8 @@
 package pldtypes
 
 import (
-	"context"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,12 +60,38 @@ func TestHexInt256(t *testing.T) {
 	v = MustParseHexInt256("0x8000000000000000")
 	assert.Equal(t, uint64(0x8000000000000000), v.Int().Uint64())
 
+	// The type is a sign character plus 32 bytes of two's complement, so it spans
+	// -2^255 to 2^255-1 and both ends round-trip through the DB
+	v = MustParseHexInt256("57896044618658097711785492504343953926634992332820282019728792003956564819967")
+	dbv, err = v.Value()
+	require.NoError(t, err)
+	err = v.Scan(dbv)
+	require.NoError(t, err)
+	assert.Equal(t, "57896044618658097711785492504343953926634992332820282019728792003956564819967", v.Int().Text(10))
+
+	v = MustParseHexInt256("-57896044618658097711785492504343953926634992332820282019728792003956564819968")
+	dbv, err = v.Value()
+	require.NoError(t, err)
+	err = v.Scan(dbv)
+	require.NoError(t, err)
+	assert.Equal(t, "-57896044618658097711785492504343953926634992332820282019728792003956564819968", v.Int().Text(10))
+
 	assert.Panics(t, func() {
 		_ = MustParseHexInt256("wrong")
 	})
 
-	_, err = ParseHexInt256(context.Background(), "wrong")
+	assert.Panics(t, func() {
+		_ = MustParseHexInt256("57896044618658097711785492504343953926634992332820282019728792003956564819968")
+	})
+
+	_, err = ParseHexInt256(t.Context(), "wrong")
 	require.Regexp(t, "PD020009", err)
+
+	// A value either side of that span cannot be represented
+	_, err = ParseHexInt256(t.Context(), "57896044618658097711785492504343953926634992332820282019728792003956564819968")
+	assert.Regexp(t, "PD020029", err)
+	_, err = ParseHexInt256(t.Context(), "-57896044618658097711785492504343953926634992332820282019728792003956564819969")
+	assert.Regexp(t, "PD020029", err)
 
 	type testStruct struct {
 		F1 *HexInt256 `json:"f1"`
@@ -106,6 +132,13 @@ func TestHexInt256(t *testing.T) {
 
 	err = v.Scan("wrong000000000000000000000000000000000000000000007fffffffffffffff")
 	assert.Regexp(t, "PD020012", err)
+
+	// A value can also be handed to the type by conversion, bypassing the constructors,
+	// and one it cannot represent is rejected rather than serialized with its sign flipped
+	past := (*HexInt256)(new(big.Int).Lsh(big.NewInt(1), 255))
+	_, err = past.Value()
+	assert.Regexp(t, "PD020029", err)
+	assert.Equal(t, "57896044618658097711785492504343953926634992332820282019728792003956564819968", past.Int().Text(10))
 
 	assert.True(t, ((*HexInt256)(nil)).NilOrZero())
 

--- a/sdk/go/pkg/pldtypes/hex_int256_test.go
+++ b/sdk/go/pkg/pldtypes/hex_int256_test.go
@@ -19,6 +19,8 @@ package pldtypes
 import (
 	"encoding/json"
 	"math/big"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,6 +117,18 @@ func TestHexInt256(t *testing.T) {
 		"f1": false
 	}`), &ts)
 	assert.Regexp(t, "PD020002", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": 57896044618658097711785492504343953926634992332820282019728792003956564819968
+	}`), &ts)
+	assert.Regexp(t, "PD020029", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": -57896044618658097711785492504343953926634992332820282019728792003956564819969
+	}`), &ts)
+	assert.Regexp(t, "PD020029", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": "0x8000000000000000000000000000000000000000000000000000000000000000"
+	}`), &ts)
+	assert.Regexp(t, "PD020029", err)
 
 	err = ts.F1.Scan(int64(12345))
 	require.NoError(t, err)
@@ -146,4 +160,70 @@ func TestHexInt256(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, dbv)
 
+}
+
+func TestInt256DBStringBounds(t *testing.T) {
+
+	int256Max := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1))
+	int256Min := new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255))
+
+	// The extremes of the range encode, and round-trip back through Scan
+	for _, bi := range []*big.Int{int256Max, int256Min, big.NewInt(0)} {
+		s, err := Int256To65CharDBSafeSortableString(t.Context(), bi)
+		require.NoError(t, err)
+		assert.Len(t, s, 65)
+		var back HexInt256
+		require.NoError(t, back.Scan(s))
+		assert.Equal(t, bi.String(), back.Int().String())
+	}
+
+	// Outside the range the two's complement body wraps modulo 2^256 while the sign character is
+	// taken from the original value, so the encoding would both lose the value and contradict
+	// itself - 2^255 encoding as a positive that reads back as the most negative value
+	for _, bi := range []*big.Int{
+		new(big.Int).Lsh(big.NewInt(1), 255),
+		new(big.Int).Sub(int256Min, big.NewInt(1)),
+	} {
+		_, err := Int256To65CharDBSafeSortableString(t.Context(), bi)
+		assert.Regexp(t, "PD020029", err, "encoding %s", bi)
+	}
+
+	// A buffer too small for the 64 character body is an error, not a truncated encoding
+	_, err := PadHexBigIntTwosComplement(t.Context(), big.NewInt(1), make([]byte, 8))
+	assert.Regexp(t, "PD020030", err)
+}
+
+func TestInt256DBStringSortsInValueOrder(t *testing.T) {
+
+	ordered := []*big.Int{
+		new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 255)),
+		new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 128)),
+		big.NewInt(-1000000),
+		big.NewInt(-1),
+		big.NewInt(0),
+		big.NewInt(1),
+		big.NewInt(1000000),
+		new(big.Int).Lsh(big.NewInt(1), 128),
+		new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(1)),
+	}
+	encoded := make([]string, len(ordered))
+	for i, bi := range ordered {
+		s, err := Int256To65CharDBSafeSortableString(t.Context(), bi)
+		require.NoError(t, err)
+		encoded[i] = s
+	}
+	assert.True(t, slices.IsSorted(encoded), "not in sorted order: %v", encoded)
+}
+
+func TestPadHexBigIntTwosComplementSignExtends(t *testing.T) {
+
+	// Padding to the left of the 64 character body must extend the sign, so that a wider buffer
+	// encodes the same value rather than flipping a positive into a negative
+	pos, err := PadHexBigIntTwosComplement(t.Context(), big.NewInt(1), make([]byte, 66))
+	require.NoError(t, err)
+	assert.Equal(t, "00"+strings.Repeat("0", 63)+"1", string(pos))
+
+	neg, err := PadHexBigIntTwosComplement(t.Context(), big.NewInt(-1), make([]byte, 66))
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("f", 66), string(neg))
 }

--- a/sdk/go/pkg/pldtypes/hex_uint256.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256.go
@@ -21,12 +21,14 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"math/big"
+	"strconv"
 
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/i18n"
 	"github.com/LFDT-Paladin/paladin/common/go/pkg/pldmsgs"
 )
 
-// HexUint256 is any integer (signed or unsigned) up to 256 bits in size, serialized to the DB using a 65 sortable string (a 0/1 sign character, followed by 32 hex bytes)
+// HexUint256 is an unsigned integer of at most 256 bits, serialized to the DB as a 64 character
+// string of zero-padded hex, which sorts naturally as an unsigned value
 type HexUint256 big.Int
 
 func Uint64ToUint256(v uint64) *HexUint256 {
@@ -39,7 +41,23 @@ func ParseHexUint256(ctx context.Context, s string) (*HexUint256, error) {
 	if !ok {
 		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesInvalidHexInteger, s)
 	}
+	if err := checkUint256Range(ctx, bi, s); err != nil {
+		return nil, err
+	}
 	return (*HexUint256)(bi), nil
+}
+
+// checkUint256Range enforces the range of the type. The DB serialization is exactly 256
+// unsigned bits, so the same check covers both parsing a value and persisting one.
+func checkUint256Range(ctx context.Context, bi *big.Int, desc string) error {
+	switch {
+	case bi.Sign() < 0:
+		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256Negative, desc)
+	case bi.BitLen() > 256:
+		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256TooLarge, desc)
+	default:
+		return nil
+	}
 }
 
 func MustParseHexUint256(s string) *HexUint256 {
@@ -91,13 +109,17 @@ func (hi *HexUint256) HexString0xPrefix() string {
 	i := hi.Int()
 	// Avoid allocating a new big.Int for Abs in the common non-negative case
 	str := i.Text(16)
+	sign := ""
 	if i.Sign() < 0 {
+		// A negative can only have been supplied by conversion, as no constructor of this
+		// type accepts one. Report it as what it is rather than as its absolute value
+		sign = "-"
 		str = new(big.Int).Abs(i).Text(16)
 	}
 	if len(str)%2 != 0 {
-		return "0x0" + str
+		return sign + "0x0" + str
 	}
-	return "0x" + str
+	return sign + "0x" + str
 }
 
 // Get string (without 0x prefix) - nil is all zeros
@@ -109,7 +131,11 @@ func (hi *HexUint256) Value() (driver.Value, error) {
 	if hi == nil {
 		return nil, nil
 	}
-	return string(PadHexBigUint((*big.Int)(hi), make([]byte, 64))), nil
+	bi := (*big.Int)(hi)
+	if err := checkUint256Range(context.Background(), bi, bi.Text(10)); err != nil {
+		return nil, err
+	}
+	return string(PadHexBigUint(bi, make([]byte, 64))), nil
 }
 
 func (hi *HexUint256) Scan(src interface{}) error {
@@ -123,6 +149,9 @@ func (hi *HexUint256) Scan(src interface{}) error {
 		*hi = (HexUint256)(*bi)
 		return nil
 	case int64:
+		if v < 0 {
+			return i18n.NewError(context.Background(), pldmsgs.MsgTypesUint256Negative, strconv.FormatInt(v, 10))
+		}
 		*hi = (HexUint256)(*big.NewInt(v))
 		return nil
 	default:
@@ -130,9 +159,10 @@ func (hi *HexUint256) Scan(src interface{}) error {
 	}
 }
 
-// PadHexBigUint returns the supplied buffer, with all the bytes to the left of the integer set to '0'
+// PadHexBigUint returns the supplied buffer, with all the bytes to the left of the integer set to '0'.
+// The supplied integer is not modified, and a negative one is padded as its absolute value
 func PadHexBigUint(bi *big.Int, buff []byte) []byte {
-	unPadded := bi.Abs(bi).Text(16)
+	unPadded := new(big.Int).Abs(bi).Text(16)
 	boundary := len(buff) - len(unPadded)
 	for i := 0; i < len(buff); i++ {
 		if i >= boundary {

--- a/sdk/go/pkg/pldtypes/hex_uint256.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256.go
@@ -41,7 +41,7 @@ func ParseHexUint256(ctx context.Context, s string) (*HexUint256, error) {
 	if !ok {
 		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesInvalidHexInteger, s)
 	}
-	if err := checkUint256Range(ctx, bi, s); err != nil {
+	if err := checkUint256Range(ctx, bi); err != nil {
 		return nil, err
 	}
 	return (*HexUint256)(bi), nil
@@ -49,12 +49,12 @@ func ParseHexUint256(ctx context.Context, s string) (*HexUint256, error) {
 
 // checkUint256Range enforces the range of the type. The DB serialization is exactly 256
 // unsigned bits, so the same check covers both parsing a value and persisting one.
-func checkUint256Range(ctx context.Context, bi *big.Int, desc string) error {
+func checkUint256Range(ctx context.Context, bi *big.Int) error {
 	switch {
 	case bi.Sign() < 0:
-		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256Negative, desc)
+		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256Negative, bi.Text(10))
 	case bi.BitLen() > 256:
-		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256TooLarge, desc)
+		return i18n.NewError(ctx, pldmsgs.MsgTypesUint256TooLarge, bi.Text(10))
 	default:
 		return nil
 	}
@@ -131,18 +131,20 @@ func (hi *HexUint256) Value() (driver.Value, error) {
 	if hi == nil {
 		return nil, nil
 	}
-	bi := (*big.Int)(hi)
-	if err := checkUint256Range(context.Background(), bi, bi.Text(10)); err != nil {
+	buff, err := PadHexBigUint(context.Background(), (*big.Int)(hi), make([]byte, 64))
+	if err != nil {
 		return nil, err
 	}
-	return string(PadHexBigUint(bi, make([]byte, 64))), nil
+	return string(buff), nil
 }
 
 func (hi *HexUint256) Scan(src interface{}) error {
 	switch v := src.(type) {
 	case string:
 		bi, ok := new(big.Int).SetString(v, 16)
-		if len(v) != 64 || !ok {
+		// Note SetString accepts a leading sign, where Value() writes 64 hex digits and no
+		// sign. A '-' would otherwise scan into a negative, outside the range of this type
+		if len(v) != 64 || v[0] == '-' || v[0] == '+' || !ok {
 			// This type was not used to serialize to the database
 			return i18n.NewError(context.Background(), pldmsgs.MsgTypesInvalidDBUint256, v)
 		}
@@ -160,10 +162,20 @@ func (hi *HexUint256) Scan(src interface{}) error {
 }
 
 // PadHexBigUint returns the supplied buffer, with all the bytes to the left of the integer set to '0'.
-// The supplied integer is not modified, and a negative one is padded as its absolute value
-func PadHexBigUint(bi *big.Int, buff []byte) []byte {
-	unPadded := new(big.Int).Abs(bi).Text(16)
+// The supplied integer is not modified.
+//
+// The integer must be in the range of a uint256, and its encoding must fit within the supplied
+// buffer. Both are errors, rather than the silently truncated - and so incorrect - encoding that
+// a value too large for the buffer would otherwise produce
+func PadHexBigUint(ctx context.Context, bi *big.Int, buff []byte) ([]byte, error) {
+	if err := checkUint256Range(ctx, bi); err != nil {
+		return nil, err
+	}
+	unPadded := bi.Text(16)
 	boundary := len(buff) - len(unPadded)
+	if boundary < 0 {
+		return nil, i18n.NewError(ctx, pldmsgs.MsgTypesHexIntBufferTooSmall, len(buff), len(unPadded))
+	}
 	for i := 0; i < len(buff); i++ {
 		if i >= boundary {
 			buff[i] = unPadded[i-boundary]
@@ -171,5 +183,5 @@ func PadHexBigUint(bi *big.Int, buff []byte) []byte {
 			buff[i] = '0'
 		}
 	}
-	return buff
+	return buff, nil
 }

--- a/sdk/go/pkg/pldtypes/hex_uint256_test.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256_test.go
@@ -19,6 +19,7 @@ package pldtypes
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,9 +172,15 @@ func TestHexUint256(t *testing.T) {
 	assert.Regexp(t, "PD020028", err)
 	assert.Equal(t, 257, over.Int().BitLen())
 
+	// A negative is rejected rather than encoded as its absolute value, and is left unmodified
 	bi := big.NewInt(-99)
-	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000063", string(PadHexBigUint(bi, make([]byte, 64))))
+	_, err = PadHexBigUint(t.Context(), bi, make([]byte, 64))
+	assert.Regexp(t, "PD020027", err)
 	assert.Equal(t, int64(-99), bi.Int64())
+
+	padded, err := PadHexBigUint(t.Context(), big.NewInt(99), make([]byte, 64))
+	require.NoError(t, err)
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000063", string(padded))
 
 	assert.True(t, ((*HexUint256)(nil)).NilOrZero())
 
@@ -181,4 +188,45 @@ func TestHexUint256(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, dbv)
 
+}
+
+func TestHexUint256ScanRejectsSignedDBValue(t *testing.T) {
+
+	// big.Int.SetString accepts a leading sign, so a 64 character value carrying one would
+	// otherwise scan into a negative - a value outside the range of this type, and one that
+	// Value() never writes
+	for _, v := range []string{
+		"-" + strings.Repeat("f", 63),
+		"+" + strings.Repeat("f", 63),
+		"-" + strings.Repeat("0", 62) + "1",
+	} {
+		var hi HexUint256
+		err := hi.Scan(v)
+		assert.Regexp(t, "PD020013", err, "scanning %q", v)
+	}
+
+	// The full unsigned range of the type still scans
+	for _, v := range []string{strings.Repeat("0", 64), strings.Repeat("f", 64)} {
+		var hi HexUint256
+		require.NoError(t, hi.Scan(v))
+		assert.GreaterOrEqual(t, hi.Int().Sign(), 0)
+	}
+}
+
+func TestPadHexBigUintBounds(t *testing.T) {
+
+	maxUint256 := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
+
+	padded, err := PadHexBigUint(t.Context(), maxUint256, make([]byte, 64))
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("f", 64), string(padded))
+
+	// 2^256 does not fit the 64 character encoding. Without a range check the leading digit is
+	// silently dropped, making it indistinguishable from the encoding of zero
+	_, err = PadHexBigUint(t.Context(), new(big.Int).Lsh(big.NewInt(1), 256), make([]byte, 64))
+	assert.Regexp(t, "PD020028", err)
+
+	// A buffer too small for an in-range value truncates the same way, so is also an error
+	_, err = PadHexBigUint(t.Context(), big.NewInt(0x1234), make([]byte, 3))
+	assert.Regexp(t, "PD020030", err)
 }

--- a/sdk/go/pkg/pldtypes/hex_uint256_test.go
+++ b/sdk/go/pkg/pldtypes/hex_uint256_test.go
@@ -17,8 +17,8 @@
 package pldtypes
 
 import (
-	"context"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,12 +60,44 @@ func TestHexUint256(t *testing.T) {
 	v = MustParseHexUint256("0x8000000000000000")
 	assert.Equal(t, uint64(0x8000000000000000), v.Int().Uint64())
 
+	// The largest value the type holds is 256 bits, and round-trips through the DB
+	v = MustParseHexUint256("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	assert.Equal(t, 256, v.Int().BitLen())
+	dbv, err = v.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", dbv)
+	err = v.Scan(dbv)
+	require.NoError(t, err)
+	assert.Equal(t, 256, v.Int().BitLen())
+
 	assert.Panics(t, func() {
 		_ = MustParseHexUint256("wrong")
 	})
 
-	_, err = ParseHexUint256(context.Background(), "wrong")
+	assert.Panics(t, func() {
+		_ = MustParseHexUint256("-1")
+	})
+
+	assert.Panics(t, func() {
+		_ = MustParseHexUint256("115792089237316195423570985008687907853269984665640564039457584007913129639936")
+	})
+
+	_, err = ParseHexUint256(t.Context(), "wrong")
 	require.Regexp(t, "PD020009", err)
+
+	// The type is unsigned, so a negative is not a valid value for it
+	_, err = ParseHexUint256(t.Context(), "-1")
+	assert.Regexp(t, "PD020027", err)
+	_, err = ParseHexUint256(t.Context(), "-0x2a")
+	assert.Regexp(t, "PD020027", err)
+	_, err = ParseHexUint256(t.Context(), "-255")
+	assert.Regexp(t, "PD020027", err)
+
+	// Nor is a value of more than 256 bits
+	_, err = ParseHexUint256(t.Context(), "115792089237316195423570985008687907853269984665640564039457584007913129639936")
+	assert.Regexp(t, "PD020028", err)
+	_, err = ParseHexUint256(t.Context(), "0x10000000000000000000000000000000000000000000000000000000000000000")
+	assert.Regexp(t, "PD020028", err)
 
 	type testStruct struct {
 		F1 *HexUint256 `json:"f1"`
@@ -89,6 +121,18 @@ func TestHexUint256(t *testing.T) {
 		"f1": false
 	}`), &ts)
 	assert.Regexp(t, "PD020002", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": "-0x2a"
+	}`), &ts)
+	assert.Regexp(t, "PD020027", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": -42
+	}`), &ts)
+	assert.Regexp(t, "PD020027", err)
+	err = json.Unmarshal([]byte(`{
+		"f1": 115792089237316195423570985008687907853269984665640564039457584007913129639936
+	}`), &ts)
+	assert.Regexp(t, "PD020028", err)
 
 	err = ts.F1.Scan(int64(12345))
 	require.NoError(t, err)
@@ -104,12 +148,32 @@ func TestHexUint256(t *testing.T) {
 	err = ts.F1.Scan("0x12346")
 	assert.Regexp(t, "PD020013", err)
 
+	err = ts.F1.Scan(int64(-1))
+	assert.Regexp(t, "PD020027", err)
+
 	err = v.Scan("wrong000000000000000000000000000000000000000000007fffffffffffffff")
 	assert.Regexp(t, "PD020013", err)
 
-	// Negative values are serialized using their absolute value
-	assert.Equal(t, "0x01", MustParseHexUint256("-1").HexString0xPrefix())
-	assert.Equal(t, "0xff", MustParseHexUint256("-255").HexString0xPrefix())
+	// A value can also be handed to the type by conversion, bypassing the constructors.
+	// The two hex accessors must agree on what it is, and neither may misreport its sign
+	neg := (*HexUint256)(big.NewInt(-42))
+	assert.Equal(t, "-0x2a", neg.HexString0xPrefix())
+	assert.Equal(t, "-2a", neg.HexString())
+
+	// Such a value cannot be represented in the DB, so it is rejected rather than
+	// serialized as something else, and the caller's value is left as it was
+	_, err = neg.Value()
+	assert.Regexp(t, "PD020027", err)
+	assert.Equal(t, int64(-42), neg.Int().Int64())
+
+	over := (*HexUint256)(new(big.Int).Lsh(big.NewInt(1), 256))
+	_, err = over.Value()
+	assert.Regexp(t, "PD020028", err)
+	assert.Equal(t, 257, over.Int().BitLen())
+
+	bi := big.NewInt(-99)
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000063", string(PadHexBigUint(bi, make([]byte, 64))))
+	assert.Equal(t, int64(-99), bi.Int64())
 
 	assert.True(t, ((*HexUint256)(nil)).NilOrZero())
 

--- a/test/internal/testsuite/noto_failable_hooks.go
+++ b/test/internal/testsuite/noto_failable_hooks.go
@@ -397,7 +397,7 @@ func (s *notoRevertableHooksSuite) Setup() error {
 	log.Info("Minting initial supply to sender...")
 	mintParams := &nototypes.MintParams{
 		To:     s.sender,
-		Amount: pldtypes.Int64ToInt256(s.initialMintAmount),
+		Amount: pldtypes.Uint64ToUint256(uint64(s.initialMintAmount)),
 	}
 	mintJSON, err := json.Marshal(mintParams)
 	if err != nil {
@@ -756,7 +756,7 @@ func (tc *notoRevertableHooksWorker) RunOnce(iterationCount int) (string, error)
 
 	transferParams := &nototypes.TransferParams{
 		To:     targetIdentity,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}
 	transferJSON, err := json.Marshal(transferParams)
 	if err != nil {

--- a/test/internal/testsuite/noto_pente_tracker.go
+++ b/test/internal/testsuite/noto_pente_tracker.go
@@ -217,7 +217,7 @@ func (s *notoPenteTrackerSuite) Setup() error {
 		log.Infof("Minting %d tokens to %s...", s.initialMintAmount, memberIdentity)
 		mintParams := &nototypes.MintParams{
 			To:     memberIdentity,
-			Amount: pldtypes.Int64ToInt256(s.initialMintAmount),
+			Amount: pldtypes.Uint64ToUint256(uint64(s.initialMintAmount)),
 		}
 		mintJSON, err := json.Marshal(mintParams)
 		if err != nil {
@@ -400,7 +400,7 @@ func (tc *notoPenteTrackerWorker) RunOnce(iterationCount int) (string, error) {
 
 	transferParams := &nototypes.TransferParams{
 		To:     recipient,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}
 	transferJSON, err := json.Marshal(transferParams)
 	if err != nil {

--- a/test/internal/testsuite/noto_transfer.go
+++ b/test/internal/testsuite/noto_transfer.go
@@ -148,7 +148,7 @@ func (s *notoTransferSuite) Setup() error {
 		log.Infof("Minting initial supply of %d to %s (Noto instance %d)...", s.initialMintAmount, senderIdentity, i)
 		mintParams := &nototypes.MintParams{
 			To:     senderIdentity,
-			Amount: pldtypes.Int64ToInt256(s.initialMintAmount),
+			Amount: pldtypes.Uint64ToUint256(uint64(s.initialMintAmount)),
 		}
 		mintJSON, err := json.Marshal(mintParams)
 		if err != nil {
@@ -335,7 +335,7 @@ func (tc *notoTransferWorker) RunOnce(iterationCount int) (string, error) {
 
 	transferParams := &nototypes.TransferParams{
 		To:     target,
-		Amount: pldtypes.Int64ToInt256(1),
+		Amount: pldtypes.Uint64ToUint256(1),
 	}
 	transferJSON, err := json.Marshal(transferParams)
 	if err != nil {


### PR DESCRIPTION
`HexUint256` and `HexInt256` types now enforce their maximum ranges. This applies when
* read from a DB
* written to a DB
* unmarshalled from JSON
* marshalled to JSON

It is possible to create both of these types directly by casting a `BigInt`, in which case there is no way to enforce value checks 